### PR TITLE
chore(gha): prevent gha from running on forks

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -6,6 +6,7 @@ on:
     
 jobs:
   release:
+    if: github.repository == 'awslabs/cdk8s'
     runs-on: ubuntu-latest
     container:
       image: jsii/superchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build_artifact:
     name: Build and upload artifact
+    if: github.repository == 'awslabs/cdk8s'
     runs-on: ubuntu-latest
     container:
       image: jsii/superchain


### PR DESCRIPTION
Fixes https://github.com/awslabs/cdk8s/issues/76

Only runs release scripts if on the `awslabs/cdk8s` repository.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
