### PR TITLE
chore(build): Fix integration tests by realigning versions

### DIFF
--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -33,10 +33,10 @@
     "@types/node": "13.7.0",
     "cdk8s": "0.0.0",
     "codemaker": "^0.22.0",
-    "constructs": "^2.0.0",
+    "constructs": "2.0.0",
     "fs-extra": "^8.1.0",
-    "jsii": "^1.1.0",
-    "jsii-pacmak": "^1.1.0",
+    "jsii": "1.1.0",
+    "jsii-pacmak": "1.1.0",
     "sscaff": "^1.2.0",
     "yaml": "^1.7.2",
     "yargs": "^15.1.0"

--- a/packages/cdk8s/package.json
+++ b/packages/cdk8s/package.json
@@ -74,8 +74,8 @@
     "constructs": "2.0.0",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
-    "jsii": "^1.1.0",
-    "jsii-pacmak": "^1.1.0",
+    "jsii": "1.1.0",
+    "jsii-pacmak": "1.1.0",
     "json-schema-to-typescript": "^8.0.1",
     "typescript": "^3.7.5"
   },
@@ -94,7 +94,7 @@
     "yaml": "^1.7.2"
   },
   "peerDependencies": {
-    "constructs": "^2.0.0"
+    "constructs": "2.0.0"
   },
   "stability": "experimental"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,7 +4685,7 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-pacmak@^1.1.0:
+jsii-pacmak@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.1.0.tgz#a5363bde828bda6d24cbc33a8dd13971eea28e67"
   integrity sha512-TLJjLN53fwA5n7hQ2UKRxRYUhead7sRILo4KOJQxN8dVAI1+oocp198QaVGbDD6ZE3aIUKKVThOkBZkY8K3zbw==
@@ -4727,7 +4727,7 @@ jsii-rosetta@^1.1.0:
     xmldom "^0.3.0"
     yargs "^15.3.0"
 
-jsii@^1.1.0:
+jsii@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.1.0.tgz#cc76544fd67793f92f3fbe8f0d1ff22d75f61092"
   integrity sha512-QmtKu2ZEXwMop+An4AnDsOZJr5EObcXtGiuw8bVy8ldq1WHiri4mvSWwZQI3ekUcWyOGjwFY9CuDy+xYbsf+Pg==


### PR DESCRIPTION
Latest release of `jsii-1.2.0` and `constructs-2.0.1` are  _likely_ breaking the python integration tests with error:

```
Traceback (most recent call last):
  File "/tmp/tmp.gaCdcsnX6z/test/main.py", line 5, in <module>
    from imports import k8s
  File "/tmp/tmp.gaCdcsnX6z/test/imports/k8s/__init__.py", line 14, in <module>
    __jsii_assembly__ = jsii.JSIIAssembly.load("k8s", "0.0.0", "k8s", "k8s@0.0.0.jsii.tgz")
  File "/github/home/.local/share/virtualenvs/test-a1HuYYWE/lib/python3.7/site-packages/jsii/_runtime.py", line 38, in load
    f"{assembly.module}._jsii", assembly.filename
  File "/usr/lib64/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/usr/lib64/python3.7/importlib/resources.py", line 184, in path
    package = _get_package(package)
  File "/usr/lib64/python3.7/importlib/resources.py", line 47, in _get_package
    module = import_module(package)
  File "/usr/lib64/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ModuleNotFoundError: No module named 'k8s'
```

@eladb I think you have more context on this than I do :)

Is this the right fix? Or are we compiling / jsii-ing the `k8s` module incorrectly? 

---

Note: these tests are failing even on latest commit to `cdk8s` (not just in this PR https://github.com/awslabs/cdk8s/pull/84)

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
