### PR TITLE
chore(gha): use yarn integ for build integ script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,5 @@ jobs:
       - name: create bundle
         run: yarn package
       - name: integration tests
-        run: test/run-against-dist test/test-all.sh
+        run: yarn integ
 


### PR DESCRIPTION
Updating github build workflow script to just use `yarn integ`. 

This aligns with the release workflows, and lets us change the underlying integ scripts in just one place (`package.json`)

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
