### PR TITLE
feat: default namespaces for charts

### DIFF
--- a/packages/cdk8s/lib/api-object.ts
+++ b/packages/cdk8s/lib/api-object.ts
@@ -114,8 +114,9 @@ export class ApiObject extends Construct {
     const data = {
       ...this.options,
       metadata: {
+        namespace: Chart.of(this).namespace,
         ...this.options.metadata,
-        name: this.name
+        name: this.name,
       }
     };
 

--- a/packages/cdk8s/lib/chart.ts
+++ b/packages/cdk8s/lib/chart.ts
@@ -5,6 +5,17 @@ import { ApiObject } from './api-object';
 import * as YAML from 'yaml';
 import { Names } from './names';
 
+export interface ChartOptions {
+  /**
+   * The default namespace for all objects defined in this chart (directly or
+   * indirectly). This namespace will only apply to objects that don't have a
+   * `namespace` explicitly defined for them.
+   *
+   * @default - no namespace is synthesized (usually this implies "default")
+   */
+  readonly namespace?: string;
+}
+
 export class Chart extends Construct {
 
   /**
@@ -30,9 +41,15 @@ export class Chart extends Construct {
    */
   public readonly manifestFile: string;
 
-  constructor(scope: Construct, ns: string) {
+  /**
+   * The default namespace for all objects in this chart.
+   */
+  public readonly namespace?: string;
+
+  constructor(scope: Construct, ns: string, options: ChartOptions = { }) {
     super(scope, ns);
     this.manifestFile = `${this.node.uniqueId}.k8s.yaml`;
+    this.namespace = options.namespace;
   }
 
   /**

--- a/packages/cdk8s/test/api-object.test.ts
+++ b/packages/cdk8s/test/api-object.test.ts
@@ -116,3 +116,32 @@ test('object naming logic can be overridden at the chart level', () => {
     "metadata": { "name": "fixed!" }
   }]);
 });
+
+test('default namespace can be defined at the chart level', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'chart', { namespace: 'ns1' });
+  const group1 = new Construct(chart, 'group1');
+
+  // WHEN
+  new ApiObject(group1, 'obj1', { apiVersion: 'v1', kind: 'Kind1' });
+  new ApiObject(group1, 'obj2', { apiVersion: 'v2', kind: 'Kind2', metadata: { namespace: 'foobar' } });
+
+  // THEN
+  expect(Testing.synth(chart)).toStrictEqual([{ 
+    "apiVersion": "v1", 
+    "kind": 
+    "Kind1", 
+    "metadata": { 
+      "name": "chart-group1-obj1-b4b7a9d0", 
+      "namespace": "ns1" 
+    } 
+  }, { 
+    "apiVersion": "v2", 
+    "kind": "Kind2", 
+    "metadata": { 
+      "name": "chart-group1-obj2-3cdc9d22", 
+      "namespace": "foobar" 
+    } 
+  }]);
+});


### PR DESCRIPTION
Allow specifying a default namespace when defining a chart. This namespace will be used for all API objects that do not have an explicit namespace defined.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
