### PR TITLE
chore: fixes to "import python"

### DIFF
--- a/packages/cdk8s-cli/lib/import.ts
+++ b/packages/cdk8s-cli/lib/import.ts
@@ -62,9 +62,7 @@ export async function generateAllApiObjects(outdir: string, options: Options) {
     await jsiiCompile('.');
 
     const pacmak = require.resolve('jsii-pacmak/bin/jsii-pacmak');
-    await shell(`${pacmak} --target ${options.language} --code-only`);
-
-    console.error(process.cwd());
+    await shell(pacmak, [ '--target', options.language, '--code-only' ]);
     await harvestCode(options.language, outdir);
   });
 }
@@ -84,7 +82,7 @@ async function harvestCode(language: Language, outdir: string) {
 
   async function harvestPython() {
     const target = path.join(outdir, 'k8s');
-    await fs.move('dist/python/src/k8s', target);
+    await fs.move('dist/python/src/k8s', target, { overwrite: true });
     console.error(target);
   }
 }

--- a/packages/cdk8s-cli/lib/jsii.ts
+++ b/packages/cdk8s-cli/lib/jsii.ts
@@ -5,7 +5,7 @@ import { shell } from './util';
 /**
  * Compiles the source files in `workdir` with jsii.
  */
-export async function jsiiCompile(workdir: string) {
+export async function jsiiCompile(workdir: string, stdout = false) {
   const compiler = require.resolve('jsii/bin/jsii');
   const args = [ '--silence-warnings', 'reserved-word' ];
 
@@ -13,7 +13,7 @@ export async function jsiiCompile(workdir: string) {
     '@aws-cdk/core', 
     '@aws-cdk/cx-api', 
     'cdk8s',
-    '@types/node'
+    '@types/node',
   ];
 
   const pkg = {
@@ -52,6 +52,7 @@ export async function jsiiCompile(workdir: string) {
   await fs.writeFile(path.join(workdir, 'package.json'), JSON.stringify(pkg, undefined, 2));
 
   await shell(compiler, args, { 
-    cwd: workdir 
+    cwd: workdir,
+    stdio: [ 'inherit', stdout ? 'inherit' : 'ignore', 'inherit' ]
   });
 }

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -24,6 +24,6 @@ export async function withTempDir(dirname: string, closure: () => Promise<void>)
     await closure();
   } finally {
     process.chdir(prevdir);
-    // await fs.remove(parent);
+    await fs.remove(parent);
   }
 }

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -37,7 +37,8 @@
     "jsii": "^1.0.0",
     "jsii-pacmak": "^1.0.0",
     "sscaff": "^1.2.0",
-    "yargs": "^15.1.0"
+    "yargs": "^15.1.0",
+    "@types/node": "13.7.0"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/packages/cdk8s-cli/test/codegen-types.test.ts
+++ b/packages/cdk8s-cli/test/codegen-types.test.ts
@@ -179,7 +179,7 @@ async function generate(gen: TypeGenerator) {
   const source = await fs.readFile(path.join('.', entrypoint), 'utf-8');
 
   try {
-    await jsiiCompile('.');
+    await jsiiCompile('.', true);
   } catch (e) {
     console.error(source);
     throw e;

--- a/packages/cdk8s-cli/test/integration.test.ts
+++ b/packages/cdk8s-cli/test/integration.test.ts
@@ -12,7 +12,8 @@ test('generate and compile 1.14.0', async () => {
       language: Language.TYPESCRIPT,
       apiVersion: '1.14.0' 
     });
-    await jsiiCompile(workdir);
+    
+    await jsiiCompile(workdir, true);
   
     const manifest = JSON.parse(await fs.readFile('.jsii', 'utf-8'));
     expect(manifest).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,7 +1334,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=4.5.0":
+"@types/node@*", "@types/node@13.7.0", "@types/node@>= 8", "@types/node@>=4.5.0":
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==


### PR DESCRIPTION
- fixed error with pacmak invocation
- added @types/node as a regular dependency so it can be found at runtime
- hide stdout
- remove staging directory

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
