### PR TITLE
fix(cli): new typescript apps cannot be created with @next versions

### DIFF
--- a/packages/cdk8s-cli/bin/cmds/init.ts
+++ b/packages/cdk8s-cli/bin/cmds/init.ts
@@ -5,6 +5,7 @@ import { sscaff } from 'sscaff';
 
 const templatesDir = path.join(__dirname, '..', '..', 'templates');
 const availableTemplates = fs.readdirSync(templatesDir).filter(x => !x.startsWith('.'));
+const version: string = require('../../package.json').version;
 
 class Command implements yargs.CommandModule {
   public readonly command = 'init TYPE';
@@ -22,7 +23,16 @@ class Command implements yargs.CommandModule {
   
     console.error(`Initializing a project from the ${argv.type} template`);
     const templatePath = path.join(templatesDir, argv.type);
-    await sscaff(templatePath, '.');
+
+    // determine if we want a specific pinned version or a version range we take
+    // a pinned version if version includes a hyphen which means it is a
+    // pre-release (e.g. "0.12.0-pre.e6834d3"). otherwise, we require a caret
+    // version.
+    const ver = version.includes('-') ? version : `^${version}`;
+
+    await sscaff(templatePath, '.', {
+      version: ver
+    });
   }
 }
 


### PR DESCRIPTION
When using a pre-release version of the CLI, use a pinned versions of cdk8s and cdk8s-cli in the newly created package.json instead of caret versions. Otherwise, npm will select the @latest disc-tag instead.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
