### PR TITLE
chore: integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: yarn install
-      - run: yarn build
-      - run: yarn test
-      - run: yarn package
+      - name: installing dependencies
+        run: yarn install
+      - name: compile
+        run: |
+          tools/align-version.sh
+          yarn build
+      - name: unit tests
+        run: yarn test
+      - name: create bundle
+        run: yarn package
+      - name: integration tests
+        run: test/run-against-dist test/test-all.sh
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
       - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
         run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
         run: yarn install
       - name: compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-      - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
-        run: yarn install
+        run: |
+          pip3 install pipenv
+          yarn install
       - name: compile
         run: |
           tools/align-version.sh

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -17,6 +17,8 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn package
+      - name: integration tests
+        run: test/run-against-dist test/test-all.sh
 
       # publish to package managers only if this is a new version      
       - run: npx jsii-release-npm

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dschep/install-pipenv-action@v1
       - run: yarn install
       - run: tools/align-version.sh "-pre.${{ github.sha }}"
       - run: yarn build

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -12,9 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-      - uses: dschep/install-pipenv-action@v1
-      - run: yarn install
+      - name: installing dependencies
+        run: |
+          pip3 install pipenv
+          yarn install
       - run: tools/align-version.sh "-pre.${{ github.sha }}"
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
       - uses: dschep/install-pipenv-action@v1
       - run: yarn install
       - run: tools/align-version.sh "-pre.${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
       - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
         run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/setup-python@v1
       - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
-        run: yarn install
+        run: |
+          pip3 install pipenv
+          yarn install
       - name: compile
         run: |
           tools/align-version.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: yarn install
-      - run: tools/align-version.sh
-      - run: yarn build
-      - run: yarn test
-      - run: yarn package
+      - name: installing dependencies
+        run: yarn install
+      - name: compile
+        run: |
+          tools/align-version.sh
+          yarn build
+      - name: unit tests
+        run: yarn test
+      - name: create bundle
+        run: yarn package
+      - name: integration tests
+        run: test/run-against-dist test/test-all.sh
 
       # publish to package managers only if this is a new version      
       - run: yarn release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dschep/install-pipenv-action@v1
       - name: installing dependencies
         run: yarn install
       - name: compile

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,44 @@
+# cdk8s Integration Tests
+
+This directory contains integration tests for the cdk8s project.
+
+Each subdirectory represents a single test, with an entrypoint of `test.sh`.
+Tests are written as simple shell scripts and can simulate user activity.
+
+## Running Tests
+
+You can either run individual tests by executing their entrypoint directly (e.g.
+`test-python-app/test.sh`) or run all tests by executing the script
+`./test-all.sh`.
+
+Tests assume the `cdk8s` CLI is installed and in the PATH, and will use the same
+version of the `cdk8s` module (this is the behavior of `cdk8s init`).
+
+You can also execute a test (or all of them) against the `dist` build artifact:
+
+```shell
+$ yarn install
+$ yarn build
+$ yarn run package # creates "dist/"
+$ cd test
+$ ./run-against-dist ./test-all.sh
+# or
+$ ./run-against-dist ./test-typescript-app/test.sh
+```
+
+## Writing Tests
+
+1. Create a new subdirectory with a `test-` prefix.
+2. Create a file named `test.sh`, make it executable.
+
+Test Environment:
+- The script `test.sh` is executed within a temporary working directory under
+  /tmp/xxxx/test (where xxxx is some random tmp file).
+- See existing tests as examples on how to bring in auxiliary files to the test.
+- Test MUST NOT install any dependencies or the `cdk8s` CLI. They can expect it
+  to be available in the environment.
+- To install dependencies from pacakge managers, use `yarn`, `npm`, `pipenv`,
+  `mvn` and `nuget`. Those programs will be shimmed to allow consuming local
+  dependencies.
+
+

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+
+export CDK8S_DIST="${scriptdir}/../dist"
+
+cwd=$PWD
+
+cd ${CDK8S_DIST}
+
+# verify this is indeed a "dist" directory
+if [ ! -d "js" ] || [ ! -d "java" ] || [ ! -d "python" ] || [ ! -d "dotnet" ]; then
+  echo "ERROR: unable to find the subdirectories 'js', 'java', 'python' and 'dotnet' which should be in the 'dist' directory"
+  echo "Did you run 'yarn run package' to create the 'dist' directory?"
+  exit 1
+fi
+
+# install the CLI from dist/js in a temporary area and add to path
+echo "Extracting CLI from 'dist'..."
+staging=$(mktemp -d)
+cd ${staging}
+npm init -y > /dev/null
+npm install ${CDK8S_DIST}/js/*.tgz
+export PATH=${staging}/node_modules/.bin:$PATH
+
+# restore working directory
+cd $cwd
+$@

--- a/test/test-all.sh
+++ b/test/test-all.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+
+cd ${scriptdir}
+  
+for dir in test-*; do
+  [ ! -d $dir ] && continue
+  
+  echo "--------------------------------------------------------------------"
+  echo $dir
+  echo "--------------------------------------------------------------------"
+  $dir/test.sh
+done

--- a/test/test-python-app/expected/test.k8s.yaml
+++ b/test/test-python-app/expected/test.k8s.yaml
@@ -1,0 +1,10 @@
+spec:
+  containers:
+    - name: hello-kubernetes
+      image: paulbouwer/hello-kubernetes:1.7
+      ports:
+        - containerPort: 8080
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod-84164e5f

--- a/test/test-python-app/main.py
+++ b/test/test-python-app/main.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from aws_cdk.core import Construct
+from cdk8s import App, Chart
+
+from imports import k8s
+
+class MyChart(Chart):
+  def __init__(self, scope: Construct, ns: str, **kwargs):
+    super().__init__(scope, ns, **kwargs)
+
+    # define resources here
+    k8s.Pod(self, 'pod',
+      spec=k8s.PodSpec(
+        containers=[
+          k8s.Container(
+            name="hello-kubernetes", 
+            image="paulbouwer/hello-kubernetes:1.7",
+            ports=[ k8s.ContainerPort(container_port=8080) ]
+          )
+        ]
+      )
+    )
+
+app = App()
+MyChart(app, "test")
+
+app.synth()

--- a/test/test-python-app/test.sh
+++ b/test/test-python-app/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+scriptdir=$(cd $(dirname $0) && pwd)
+cd $(mktemp -d)
+mkdir test && cd test
+
+# initialize an empty project
+cdk8s init python-app
+
+# put some code in it
+cp ${scriptdir}/main.py .
+
+# build
+cdk8s synth
+
+# show output
+diff dist ${scriptdir}/expected
+
+echo "PASS"

--- a/test/test-typescript-app/expected/test.k8s.yaml
+++ b/test/test-typescript-app/expected/test.k8s.yaml
@@ -1,0 +1,10 @@
+spec:
+  containers:
+    - name: hello-kubernetes
+      image: paulbouwer/hello-kubernetes:1.7
+      ports:
+        - containerPort: 8080
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod-84164e5f

--- a/test/test-typescript-app/main.ts
+++ b/test/test-typescript-app/main.ts
@@ -1,0 +1,28 @@
+import { Construct } from '@aws-cdk/core';
+import { App, Chart } from 'cdk8s';
+
+import { Pod } from './imports/k8s';
+
+class MyChart extends Chart {
+  constructor(scope: Construct, name: string) {
+    super(scope, name);
+
+    // define resources here
+
+    new Pod(this, 'pod', {
+      spec: {
+        containers: [
+          {
+            name: 'hello-kubernetes',
+            image: 'paulbouwer/hello-kubernetes:1.7',
+            ports: [ { containerPort: 8080 } ]
+          }
+        ]
+      }
+    });
+  }
+}
+
+const app = new App();
+new MyChart(app, 'test');
+app.synth();

--- a/test/test-typescript-app/test.sh
+++ b/test/test-typescript-app/test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+scriptdir=$(cd $(dirname $0) && pwd)
+
+cd $(mktemp -d)
+mkdir test && cd test
+
+# initialize an empty project
+cdk8s init typescript-app
+
+# put some code in it
+cp ${scriptdir}/main.ts .
+
+# build
+yarn build
+
+# show output
+diff dist ${scriptdir}/expected
+
+echo "PASS"


### PR DESCRIPTION
Introduces an integration test harness which can execute arbitrary tests against the build artifacts created under "dist".

Adds a workflow stage to execute these tests during CI builds and releases.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
