### PR TITLE
feat(cli): python project template

### DIFF
--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -15,9 +15,10 @@ exports.post = () => {
   chmodSync('synth.sh', '700');
 
   console.log();
-  console.log("==================================================================================")
-  console.log(" Your cdk8s Python project was created successfully.")
-  console.log()
-  console.log(" Useful commands:")
-  console.log(" - ./synth.sh: synthesizes a k8s manifest in 'dist/' (ready for 'kubectl apply -f')")
+  console.log("==================================================================================");
+  console.log(" Your cdk8s Python project was created successfully.");
+  console.log();
+  console.log(" Useful commands:");
+  console.log(" - pipenv install: creates a virtual environment and installs deps");
+  console.log(" - pipenv run python main.py: synthesizes a k8s manifest in 'dist/' (ready for 'kubectl apply -f')");
 };

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+const { chmodSync } = require('fs');
+
+exports.pre = () => {
+  try {
+    execSync('which pipenv')
+  } catch {
+    console.error(`Unable to find "pipenv". Please install https://pipenv.kennethreitz.org/`)
+    process.exit(1);
+  }
+};
+
+exports.post = () => {
+  execSync('pipenv install', { stdio: 'inherit' });
+  chmodSync('synth.sh', '700');
+
+  console.log();
+  console.log("==================================================================================")
+  console.log(" Your cdk8s Python project was created successfully.")
+  console.log()
+  console.log(" Useful commands:")
+  console.log(" - ./synth.sh: synthesizes a k8s manifest in 'dist/' (ready for 'kubectl apply -f')")
+};

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -12,7 +12,6 @@ exports.pre = () => {
 
 exports.post = () => {
   execSync('pipenv install', { stdio: 'inherit' });
-  chmodSync('synth.sh', '700');
 
   console.log();
   console.log("==================================================================================");

--- a/packages/cdk8s-cli/templates/python-app/Pipfile
+++ b/packages/cdk8s-cli/templates/python-app/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pylint = "*"
+
+[packages]
+aws-cdk-core = "*"
+cdk8s = "*"
+
+[requires]
+python_version = "3.7"

--- a/packages/cdk8s-cli/templates/python-app/main.py
+++ b/packages/cdk8s-cli/templates/python-app/main.py
@@ -1,0 +1,13 @@
+from aws_cdk.core import Construct
+from cdk8s import App, Chart
+
+class MyChart(Chart):
+  def __init__(self, scope: Construct, ns: str, **kwargs):
+    super().__init__(scope, ns, **kwargs)
+
+    # define resources here
+
+app = App()
+MyChart(app, "{{ $base }}")
+
+app.synth()

--- a/packages/cdk8s-cli/templates/python-app/synth.sh
+++ b/packages/cdk8s-cli/templates/python-app/synth.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec pipenv run python main.py

--- a/packages/cdk8s-cli/templates/python-app/synth.sh
+++ b/packages/cdk8s-cli/templates/python-app/synth.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec pipenv run python main.py


### PR DESCRIPTION
The command `cdk8s init python-app` will create a new python cdk8s project.

NOTE: this is intentionally not documented yet since we still don’t support `cdk8s gen` for python, so basically this only allows defining resources by directly instantiating `ApiObject`s. But this is still functional.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
