### PR TITLE
chore: upgrade jsii & constructs

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -20,8 +20,7 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn package
-      - name: integration tests
-        run: test/run-against-dist test/test-all.sh
+      - run: yarn integ
 
       # publish to package managers only if this is a new version      
       - run: npx jsii-release-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: create bundle
         run: yarn package
       - name: integration tests
-        run: test/run-against-dist test/test-all.sh
+        run: yarn integ
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/examples/crd/package.json
+++ b/examples/crd/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^1.1.2"
+    "constructs": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^1.1.2"
+    "constructs": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/podinfo/package.json
+++ b/examples/podinfo/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^1.1.2"
+    "constructs": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/web-service/package.json
+++ b/examples/web-service/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^1.1.2"
+    "constructs": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "lerna run build",
     "test": "lerna run test",
     "package": "lerna run package && tools/collect-dist.sh",
+    "integ": "test/run-against-dist test/test-all.sh",
     "release-github": "tools/release-github.sh"
   },
   "workspaces": {

--- a/packages/cdk8s-cli/bin/cmds/init.ts
+++ b/packages/cdk8s-cli/bin/cmds/init.ts
@@ -5,7 +5,10 @@ import { sscaff } from 'sscaff';
 
 const templatesDir = path.join(__dirname, '..', '..', 'templates');
 const availableTemplates = fs.readdirSync(templatesDir).filter(x => !x.startsWith('.'));
-const version: string = require('../../package.json').version;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../../package.json');
+const constructsVersion = pkg.dependencies.constructs;
 
 class Command implements yargs.CommandModule {
   public readonly command = 'init TYPE';
@@ -13,7 +16,8 @@ class Command implements yargs.CommandModule {
   public readonly builder = (args: yargs.Argv) => args
     .positional('TYPE', { demandOption: true, desc: 'Project type' })
     .showHelpOnFail(true)
-    .option('dist DIR', { type: 'string', desc: 'Install dependencies from a "dist" directory (for development)' })
+    .option('dist', { type: 'string', desc: 'Install dependencies from a "dist" directory (for development)' })
+    .option('cdk8s-version', { type: 'string', desc: 'The cdk8s version to use when creating the new project', default: pkg.version })
     .choices('TYPE', availableTemplates);
 
   public async handler(argv: any) {
@@ -25,7 +29,7 @@ class Command implements yargs.CommandModule {
     console.error(`Initializing a project from the ${argv.type} template`);
     const templatePath = path.join(templatesDir, argv.type);
 
-    const deps = await determineDeps(argv.dist);
+    const deps: any = await determineDeps(argv.cdk8SVersion, argv.dist);
 
     await sscaff(templatePath, '.', {
       ...deps
@@ -33,12 +37,13 @@ class Command implements yargs.CommandModule {
   }
 }
 
-async function determineDeps(dist?: string): Promise<Deps> {
+async function determineDeps(version: string, dist?: string): Promise<Deps> {
   if (dist) {
     const ret = {
       'npm_cdk8s': path.resolve(dist, 'js', `cdk8s@${version}.jsii.tgz`),
       'npm_cdk8s_cli': path.resolve(dist, 'js', `cdk8s-cli-${version}.tgz`),
       'pypi_cdk8s': path.resolve(dist, 'python', `cdk8s-${version.replace(/-/g, '_')}-py3-none-any.whl`),
+      'npm_constructs': `constructs@${constructsVersion}`
     };
 
     for (const file of Object.values(ret)) {
@@ -51,7 +56,7 @@ async function determineDeps(dist?: string): Promise<Deps> {
   }
   
   if (version === '0.0.0') {
-    throw new Error(`cannot use version 0.0.0, use --dist or CDK8S_DIST to install from a "dist" directory`);
+    throw new Error(`cannot use version 0.0.0, use --cdk8s-version, --dist or CDK8S_DIST to install from a "dist" directory`);
   }
 
   // determine if we want a specific pinned version or a version range we take
@@ -63,13 +68,15 @@ async function determineDeps(dist?: string): Promise<Deps> {
   return {
     'npm_cdk8s': `cdk8s@${ver}`,
     'npm_cdk8s_cli': `cdk8s-cli@${ver}`,
-    'pypi_cdk8s': `cdk8s~=${version}` // no support for pre-release
+    'pypi_cdk8s': `cdk8s~=${version}`, // no support for pre-release
+    'npm_constructs': constructsVersion
   };
 }
 
 interface Deps {
   npm_cdk8s: string;
   npm_cdk8s_cli: string;
+  npm_constructs: string;
   pypi_cdk8s: string;
 }
 

--- a/packages/cdk8s-cli/bin/cmds/init.ts
+++ b/packages/cdk8s-cli/bin/cmds/init.ts
@@ -8,7 +8,6 @@ const availableTemplates = fs.readdirSync(templatesDir).filter(x => !x.startsWit
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('../../package.json');
-const constructsVersion = pkg.dependencies.constructs;
 
 class Command implements yargs.CommandModule {
   public readonly command = 'init TYPE';
@@ -42,8 +41,7 @@ async function determineDeps(version: string, dist?: string): Promise<Deps> {
     const ret = {
       'npm_cdk8s': path.resolve(dist, 'js', `cdk8s@${version}.jsii.tgz`),
       'npm_cdk8s_cli': path.resolve(dist, 'js', `cdk8s-cli-${version}.tgz`),
-      'pypi_cdk8s': path.resolve(dist, 'python', `cdk8s-${version.replace(/-/g, '_')}-py3-none-any.whl`),
-      'npm_constructs': `constructs@${constructsVersion}`
+      'pypi_cdk8s': path.resolve(dist, 'python', `cdk8s-${version.replace(/-/g, '_')}-py3-none-any.whl`)
     };
 
     for (const file of Object.values(ret)) {
@@ -69,14 +67,12 @@ async function determineDeps(version: string, dist?: string): Promise<Deps> {
     'npm_cdk8s': `cdk8s@${ver}`,
     'npm_cdk8s_cli': `cdk8s-cli@${ver}`,
     'pypi_cdk8s': `cdk8s~=${version}`, // no support for pre-release
-    'npm_constructs': constructsVersion
   };
 }
 
 interface Deps {
   npm_cdk8s: string;
   npm_cdk8s_cli: string;
-  npm_constructs: string;
   pypi_cdk8s: string;
 }
 

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -33,10 +33,10 @@
     "@types/node": "13.7.0",
     "cdk8s": "0.0.0",
     "codemaker": "^0.22.0",
-    "constructs": "^1.1.2",
+    "constructs": "^2.0.0",
     "fs-extra": "^8.1.0",
-    "jsii": "^0.22.0",
-    "jsii-pacmak": "^0.22.0",
+    "jsii": "^1.1.0",
+    "jsii-pacmak": "^1.1.0",
     "sscaff": "^1.2.0",
     "yaml": "^1.7.2",
     "yargs": "^15.1.0"

--- a/packages/cdk8s-cli/templates/python-app/Pipfile
+++ b/packages/cdk8s-cli/templates/python-app/Pipfile
@@ -3,8 +3,5 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[packages]
-constructs = "*"
-
 [requires]
 python_version = "3.7"

--- a/packages/cdk8s-cli/templates/typescript-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/typescript-app/.hooks.sscaff.js
@@ -4,11 +4,13 @@ const { readFileSync } = require('fs');
 exports.post = ctx => {
   const npm_cdk8s = ctx.npm_cdk8s;
   const npm_cdk8s_cli = ctx.npm_cdk8s_cli;
+  const npm_constructs = ctx.npm_constructs;
 
   if (!npm_cdk8s) { throw new Error(`missing context "npm_cdk8s"`); }
   if (!npm_cdk8s_cli) { throw new Error(`missing context "npm_cdk8s_cli"`); }
+  if (!npm_constructs) { throw new Error(`missing context "npm_constructs"`); }
 
-  installDeps([ npm_cdk8s, 'constructs' ]);
+  installDeps([ npm_cdk8s, npm_constructs ]);
   installDeps([ npm_cdk8s_cli, '@types/node', 'typescript' ], true);
 
   // import k8s objects

--- a/packages/cdk8s-cli/templates/typescript-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/typescript-app/.hooks.sscaff.js
@@ -1,16 +1,16 @@
 const { execSync } = require('child_process');
 const { readFileSync } = require('fs');
 
+const constructs_version = require('../../package.json').dependencies.constructs;
+
 exports.post = ctx => {
   const npm_cdk8s = ctx.npm_cdk8s;
   const npm_cdk8s_cli = ctx.npm_cdk8s_cli;
-  const npm_constructs = ctx.npm_constructs;
 
   if (!npm_cdk8s) { throw new Error(`missing context "npm_cdk8s"`); }
   if (!npm_cdk8s_cli) { throw new Error(`missing context "npm_cdk8s_cli"`); }
-  if (!npm_constructs) { throw new Error(`missing context "npm_constructs"`); }
 
-  installDeps([ npm_cdk8s, npm_constructs ]);
+  installDeps([ npm_cdk8s, `constructs@${constructs_version}` ]);
   installDeps([ npm_cdk8s_cli, '@types/node', 'typescript' ], true);
 
   // import k8s objects

--- a/packages/cdk8s-cli/test/import/__snapshots__/import-crd.test.js.snap
+++ b/packages/cdk8s-cli/test/import/__snapshots__/import-crd.test.js.snap
@@ -59,9 +59,9 @@ Object {
     },
   },
   "description": "jenkins",
-  "fingerprint": "/T8z5Q9e8TZL1FOlrfOvh/VJZ5R4fTkx6T19fbw1E5M=",
+  "fingerprint": "wvCqW07ix3SnOotRut5fw9VneFCG6rF5/u+OV4qcYfg=",
   "homepage": "http://repo",
-  "jsiiVersion": "0.22.0 (build 14afdde)",
+  "jsiiVersion": "1.1.0 (build df55f5e)",
   "license": "Apache-2.0",
   "name": "jenkins",
   "repository": Object {

--- a/packages/cdk8s/package.json
+++ b/packages/cdk8s/package.json
@@ -71,11 +71,11 @@
     "@types/yaml": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
-    "constructs": "1.1.2",
+    "constructs": "2.0.0",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
-    "jsii": "^0.22.0",
-    "jsii-pacmak": "^0.22.0",
+    "jsii": "^1.1.0",
+    "jsii-pacmak": "^1.1.0",
     "json-schema-to-typescript": "^8.0.1",
     "typescript": "^3.7.5"
   },
@@ -94,7 +94,7 @@
     "yaml": "^1.7.2"
   },
   "peerDependencies": {
-    "constructs": "^1.1.2"
+    "constructs": "^2.0.0"
   },
   "stability": "experimental"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,10 +406,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jsii/spec@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-0.22.0.tgz#e8b8166692ce2de4ff969078403ce18b2a5341fd"
-  integrity sha512-c7jHvb0mdqbMpIDXULxzV2k8eizu+3uA9ffzMrXUJNATS7iQTwHfgIjlg3DIUxBfGPQPZPfQ/NFj62MaRj14Dg==
+"@jsii/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@jsii/spec/-/spec-1.1.0.tgz#1e7093807d191970bf2b22c537b905e298091d1f"
+  integrity sha512-zi5/k1oqkCGwoWutm9ZXnC9pZXILREvtLOMg4dci8jeotHYxnrAk7Wk6FskLD9StzHzf0hzewa8cJPqfPiZ+ZA==
   dependencies:
     jsonschema "^1.2.5"
 
@@ -2097,6 +2097,15 @@ codemaker@^0.22.0:
     decamelize "^1.2.0"
     fs-extra "^8.1.0"
 
+codemaker@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/codemaker/-/codemaker-1.1.0.tgz#157020837e6bbb6bdae55f6b3ac9fce8d7676b69"
+  integrity sha512-XkPDpK8tagP+UUo+/d/4xD1nbP9LxefMLWDE772QmOR4tTINc4WYZkLPLdpnU1v+qRKX1kALD1dQ2MtsC3ZHYw==
+  dependencies:
+    camelcase "^5.3.1"
+    decamelize "^1.2.0"
+    fs-extra "^8.1.0"
+
 collect-v8-coverage@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz#150ee634ac3650b71d9c985eb7f608942334feb1"
@@ -2220,10 +2229,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@1.1.2, constructs@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/constructs/-/constructs-1.1.2.tgz#5d9f62d43e28836ec2dac216fdfcd260d370a3c3"
-  integrity sha512-JaNYYTHbgC6kzLYz2dgIvqYZSX++/cYQREHREfqltSRNBYVs4QKWm3N48N78RrAhnonRWuhCkOTYy+PbqcqTyw==
+constructs@2.0.0, constructs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/constructs/-/constructs-2.0.0.tgz#8cd035411254853b87c00bb9fec013c644c1c488"
+  integrity sha512-5bW84vSNMZ0XuEW93OTQG+HuPfRRPzVtXcsCAjUhc5Cmm9pHds10vz+GyDTbBZZ9jsFlY+YjXpcuVyTQ7dV14w==
 
 conventional-changelog-angular@^5.0.3, conventional-changelog-angular@^5.0.6:
   version "5.0.6"
@@ -4676,65 +4685,65 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-pacmak@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-0.22.0.tgz#8e67623cb077963da35a77edc8f3c337d4f100b3"
-  integrity sha512-TIrjA8UNRn529W4gwIM5KcwxjcfAlDNcQrfMjOOBo/VTAjr/I0+N5RjbMZqOA1M3jPaCGLY5mu3jZgZlZfiPmw==
+jsii-pacmak@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.1.0.tgz#a5363bde828bda6d24cbc33a8dd13971eea28e67"
+  integrity sha512-TLJjLN53fwA5n7hQ2UKRxRYUhead7sRILo4KOJQxN8dVAI1+oocp198QaVGbDD6ZE3aIUKKVThOkBZkY8K3zbw==
   dependencies:
-    "@jsii/spec" "^0.22.0"
+    "@jsii/spec" "^1.1.0"
     camelcase "^5.1.3"
     clone "^2.1.2"
-    codemaker "^0.22.0"
+    codemaker "^1.1.0"
     commonmark "^0.29.1"
     escape-string-regexp "^2.0.0"
     fs-extra "^8.1.0"
-    jsii-reflect "^0.22.0"
-    jsii-rosetta "^0.22.0"
-    semver "^7.1.2"
+    jsii-reflect "^1.1.0"
+    jsii-rosetta "^1.1.0"
+    semver "^7.1.3"
     spdx-license-list "^6.1.0"
-    xmlbuilder "^13.0.2"
-    yargs "^15.1.0"
+    xmlbuilder "^15.0.0"
+    yargs "^15.3.0"
 
-jsii-reflect@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-0.22.0.tgz#c4188495a5d6db27cf73af1ead9bb78950d322df"
-  integrity sha512-39z6m0lyd91R88F0vJrU+lR9xyF3v/6BIydCsto3pfCwEzP3+/73GDbYoWdTMMQHEDb6mpZ27tGWipFjUyKVmg==
+jsii-reflect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.1.0.tgz#5f013e2d90f8d97299402e14355bb666b1147084"
+  integrity sha512-/Ik0DKL/PhS5LDbwY4GrgaVIulc2SPqJAIuLJVwGeEQgBqj9kgPto0Huh5icMw3WK4+qwp/B/WCPbYivnkjF+w==
   dependencies:
-    "@jsii/spec" "^0.22.0"
+    "@jsii/spec" "^1.1.0"
     colors "^1.4.0"
     fs-extra "^8.1.0"
-    oo-ascii-tree "^0.22.0"
-    yargs "^15.1.0"
+    oo-ascii-tree "^1.1.0"
+    yargs "^15.3.0"
 
-jsii-rosetta@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-0.22.0.tgz#41e6353dfa52fc0868f64db97c793c69abdfbccc"
-  integrity sha512-3G6idoZ0RPCsnwYJbi0CcErFh7AJqLjTgOGKozalxBzz/c03O9cOuf52LFPczi/t5uX9FbWYnYzsJPUFgrGlvQ==
+jsii-rosetta@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.1.0.tgz#c70fa9d6d78e116c4308415a8bc918b05a94fe2d"
+  integrity sha512-GWLntW4U7i+fnjmPfVaU7qjx+U6eU9BHMufpZVhtQVh7IGoY81dQSnDT1bAJQLSNqvmbaada4CEj8FuR9xdDeQ==
   dependencies:
-    "@jsii/spec" "^0.22.0"
+    "@jsii/spec" "^1.1.0"
     commonmark "^0.29.1"
     fs-extra "^8.1.0"
-    typescript "~3.7.5"
-    xmldom "^0.2.1"
-    yargs "^15.1.0"
+    typescript "~3.8.3"
+    xmldom "^0.3.0"
+    yargs "^15.3.0"
 
-jsii@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-0.22.0.tgz#d0ad0c857d98874b607f2669d9c4d23d573e346b"
-  integrity sha512-pUoef6QmibfaaZSaEu4iu96ply1W/DMzNP2Xid8lFDps6Z1bI7WzWoMber11Mqm2uyWB2h8s27AOU5rBZ7nXgw==
+jsii@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/jsii/-/jsii-1.1.0.tgz#cc76544fd67793f92f3fbe8f0d1ff22d75f61092"
+  integrity sha512-QmtKu2ZEXwMop+An4AnDsOZJr5EObcXtGiuw8bVy8ldq1WHiri4mvSWwZQI3ekUcWyOGjwFY9CuDy+xYbsf+Pg==
   dependencies:
-    "@jsii/spec" "^0.22.0"
+    "@jsii/spec" "^1.1.0"
     case "^1.6.2"
     colors "^1.4.0"
     deep-equal "^2.0.1"
     fs-extra "^8.1.0"
-    log4js "^6.1.1"
-    semver "^7.1.2"
+    log4js "^6.1.2"
+    semver "^7.1.3"
     semver-intersect "^1.4.0"
     sort-json "^2.0.0"
     spdx-license-list "^6.1.0"
-    typescript "~3.7.5"
-    yargs "^15.1.0"
+    typescript "~3.8.3"
+    yargs "^15.3.0"
 
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -5014,9 +5023,9 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log4js@^6.1.1:
+log4js@^6.1.2:
   version "6.1.2"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.1.2.tgz#04688e1f4b8080c127b7dccb0db1c759cbb25dc4"
+  resolved "https://registry.npmjs.org/log4js/-/log4js-6.1.2.tgz#04688e1f4b8080c127b7dccb0db1c759cbb25dc4"
   integrity sha512-knS4Y30pC1e0n7rfx3VxcLOdBCsEo0o6/C7PVTGxdVK+5b1TYOSGQPn9FDcrhkoQBV29qwmA2mtkznPAQKnxQg==
   dependencies:
     date-format "^3.0.0"
@@ -5716,10 +5725,10 @@ ono@^4.0.11:
   dependencies:
     format-util "^1.0.3"
 
-oo-ascii-tree@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-0.22.0.tgz#a2e9a959036cc20b803f05ae84b48f7495e1cbeb"
-  integrity sha512-J+RleN39z6UHpmlyedLC93Sgx4SS2IYwmZ7kbNwmV3hbZ7ir0qXqpduAfEakjfHEfI1qPyppymZSdd5AwP8HcA==
+oo-ascii-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.1.0.tgz#e5bc65db665cfb0d6e4fc750620f7d6c11bc2702"
+  integrity sha512-GAmkryQIl44INfzyAHEnVSPzG1T2PTG8S+F1BvTvoW3Cr3pbDaPljW4prV6y1hg7YZ4isEI1dcoIQ7k4gyVKeA==
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -6602,7 +6611,7 @@ semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1, semver@^7.1.2:
+semver@^7.1.1, semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
@@ -7422,15 +7431,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5:
+typescript@^3.7.5, typescript@~3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@~3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 uglify-js@^3.1.4:
   version "3.8.0"
@@ -7799,20 +7803,20 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmlbuilder@^13.0.2:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
-  integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
+xmlbuilder@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.0.0.tgz#de9a078a0b82ef0c6da5c76e58813a879eec31ec"
+  integrity sha512-KLu/G0DoWhkncQ9eHSI6s0/w+T4TM7rQaLhtCaL6tORv8jFlJPlnGumsgTcGfYeS1qZ/IHqrvDG7zJZ4d7e+nw==
 
 xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.2.1.tgz#cac9465066f161e1c3302793ea4dbe59c518274f"
-  integrity sha512-kXXiYvmblIgEemGeB75y97FyaZavx6SQhGppLw5TKWAD2Wd0KAly0g23eVLh17YcpxZpnFym1Qk/eaRjy1APPg==
+xmldom@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz#e625457f4300b5df9c2e1ecb776147ece47f3e5a"
+  integrity sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==
 
 xtend@~4.0.1:
   version "4.0.2"
@@ -7867,6 +7871,14 @@ yargs-parser@^18.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@15.0.2:
   version "15.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.0.2.tgz#4248bf218ef050385c4f7e14ebdf425653d13bd3"
@@ -7917,3 +7929,20 @@ yargs@^15.0.0, yargs@^15.1.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.0"
+
+yargs@^15.3.0:
+  version "15.3.1"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"


### PR DESCRIPTION
## Commit Message

chore: upgrade jsii & constructs (#80)

Upgrade jsii to 1.1.0 and constructs to 2.0.0 (which is compatible with jsii 1.x).

BREAKING CHANGE: please upgrade your dependency requirement for "constructs" to ^2.0.0

## End of Commit Message

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
