### PR TITLE
feat: chart.toJson() and apiObject.toJson()

### DIFF
--- a/packages/cdk8s/lib/api-object.ts
+++ b/packages/cdk8s/lib/api-object.ts
@@ -1,5 +1,7 @@
 import { Construct } from '@aws-cdk/core';
 import { Chart } from './chart';
+import { removeEmpty } from './_util';
+import { resolve } from './_tokens';
 
 /**
  * Metadata associated with this object.
@@ -106,17 +108,20 @@ export class ApiObject extends Construct {
   }
 
   /**
-   * Renders the object to Kubernetes config.
-   * @internal
+   * Renders the object to Kubernetes JSON.
    */
-  public _render(): any {
-    return {
+  public toJson(): any {
+    const data = {
       ...this.options,
       metadata: {
         ...this.options.metadata,
         name: this.name
       }
     };
+
+    // convert to "pure data" so, for example, when we convert to yaml these
+    // references are not converted to anchors.
+    return JSON.parse(JSON.stringify(removeEmpty(resolve(this, data))));
   }
 }
 

--- a/packages/cdk8s/lib/testing.ts
+++ b/packages/cdk8s/lib/testing.ts
@@ -2,7 +2,6 @@ import fs = require('fs');
 import path = require('path');
 import os = require('os');
 import { App, Chart } from '../lib';
-import * as YAML from 'yaml';
 
 /**
  * Testing utilities for cdk8s applications.
@@ -21,11 +20,7 @@ export class Testing {
    * Returns the Kubernetes manifest synthesized from this chart.
    */
   public static synth(chart: Chart) {
-    const app = chart.node.root as App;
-    app.synth();
-    
-    const filePath = path.join(app.outdir, chart.manifestFile);
-    return YAML.parseAllDocuments(fs.readFileSync(filePath, 'utf-8')).map((doc: any) => doc.toJSON());
+    return chart.toJson();
   }
 
   /* istanbul ignore next */

--- a/packages/cdk8s/test/__snapshots__/chart.test.js.snap
+++ b/packages/cdk8s/test/__snapshots__/chart.test.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty stack 1`] = `
-Array [
-  null,
-]
-`;
+exports[`empty stack 1`] = `Array []`;
 
 exports[`output includes all synthesized resources 1`] = `
 Array [
@@ -41,6 +37,25 @@ Array [
     "kind": "Resource2",
     "metadata": Object {
       "name": "test-scope-resource2-e1b938d2",
+    },
+  },
+]
+`;
+
+exports[`synthesizeManifest() can be used to synthesize a specific chart 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Kind1",
+    "metadata": Object {
+      "name": "chart-obj1-f2e469b6",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Kind2",
+    "metadata": Object {
+      "name": "chart-obj2-e10626fd",
     },
   },
 ]

--- a/packages/cdk8s/test/chart.test.ts
+++ b/packages/cdk8s/test/chart.test.ts
@@ -79,6 +79,20 @@ test('Chart.of(node) fails when there is no chart in the tree', () => {
   expect(() => Chart.of(child)).toThrow(/cannot find a parent chart \(directly or indirectly\)/);
 });
 
+test('synthesizeManifest() can be used to synthesize a specific chart', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'chart');
+  new ApiObject(chart, 'obj1', { apiVersion: 'v1', kind: 'Kind1' });
+  new ApiObject(chart, 'obj2', { apiVersion: 'v1', kind: 'Kind2' });
+
+  // WHEN
+  const manifest = chart.toJson();
+
+  // THEN
+  expect(manifest).toMatchSnapshot();
+});
+
 function createImplictToken(value: any) {
   const implicit = {};
   Object.defineProperty(implicit, 'resolve', { value: () => value });


### PR DESCRIPTION
To simplify interoperability, expose `toJson()` methods on `ApiObject` and on `Chart` which render the Kubernetes JSON for the resource/chart.

Related to #48

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
