### PR TITLE
chore(build): pin jsii to 1.1.0 due to bug in 1.2.0

### DIFF
--- a/examples/crd/package.json
+++ b/examples/crd/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.0"
+    "constructs": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.0"
+    "constructs": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/podinfo/package.json
+++ b/examples/podinfo/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.0"
+    "constructs": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/web-service/package.json
+++ b/examples/web-service/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.0"
+    "constructs": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -33,10 +33,10 @@
     "@types/node": "13.7.0",
     "cdk8s": "0.0.0",
     "codemaker": "^0.22.0",
-    "constructs": "^2.0.0",
+    "constructs": "^2.0.1",
     "fs-extra": "^8.1.0",
-    "jsii": "^1.1.0",
-    "jsii-pacmak": "^1.1.0",
+    "jsii": "1.1.0",
+    "jsii-pacmak": "1.1.0",
     "sscaff": "^1.2.0",
     "yaml": "^1.7.2",
     "yargs": "^15.1.0"
@@ -69,6 +69,7 @@
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
     "eslint": "^6.8.0",
-    "jest": "^25.1.0"
+    "jest": "^25.1.0",
+    "typescript": "^3.8.3"
   }
 }

--- a/packages/cdk8s/package.json
+++ b/packages/cdk8s/package.json
@@ -71,11 +71,11 @@
     "@types/yaml": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
-    "constructs": "2.0.0",
+    "constructs": "2.0.1",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
-    "jsii": "^1.1.0",
-    "jsii-pacmak": "^1.1.0",
+    "jsii": "1.1.0",
+    "jsii-pacmak": "1.1.0",
     "json-schema-to-typescript": "^8.0.1",
     "typescript": "^3.7.5"
   },
@@ -94,7 +94,7 @@
     "yaml": "^1.7.2"
   },
   "peerDependencies": {
-    "constructs": "^2.0.0"
+    "constructs": "^2.0.1"
   },
   "stability": "experimental"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,10 +2229,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@2.0.0, constructs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-2.0.0.tgz#8cd035411254853b87c00bb9fec013c644c1c488"
-  integrity sha512-5bW84vSNMZ0XuEW93OTQG+HuPfRRPzVtXcsCAjUhc5Cmm9pHds10vz+GyDTbBZZ9jsFlY+YjXpcuVyTQ7dV14w==
+constructs@2.0.1, constructs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/constructs/-/constructs-2.0.1.tgz#274d6b8ce6a698813495c444466b0c745349ddb5"
+  integrity sha512-edR85YFGI9TBT9byAo5vAfI0PRi+jFGzinwN3RAJwKfv6Yc9x9kALYfoEmgotp95qT7/k/iUQWHrH9BMJeqpdg==
 
 conventional-changelog-angular@^5.0.3, conventional-changelog-angular@^5.0.6:
   version "5.0.6"
@@ -4685,9 +4685,9 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-pacmak@^1.1.0:
+jsii-pacmak@1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.1.0.tgz#a5363bde828bda6d24cbc33a8dd13971eea28e67"
+  resolved "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.1.0.tgz#a5363bde828bda6d24cbc33a8dd13971eea28e67"
   integrity sha512-TLJjLN53fwA5n7hQ2UKRxRYUhead7sRILo4KOJQxN8dVAI1+oocp198QaVGbDD6ZE3aIUKKVThOkBZkY8K3zbw==
   dependencies:
     "@jsii/spec" "^1.1.0"
@@ -4727,9 +4727,9 @@ jsii-rosetta@^1.1.0:
     xmldom "^0.3.0"
     yargs "^15.3.0"
 
-jsii@^1.1.0:
+jsii@1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.1.0.tgz#cc76544fd67793f92f3fbe8f0d1ff22d75f61092"
+  resolved "https://registry.npmjs.org/jsii/-/jsii-1.1.0.tgz#cc76544fd67793f92f3fbe8f0d1ff22d75f61092"
   integrity sha512-QmtKu2ZEXwMop+An4AnDsOZJr5EObcXtGiuw8bVy8ldq1WHiri4mvSWwZQI3ekUcWyOGjwFY9CuDy+xYbsf+Pg==
   dependencies:
     "@jsii/spec" "^1.1.0"
@@ -7431,9 +7431,9 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5, typescript@~3.8.3:
+typescript@^3.7.5, typescript@^3.8.3, typescript@~3.8.3:
   version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:


### PR DESCRIPTION
In jsii 1.2.0 the way python code loads jsii tarballs has been changed and is no longer "portable" in a sense that we can harvest the python code into a user-defined location in the cdk8s project (e.g. `imports`).

Until this is fixed, we are pinning jsii to 1.1.0.

jsii bug: https://github.com/aws/jsii/issues/1501

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
