### PR TITLE
chore: fix broken build with updated jenkins crd

### DIFF
--- a/examples/crd/__snapshots__/index.test.js.snap
+++ b/examples/crd/__snapshots__/index.test.js.snap
@@ -12,6 +12,9 @@ Array [
       "jenkinsAPISettings": Object {
         "authorizationStrategy": "foo",
       },
+      "master": Object {
+        "disableCSRFProtection": false,
+      },
       "seedJobs": Array [
         Object {
           "description": "Jenkins Operator repository",

--- a/examples/crd/index.ts
+++ b/examples/crd/index.ts
@@ -21,6 +21,9 @@ export class HelloKube extends Chart {
         ],
         jenkinsAPISettings: {
           authorizationStrategy: 'foo'
+        },
+        master: {
+          disableCSRFProtection: false
         }
       }
     });


### PR DESCRIPTION
Recent [commit](https://github.com/jenkinsci/kubernetes-operator/commit/110b750ab3361d0ad1dfc57c3cee807a6e088317) to the Jenkins operator that we are using in `crd` example make `master` required.

Looks like that CRD isn't changed all that often, I think it's okay to just update our examples whenever they make breaking changes over there.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
