### PR TITLE
feat(cli): cdk8s synth

### DIFF
--- a/packages/cdk8s-cli/bin/cmds/import.ts
+++ b/packages/cdk8s-cli/bin/cmds/import.ts
@@ -6,18 +6,18 @@ const DEFAULT_OUTDIR = 'imports';
 
 class Command implements yargs.CommandModule {
   public readonly command = 'import SPEC';
-  public readonly describe = 'Imports API objects to your app by generating constructs';
+  public readonly describe = 'Imports API objects to your app by generating constructs.';
   public readonly aliases = [ 'gen', 'import', 'generate' ];
 
   public readonly builder = (args: yargs.Argv) => args
     .positional('SPEC', {  desc: `The API spec to import (only "k8s" is currently supported)` })
     .demand('SPEC')
-    .example(`cdk8s import k8s`, `imports Kubenretes API objects to imports/k8s.ts`)
+    .example(`cdk8s import k8s`, `Imports Kubenretes API objects to imports/k8s.ts`)
     .example(`cdk8s import k8s@1.13.0`, `imports a specific version of the Kubenretes API`)
 
-    .option('output', { type: 'string', desc: 'output directory', default: DEFAULT_OUTDIR, alias: 'o' })
-    .option('include', { type: 'array', desc: 'types to select instead of the default which is latest stable version' })
-    .option('exclude', { type: 'array', desc: 'do not import types that match these regular expressions. They will be represented as the "any" type' });
+    .option('output', { type: 'string', desc: 'Output directory', default: DEFAULT_OUTDIR, alias: 'o' })
+    .option('include', { type: 'array', desc: 'Types to select instead of the default which is latest stable version' })
+    .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type' });
 
   public async handler(argv: any) {
     const spec = argv.spec;
@@ -35,9 +35,8 @@ class Command implements yargs.CommandModule {
       exclude: argv.exclude
     });
 
-    console.error(`k8s@${apiVersion} imported to ${argv.output}/k8s.ts`);
+    console.log(`${argv.output}/k8s.ts`);
   }
 }
-
 
 module.exports = new Command();

--- a/packages/cdk8s-cli/bin/cmds/init.ts
+++ b/packages/cdk8s-cli/bin/cmds/init.ts
@@ -7,11 +7,11 @@ const templatesDir = path.join(__dirname, '..', '..', 'templates');
 const availableTemplates = fs.readdirSync(templatesDir);
 
 class Command implements yargs.CommandModule {
-  public readonly command = 'init TEMPLATE';
-  public readonly describe = 'Create a new cdk8s project from a template';
+  public readonly command = 'init TYPE';
+  public readonly describe = 'Create a new cdk8s project from a template.';
   public readonly builder = (args: yargs.Argv) => args
-    .positional('TEMPLATE', { demandOption: true })
-    .choices('TEMPLATE', availableTemplates);
+    .positional('TYPE', { demandOption: true, desc: 'Project type' })
+    .choices('TYPE', availableTemplates);
 
   public async handler(argv: any) {
     if (fs.readdirSync('.').length > 0) {
@@ -19,8 +19,8 @@ class Command implements yargs.CommandModule {
       process.exit(1);
     }
   
-    console.error(`Initializing a project from the ${argv.template} template`);
-    const templatePath = path.join(templatesDir, argv.template);
+    console.error(`Initializing a project from the ${argv.type} template`);
+    const templatePath = path.join(templatesDir, argv.type);
     await sscaff(templatePath, '.');
   }
 }

--- a/packages/cdk8s-cli/bin/cmds/synth.ts
+++ b/packages/cdk8s-cli/bin/cmds/synth.ts
@@ -1,0 +1,44 @@
+import * as yargs from 'yargs';
+import { shell, rmfr, exists } from '../../lib/util';
+import { promises as fs } from 'fs';
+
+class Command implements yargs.CommandModule {
+  public readonly command = 'synth';
+  public readonly describe = 'Synthesizes Kubernetes manifests for all charts in your app.';
+  public readonly aliases = [ 'synthesize' ];
+
+  public readonly builder = (args: yargs.Argv) => args
+    .option('app', { required: true, desc: 'Command to use in order to execute cdk8s app' })
+    .option('output', { default: 'dist', desc: 'Output directory', alias: 'o' });
+
+  public async handler(argv: any) {
+    const command = argv.app;
+    const outdir = argv.output;
+
+    await rmfr(outdir);
+
+    await shell(command, [], { 
+      shell: true,
+      env: { CDK8S_OUTDIR: outdir }
+    });
+
+    if (!await exists(outdir)) {
+      console.error(`ERROR: synthesis failed, app expected to create "${outdir}"`);
+      process.exit(1);
+    }
+
+    let found = false;
+    for (const file of await fs.readdir(outdir)) {
+      if (file.endsWith('.k8s.yaml')) {
+        console.log(`${outdir}/${file}`);
+        found = true;
+      }
+    }
+
+    if (!found) {
+      console.error('No manifests synthesized');
+    }
+  }
+}
+
+module.exports = new Command();

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -1,0 +1,36 @@
+import { spawn, SpawnOptions } from 'child_process';
+import { promises as fs } from 'fs';
+import { exists as _exists } from 'fs';
+import * as path from 'path';
+
+export async function shell(program: string, args: string[] = [], options: SpawnOptions = { }) {
+  return new Promise((ok, ko) => {
+    const child = spawn(program, args, { stdio: 'inherit', ...options });
+    child.once('error', ko);
+    child.once('exit', code => {
+      if (code === 0) { return ok(); }
+      else return ko(new Error(`non-zero exit code ${code}`));
+    });
+  });
+}
+
+export async function rmfr(filePath: string) {
+  if (!await exists(filePath)) {
+    return;
+  }
+
+  // if this is a directory, empty it first
+  if ((await fs.stat(filePath)).isDirectory()) {
+    const files = await fs.readdir(filePath);
+    for (const file of files) {
+      await rmfr(path.join(filePath, file));
+    }
+    fs.rmdir(filePath);
+  } else {
+    await fs.unlink(filePath);
+  }
+}
+
+export async function exists(filePath: string): Promise<boolean> {
+  return new Promise(ok => _exists(filePath, ok));
+}

--- a/packages/cdk8s-cli/templates/typescript-app/package.json
+++ b/packages/cdk8s-cli/templates/typescript-app/package.json
@@ -11,6 +11,6 @@
     "test": "echo ok",
     "build": "yarn run import && yarn compile && yarn test",
     "watch": "tsc -w",
-    "synth": "node ./main.js"
+    "synth": "cdk8s synth --app 'node main.js'"
   }
 }

--- a/packages/cdk8s-cli/test/init.test.ts
+++ b/packages/cdk8s-cli/test/init.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { withTempDir, shell } from './util';
+import { withTempDir } from './util';
+import { shell } from '../lib/util';
 
 jest.setTimeout(30_000);
 

--- a/packages/cdk8s-cli/test/util.ts
+++ b/packages/cdk8s-cli/test/util.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
-import { spawn, SpawnOptions } from 'child_process';
 import * as path from 'path';
 import * as os from 'os';
+import { shell } from '../lib/util';
 
 /**
  * Compiles the source files in `workdir` with jsii.
@@ -60,16 +60,6 @@ export async function createWorkdir() {
   return await fs.mkdtemp(path.join(os.tmpdir(), 'generator.tests'));  
 }
 
-export async function shell(command: string, args: string[] = [], options: SpawnOptions = { }) {
-  return new Promise((ok, ko) => {
-    const child = spawn(command, args, { stdio: 'inherit', ...options });
-    child.once('error', ko);
-    child.once('exit', code => {
-      if (code === 0) { return ok(); }
-      else return ko(new Error(`non-zero exit code ${code}`));
-    });
-  });
-}
 
 export async function withTempDir(dirname: string, closure: () => Promise<void>) {
   const prevdir = process.cwd();

--- a/packages/cdk8s/lib/app.ts
+++ b/packages/cdk8s/lib/app.ts
@@ -6,7 +6,7 @@ export interface AppOptions {
   /**
    * The directory to output Kubernetes manifests.
    * 
-   * @default "dist"
+   * @default - CDK8S_OUTDIR if defined, otherwise "dist"
    */
   readonly outdir?: string;
 }
@@ -26,7 +26,7 @@ export class App extends Construct {
    */
   constructor(options: AppOptions = { }) {
     super(undefined as any, '');
-    this.outdir = options.outdir ?? 'dist';
+    this.outdir = options.outdir ?? process.env.CDK8S_OUTDIR ?? 'dist';
   }
 
   /**


### PR DESCRIPTION
A universal command to synthesize manifests for an app. It basically just executes the command specified in `--app` with the specified output directory and expects to find *.k8s.yaml files in there.

Resolves #41

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
