### PR TITLE
refactor: remove extraneous JS file for CLI invocation

### DIFF
--- a/packages/cdk8s-cli/bin/cdk8s
+++ b/packages/cdk8s-cli/bin/cdk8s
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('./cdk8s.js');

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "CDK for Kubernetes CLI",
   "bin": {
-    "cdk8s": "bin/cdk8s"
+    "cdk8s": "bin/cdk8s.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
We can specify that the bin command should resolve to a specific
JS file, which will work in a backwards-compatible way with
current invocation. This saves us having to add an extra file and
is clearer in terms of which file actually has the code being
executed

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
