### PR TITLE
feat(cli): cdk8s.yaml

### DIFF
--- a/packages/cdk8s-cli/bin/cdk8s.ts
+++ b/packages/cdk8s-cli/bin/cdk8s.ts
@@ -1,7 +1,13 @@
 import * as yargs from 'yargs';
 
-yargs
+const args = yargs
   .commandDir('cmds')
-  .demandCommand()
+  .recommendCommands()
+  .wrap(yargs.terminalWidth())
+  .showHelpOnFail(false)
   .help()
   .argv;
+
+if (args._.length === 0) {
+  yargs.showHelp();
+}

--- a/packages/cdk8s-cli/bin/cmds/import.ts
+++ b/packages/cdk8s-cli/bin/cmds/import.ts
@@ -1,42 +1,52 @@
 import * as yargs from 'yargs';
-import { generateAllApiObjects, DEFAULT_API_VERSION } from '../../lib/import';
+import { importKubernetesApi, DEFAULT_API_VERSION } from '../../lib/import';
+import { readConfigSync } from '../../lib/config';
 
-const K8S_SPEC = 'k8s';
+const config = readConfigSync();
+
+const K8S_SOURCE = 'k8s';
 const DEFAULT_OUTDIR = 'imports';
 const LANGUAGES = [ 'typescript', 'python' ];
 
 class Command implements yargs.CommandModule {
-  public readonly command = 'import SPEC';
+  public readonly command = 'import [SOURCE]';
   public readonly describe = 'Imports API objects to your app by generating constructs.';
   public readonly aliases = [ 'gen', 'import', 'generate' ];
 
   public readonly builder = (args: yargs.Argv) => args
-    .positional('SPEC', {  desc: `The API spec to import (only "k8s" is currently supported)` })
-    .demand('SPEC')
+    .positional('SOURCE', { default: config.imports, desc: `The API source to import (supported sources: "${K8S_SOURCE}")`, array: true })
     .example(`cdk8s import k8s`, `Imports Kubenretes API objects to imports/k8s.ts`)
     .example(`cdk8s import k8s@1.13.0`, `imports a specific version of the Kubenretes API`)
 
-    .option('output', { type: 'string', desc: 'Output directory', default: DEFAULT_OUTDIR, alias: 'o' })
+    .option('output', { default: DEFAULT_OUTDIR, type: 'string', desc: 'Output directory', alias: 'o' })
     .option('include', { type: 'array', desc: 'Types to select instead of the default which is latest stable version' })
     .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type' })
-    .option('language', { demand: true, type: 'string', desc: 'Output programming language', alias: 'l', choices: LANGUAGES });
+    .option('language', { default: config.language, demand: true, type: 'string', desc: 'Output programming language', alias: 'l', choices: LANGUAGES });
 
   public async handler(argv: any) {
-    const spec = argv.spec;
-    const [ src, specver ] = spec.split('@');
+    const sources = Array.isArray(argv.source) ? argv.source : [ argv.source ];
 
-    const apiVersion = specver ?? DEFAULT_API_VERSION;
-
-    if (src !== K8S_SPEC) {
-      throw new Error(`currently we only support the source ${K8S_SPEC}`);
+    if (sources.length > 1) {
+      throw new Error(`only a single source is supported at the moment. got: ${sources.join(',')}`);
     }
 
-    await generateAllApiObjects(argv.output, {
-      apiVersion,
-      include: argv.include,
-      exclude: argv.exclude,
-      language: argv.language
-    });
+    for (const source of sources) {
+      const [ src, srcver ] = source.split('@');
+
+      const apiVersion = srcver ?? DEFAULT_API_VERSION;
+  
+      if (src !== K8S_SOURCE) {
+        throw new Error(`unsupported import source "${src}", supported sources: "${K8S_SOURCE}"`);
+      }
+  
+      await importKubernetesApi(argv.output, {
+        apiVersion,
+        include: argv.include,
+        exclude: argv.exclude,
+        language: argv.language
+      });
+    }
+
   }
 }
 

--- a/packages/cdk8s-cli/bin/cmds/init.ts
+++ b/packages/cdk8s-cli/bin/cmds/init.ts
@@ -15,7 +15,7 @@ class Command implements yargs.CommandModule {
 
   public async handler(argv: any) {
     if (fs.readdirSync('.').length > 0) {
-      console.error(`cannot initialize a project in a non-empty directory`);
+      console.error(`Cannot initialize a project in a non-empty directory`);
       process.exit(1);
     }
   

--- a/packages/cdk8s-cli/bin/cmds/synth.ts
+++ b/packages/cdk8s-cli/bin/cmds/synth.ts
@@ -1,6 +1,9 @@
 import * as yargs from 'yargs';
 import { shell } from '../../lib/util';
 import * as fs from 'fs-extra';
+import { readConfigSync } from '../../lib/config';
+
+const config = readConfigSync();
 
 class Command implements yargs.CommandModule {
   public readonly command = 'synth';
@@ -8,8 +11,8 @@ class Command implements yargs.CommandModule {
   public readonly aliases = [ 'synthesize' ];
 
   public readonly builder = (args: yargs.Argv) => args
-    .option('app', { required: true, desc: 'Command to use in order to execute cdk8s app', alias: 'a' })
-    .option('output', { default: 'dist', desc: 'Output directory', alias: 'o' });
+    .option('app', { default: config.app, required: true, desc: 'Command to use in order to execute cdk8s app', alias: 'a' })
+    .option('output', { default: config.output, required: true, desc: 'Output directory', alias: 'o' });
 
   public async handler(argv: any) {
     const command = argv.app;

--- a/packages/cdk8s-cli/lib/config.ts
+++ b/packages/cdk8s-cli/lib/config.ts
@@ -1,0 +1,28 @@
+import { Language } from "./import";
+import * as yaml from 'yaml';
+import * as fs from 'fs-extra';
+
+const CONFIG_FILE = 'cdk8s.yaml';
+
+export interface Config {
+  readonly app?: string;
+  readonly language?: Language;
+  readonly output?: string;
+  readonly imports?: string[];
+}
+
+const DEFAULTS: Config = {
+  output: 'dist'
+};
+
+export function readConfigSync(): Config {
+  let config: Config = DEFAULTS;
+  if (fs.existsSync(CONFIG_FILE)) {
+    config = {
+      ...config,
+      ...yaml.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'))
+    };
+  }
+
+  return config;
+}

--- a/packages/cdk8s-cli/lib/import.ts
+++ b/packages/cdk8s-cli/lib/import.ts
@@ -29,7 +29,7 @@ export interface Options {
   /**
    * The API version to generate.
    */
-  readonly apiVersion?: string;
+  readonly apiVersion: string;
 
   /**
    * FQNs of API object types to select instead of selecting the latest stable
@@ -47,24 +47,26 @@ export interface Options {
   readonly exclude?: string[];
 }
 
-export async function generateAllApiObjects(outdir: string, options: Options) {
+export async function importKubernetesApi(outdir: string, options: Options) {
+  const relout = outdir;
   outdir = path.resolve(outdir);
+  
 
   if (options.language === Language.TYPESCRIPT) {
-    await generateApiObjectsTypeScript(outdir, options);
-    console.log(`${outdir}/k8s.ts`);
-    return;
+    await generateTypeScript(outdir, options);
+  } else {
+    // this is not typescript, so we generate in a staging directory and harvest the code
+    await withTempDir('k8s', async () => {
+      await generateTypeScript('.', options);
+      await jsiiCompile('.');
+
+      const pacmak = require.resolve('jsii-pacmak/bin/jsii-pacmak');
+      await shell(pacmak, [ '--target', options.language, '--code-only' ]);
+      await harvestCode(options.language, outdir);
+    });
   }
 
-  // this is not typescript, so we generate in a staging directory and harvest the code
-  await withTempDir('k8s', async () => {
-    await generateApiObjectsTypeScript('.', options);
-    await jsiiCompile('.');
-
-    const pacmak = require.resolve('jsii-pacmak/bin/jsii-pacmak');
-    await shell(pacmak, [ '--target', options.language, '--code-only' ]);
-    await harvestCode(options.language, outdir);
-  });
+  console.error(`Constructs for Kubernetes API v${options.apiVersion} imported to "${relout}/k8s".`);
 }
 
 async function harvestCode(language: Language, outdir: string) {
@@ -83,15 +85,14 @@ async function harvestCode(language: Language, outdir: string) {
   async function harvestPython() {
     const target = path.join(outdir, 'k8s');
     await fs.move('dist/python/src/k8s', target, { overwrite: true });
-    console.error(target);
   }
 }
 
-async function generateApiObjectsTypeScript(outdir: string, options: Options) {
+async function generateTypeScript(outdir: string, options: Options) {
   const code = new CodeMaker();
   code.indentation = 2;
 
-  const schema = await downloadSchema(options.apiVersion ?? DEFAULT_API_VERSION);
+  const schema = await downloadSchema(options.apiVersion);
   const map = findApiObjectDefinitions(schema);
 
   const topLevelObjects = selectApiObjects(map, { include: options.include });

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -31,14 +31,15 @@
   "dependencies": {
     "@aws-cdk/core": "^1.24.0",
     "@aws-cdk/cx-api": "^1.24.0",
-    "fs-extra": "^8.1.0",
+    "@types/node": "13.7.0",
     "cdk8s": "0.0.0",
     "codemaker": "^0.22.0",
+    "fs-extra": "^8.1.0",
     "jsii": "^1.0.0",
     "jsii-pacmak": "^1.0.0",
     "sscaff": "^1.2.0",
-    "yargs": "^15.1.0",
-    "@types/node": "13.7.0"
+    "yaml": "^1.7.2",
+    "yargs": "^15.1.0"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/packages/cdk8s-cli/test/integration.test.ts
+++ b/packages/cdk8s-cli/test/integration.test.ts
@@ -1,4 +1,4 @@
-import { generateAllApiObjects, Language } from "../lib/import";
+import { importKubernetesApi, Language } from "../lib/import";
 import { jsiiCompile } from "../lib/jsii";
 import { promises as fs } from 'fs';
 import { withTempDir } from "../lib/util";
@@ -8,7 +8,7 @@ jest.setTimeout(60_000);
 test('generate and compile 1.14.0', async () => {
   await withTempDir('import-k8s', async () => {
     const workdir = '.';
-    await generateAllApiObjects(workdir, {
+    await importKubernetesApi(workdir, {
       language: Language.TYPESCRIPT,
       apiVersion: '1.14.0' 
     });


### PR DESCRIPTION
Allow specifying certain switches through a local `cdk8s.yaml` file:

- `app` describes the command to run for `cdk8s synth`
- `language` is the language to use for `cdk8s import`
- `imports` lists all the api sources to import
- `output` can be used to specify the synth output directory

Here is an example for a python project:

```yaml
language: python
app: pipenv run ./main.py
imports:
  - k8s@1.14.0
```

Resolves #42

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
