### PR TITLE
fix(readme): missing information about imports in cdk8s-cli readme

### DIFF
--- a/packages/cdk8s-cli/README.md
+++ b/packages/cdk8s-cli/README.md
@@ -16,7 +16,9 @@ Install globally via `yarn` (or `npm`):
 yarn global add cdk8s-cli
 ```
 
-## init - Create new projects
+## init
+
+### Create new projects
 
 This command creates new cdk8s projects from built in templates:
 
@@ -32,7 +34,9 @@ $ cd my-fun-little-project
 $ cdk8s init typescript-app
 ```
 
-## import - Import API objects as constructs
+## import
+
+### Import API objects as constructs
 
 To generate constructs for all Kubernetes API objects of a certain version, use
 the `import` subcommand:
@@ -51,6 +55,46 @@ objects:
 ```shell
 $ cdk8s import k8s
 ```
+
+### Import different versions of the k8s API
+
+By default, the command `cdk8s import k8s` will use the latest stable version of k8s objects.
+
+For example, when using k8s 1.17,  if you want to use `DeploymentSpec`, you would be importing it from [Deployment v1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deploymentspec-v1-apps) by default. 
+
+In the default `v1`, the `revisionHistoryLimit`, which is the number of old ReplicaSets to retain, is set to 10 by default. You would have to explicitly set this to a higher number if you want to retain more.
+
+Let's say that you want the behavior of [extensions/v1beta1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deploymentspec-v1beta1-extensions), which defaults to retaining _all_ old ReplicaSets.
+
+To do this, you could add the `--include` flag to your `cdk8s import`. Here is how that would look:
+
+```code
+cdk8s import k8s --language typescript --include io.k8s.api.extensions.v1beta1.Deployment
+```
+
+Here we are explicitly choosing to use the [Deployment extensions/v1beta1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deployment-v1beta1-extensions) version, which includes the new default behavior that we want from `DeploymentSpec`
+
+### Import Customer Resource Definitions (CRDs)
+
+You can import CRDs from local files (`my_crd.yml`) or from a remote host (`https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml`)
+
+Just like other imports, this is how you do that:
+
+```code
+cdk8s import my_crd.yaml
+```
+
+By default, your imported CRD will be named by its `spec.names.kind`. If your CRD file contains multiple CRDs, this will create multiple imports, each named by its respective `spec.names.kind`.
+
+### Override default behavior of import naming
+
+You can also override the default behavior for `cdk8s` importing. This will be helpful to you if you would like to name your CRD imports differently from their kind. Here is how you do it:
+
+```code
+cdk8s import example:=my_crd.yaml
+```
+
+In this case, your import would be named `example`.
 
 ## License
 

--- a/packages/cdk8s-cli/README.md
+++ b/packages/cdk8s-cli/README.md
@@ -36,43 +36,6 @@ $ cdk8s init typescript-app
 
 ## import
 
-### Selecting import language
-
-You can specify the language of your imports with the `--language` flag.
-
-`cdk8s` CLI
-
-```code
-cdk8s import --language typescript
-```
-
-`cdk8s.yaml` Config
-
-```yaml
-language: typescript
-```
-
-Both `typescript` and `python` are supported right now, unless noted otherwise.
-
-Example output for `typescript` imports is:
-
-```
-imports/
-  k8s.ts
-```
-
-Example output for `python` imports is:
-
-```
-imports/
-  k8s/
-    __init__.py
-    py.typed
-    _jsii/
-      __init__.py
-      k8s@1.17.0.jsii.tgz
-```
-
 ### Import Kubernetes API objects as constructs
 
 To generate constructs for all Kubernetes API objects of a certain version, use
@@ -82,7 +45,7 @@ the `import` subcommand:
 $ cdk8s import k8s
 ```
 
-By default, the import command will create a file under `imports/k8s.ts`
+By default, the import command will put your imports under `imports/`
 with constructs for each API object in the k8s spec.
 
 The following example will import a specific version of the Kubernetes API objects:
@@ -143,12 +106,19 @@ imports:
 
 By default, your imported CRD will be named by its `spec.names.kind`. If your CRD file contains multiple CRDs, this will create multiple imports, each named by its respective `spec.names.kind`.
 
-For example, if `my_crd.yaml` contained two kinds, `cluster` and `autoscaler`, you would have two imports:
+For example, if `my_crd.yaml` contained two kinds, `cluster` and `autoscaler`, you would have two imports. You could use them in this fashion:
 
+Typescript:
+
+```javascript
+import { cluster } from './imports/cluster';
+import { autoscaler } from './imports/autoscaler';
 ```
-imports/
-  cluster.ts
-  autoscaler.ts
+
+Python:
+
+```python
+from imports import cluster, autoscaler
 ```
 
 ### Override default behavior of import naming
@@ -170,13 +140,40 @@ imports:
   - example:=my_crd.yaml
 ```
 
-If your CRD contained two kinds, `cluster` and `autoscaler`, you would have two imports:
+If your CRD contained two kinds, `cluster` and `autoscaler`, you would have two imports. You could use them in this fashion:
 
+
+Typescript:
+
+```javascript
+import { cluster } from './imports/example-cluster';
+import { autoscaler } from './imports/example-autoscaler';
 ```
-imports/
-  example-cluster.ts
-  example-autoscaler.ts
+
+Python:
+
+```python
+not yet supported
 ```
+
+## Selecting language
+
+You can specify your desired language with the `--language` flag. For example:
+
+`cdk8s` CLI
+
+```code
+cdk8s import --language typescript
+```
+
+`cdk8s.yaml` Config
+
+```yaml
+language: typescript
+```
+
+Both `typescript` and `python` are supported right now, unless noted otherwise.
+
 
 ## License
 

--- a/packages/cdk8s-cli/README.md
+++ b/packages/cdk8s-cli/README.md
@@ -36,31 +36,73 @@ $ cdk8s init typescript-app
 
 ## import
 
-### Import API objects as constructs
+### Selecting import language
+
+You can specify the language of your imports with the `--language` flag.
+
+`cdk8s` CLI
+
+```code
+cdk8s import --language typescript
+```
+
+`cdk8s.yaml` Config
+
+```yaml
+language: typescript
+```
+
+Both `typescript` and `python` are supported right now, unless noted otherwise.
+
+Example output for `typescript` imports is:
+
+```
+imports/
+  k8s.ts
+```
+
+Example output for `python` imports is:
+
+```
+imports/
+  k8s/
+    __init__.py
+    py.typed
+    _jsii/
+      __init__.py
+      k8s@1.17.0.jsii.tgz
+```
+
+### Import Kubernetes API objects as constructs
 
 To generate constructs for all Kubernetes API objects of a certain version, use
 the `import` subcommand:
 
 ```shell
-$ cdk8s import SPEC
-```
-
-Currently, the only supported spec is `"k8s"` which represents the core
-Kubernetes API. The import command will create a file under `imports/k8s.ts`
-with constructs for each API object in the spec.
-
-The following example will import the latest version of the Kubernetes API
-objects:
-
-```shell
 $ cdk8s import k8s
 ```
 
-### Import different versions of the k8s API
+By default, the import command will create a file under `imports/k8s.ts`
+with constructs for each API object in the k8s spec.
+
+The following example will import a specific version of the Kubernetes API objects:
+
+```shell
+$ cdk8s import k8s@1.16.0
+```
+
+Alternatively, you can specify your `k8s` import in the `cdk8s.yaml` config file:
+
+```yaml
+imports:
+  - k8s@1.17.0
+```
+
+#### Selecting `apiVersion`s for specific objects
 
 By default, the command `cdk8s import k8s` will use the latest stable version of k8s objects.
 
-For example, when using k8s 1.17,  if you want to use `DeploymentSpec`, you would be importing it from [Deployment v1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deploymentspec-v1-apps) by default. 
+For example, when using k8s 1.17, if you want to use `DeploymentSpec`, you would be importing it from [Deployment v1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deploymentspec-v1-apps) by default. 
 
 In the default `v1`, the `revisionHistoryLimit`, which is the number of old ReplicaSets to retain, is set to 10 by default. You would have to explicitly set this to a higher number if you want to retain more.
 
@@ -68,33 +110,73 @@ Let's say that you want the behavior of [extensions/v1beta1](https://kubernetes.
 
 To do this, you could add the `--include` flag to your `cdk8s import`. Here is how that would look:
 
+`cdk8s` CLI
+
 ```code
 cdk8s import k8s --language typescript --include io.k8s.api.extensions.v1beta1.Deployment
 ```
 
+`cdk8s.yaml` Config
+
+This is not yet supported in `cdk8s.yaml` config.
+
 Here we are explicitly choosing to use the [Deployment extensions/v1beta1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deployment-v1beta1-extensions) version, which includes the new default behavior that we want from `DeploymentSpec`
 
-### Import Customer Resource Definitions (CRDs)
+### Import Custom Resource Definitions (CRDs)
 
 You can import CRDs from local files (`my_crd.yml`) or from a remote host (`https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml`)
 
 Just like other imports, this is how you do that:
 
+`cdk8s` CLI
+
 ```code
 cdk8s import my_crd.yaml
 ```
 
+`cdk8s.yaml` config
+
+```yaml
+imports:
+  - my_crd.yaml
+```
+
 By default, your imported CRD will be named by its `spec.names.kind`. If your CRD file contains multiple CRDs, this will create multiple imports, each named by its respective `spec.names.kind`.
+
+For example, if `my_crd.yaml` contained two kinds, `cluster` and `autoscaler`, you would have two imports:
+
+```
+imports/
+  cluster.ts
+  autoscaler.ts
+```
 
 ### Override default behavior of import naming
 
+Note: this is not yet supported for python.
+
 You can also override the default behavior for `cdk8s` importing. This will be helpful to you if you would like to name your CRD imports differently from their kind. Here is how you do it:
+
+`cdk8s` CLI
 
 ```code
 cdk8s import example:=my_crd.yaml
 ```
 
-In this case, your import would be named `example`.
+`cdk8s.yaml` Config
+
+```yaml
+imports:
+  - example:=my_crd.yaml
+```
+
+If your CRD contained two kinds, `cluster` and `autoscaler`, you would have two imports:
+
+```
+imports/
+  example-cluster.ts
+  example-autoscaler.ts
+```
 
 ## License
 


### PR DESCRIPTION
Updates the `cdk8s-cli` readme with some of the recent changes to importing.

Fixes: https://github.com/awslabs/cdk8s/issues/28

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
