### PR TITLE
refactor: use synchronous file system APIs and other nits

### DIFF
--- a/examples/podinfo/examples/app-example.ts
+++ b/examples/podinfo/examples/app-example.ts
@@ -1,7 +1,7 @@
-import { Construct } from "@aws-cdk/core";
-import { App, Chart } from "cdk8s";
-import { Deployment, Service } from "../lib";
-import { PodinfoContainer } from "./podinfo";
+import { Construct } from '@aws-cdk/core';
+import { App, Chart } from 'cdk8s';
+import { Deployment, Service } from '../lib';
+import { PodinfoContainer } from './podinfo';
 
 class MyChart extends Chart {
   constructor(scope: Construct, id: string) {

--- a/examples/podinfo/examples/podinfo.ts
+++ b/examples/podinfo/examples/podinfo.ts
@@ -1,4 +1,4 @@
-import { Deployment, ImagePullPolicy, IContainer } from "../lib";
+import { Deployment, ImagePullPolicy, IContainer } from '../lib';
 import { Container } from '../../imports/k8s';
 
 export interface PodinfoOptions {

--- a/examples/podinfo/lib/service.ts
+++ b/examples/podinfo/lib/service.ts
@@ -1,6 +1,6 @@
-import { Construct } from "@aws-cdk/core";
+import { Construct } from '@aws-cdk/core';
 import { Service as ServiceApiObject, ServicePort, IntOrString } from '../../imports/k8s';
-import { Ingress, IngressOptions } from "./ingress";
+import { Ingress, IngressOptions } from './ingress';
 
 export interface ISelector {
   readonly selector: { [key: string]: string };

--- a/examples/web-service/web-service.ts
+++ b/examples/web-service/web-service.ts
@@ -1,9 +1,9 @@
 import { Construct } from '@aws-cdk/core';
-import { Service, IntOrString, Deployment } from '.././imports/k8s';
+import { Service, IntOrString, Deployment } from '../imports/k8s';
 
 export interface WebServiceOptions {
   /** The Docker image to use for this service. */
-  readonly image: string; // docker image to use for this service
+  readonly image: string;
 
   /**
    * Number of replicas.

--- a/packages/cdk8s-cli/bin/cmds/synth.ts
+++ b/packages/cdk8s-cli/bin/cmds/synth.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
-import { shell, rmfr, exists } from '../../lib/util';
-import { promises as fs } from 'fs';
+import { shell, rmfr } from '../../lib/util';
+import { existsSync, readdirSync } from 'fs';
 
 class Command implements yargs.CommandModule {
   public readonly command = 'synth';
@@ -15,20 +15,20 @@ class Command implements yargs.CommandModule {
     const command = argv.app;
     const outdir = argv.output;
 
-    await rmfr(outdir);
+    rmfr(outdir);
 
     await shell(command, [], { 
       shell: true,
       env: { CDK8S_OUTDIR: outdir }
     });
 
-    if (!await exists(outdir)) {
+    if (!existsSync(outdir)) {
       console.error(`ERROR: synthesis failed, app expected to create "${outdir}"`);
       process.exit(1);
     }
 
     let found = false;
-    for (const file of await fs.readdir(outdir)) {
+    for (const file of readdirSync(outdir)) {
       if (file.endsWith('.k8s.yaml')) {
         console.log(`${outdir}/${file}`);
         found = true;

--- a/packages/cdk8s-cli/lib/codegen-constructs.ts
+++ b/packages/cdk8s-cli/lib/codegen-constructs.ts
@@ -1,8 +1,8 @@
-import { JSONSchema4 } from "json-schema";
+import { JSONSchema4 } from 'json-schema'
 import { CodeMaker } from 'codemaker';
-import { TypeGenerator } from "./codegen-types";
-import { ApiObjectDefinition, parseApiTypeName, tryGetObjectName, getObjectName, X_GROUP_VERSION_KIND } from "./types";
-import { compareApiVersions } from "./version-selection";
+import { TypeGenerator } from './codegen-types';
+import { ApiObjectDefinition, parseApiTypeName, tryGetObjectName, getObjectName, X_GROUP_VERSION_KIND } from './types';
+import { compareApiVersions } from './version-selection';
 
 /**
  * Generates a construct for an API object defined by `def`.
@@ -41,7 +41,7 @@ export function emitConstructForApiObject(code: CodeMaker, typeGenerator: TypeGe
     code.line('/**');
     code.line(` * ${def?.description}`);
     code.line(` *`);
-    code.line(` * @schema ${apidef.fullname}`)
+    code.line(` * @schema ${apidef.fullname}`);
     code.line(` */`);
     code.openBlock(`export class ${objectName.kind} extends ApiObject`);
 

--- a/packages/cdk8s-cli/lib/codegen-types.ts
+++ b/packages/cdk8s-cli/lib/codegen-types.ts
@@ -1,6 +1,6 @@
-import { JSONSchema4 } from "json-schema";
-import { CodeMaker } from "codemaker";
-import { isApiObject } from "./types";
+import { JSONSchema4 } from 'json-schema';
+import { CodeMaker } from 'codemaker';
+import { isApiObject } from './types';
 
 const PRIMITIVE_TYPES = [ 'string', 'number', 'integer', 'boolean' ];
 const DEFINITIONS_PREFIX = '#/definitions/';

--- a/packages/cdk8s-cli/lib/types.ts
+++ b/packages/cdk8s-cli/lib/types.ts
@@ -1,4 +1,4 @@
-import { JSONSchema4 } from "json-schema";
+import { JSONSchema4 } from 'json-schema';
 
 /**
  * 

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -1,6 +1,5 @@
 import { spawn, SpawnOptions } from 'child_process';
-import { promises as fs } from 'fs';
-import { exists as _exists } from 'fs';
+import { existsSync, readdirSync, rmdirSync, statSync, unlinkSync } from 'fs';
 import * as path from 'path';
 
 export async function shell(program: string, args: string[] = [], options: SpawnOptions = { }) {
@@ -14,23 +13,19 @@ export async function shell(program: string, args: string[] = [], options: Spawn
   });
 }
 
-export async function rmfr(filePath: string) {
-  if (!await exists(filePath)) {
+export function rmfr(filePath: string) {
+  if (!existsSync(filePath)) {
     return;
   }
 
   // if this is a directory, empty it first
-  if ((await fs.stat(filePath)).isDirectory()) {
-    const files = await fs.readdir(filePath);
+  if ((statSync(filePath)).isDirectory()) {
+    const files = readdirSync(filePath);
     for (const file of files) {
-      await rmfr(path.join(filePath, file));
+      rmfr(path.join(filePath, file));
     }
-    fs.rmdir(filePath);
+    rmdirSync(filePath);
   } else {
-    await fs.unlink(filePath);
+    unlinkSync(filePath);
   }
-}
-
-export async function exists(filePath: string): Promise<boolean> {
-  return new Promise(ok => _exists(filePath, ok));
 }


### PR DESCRIPTION
* Move from async to sync file operations. This is done because
for a small set of files/operations, sync is actually faster than
async in Node. Also the `exists` API is deprecated, but the
`existsSync` API is not
* Move to single-quote imports where needed

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
