### PR TITLE
fix(redirect): Handle 302 redirect case when importing from remote url

### DIFF
--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -34,22 +34,22 @@ async function get(url: string, protocol: typeof http | typeof https = https): P
   return new Promise((ok, ko) => {
     const req = protocol.get(url, async res => {
       switch(res.statusCode) {
-        case 200: {
+        case 200:
           const data = new Array<Buffer>();
           res.on('data', chunk => data.push(chunk));
           res.once('end', () => ok(Buffer.concat(data).toString('utf-8')));
           res.once('error', ko);
           break;
-        }
-        case 302: case 301: {
+
+        case 301:
+        case 302:
           if (res.headers.location) {
             await ok(get(res.headers.location, protocol));
           }
           break;
-        }
-        default: {
+
+        default:
           throw new Error(`${res.statusMessage}: ${url}`);
-        }
       }
     });
 

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -34,22 +34,25 @@ async function get(url: string, protocol: typeof http | typeof https = https): P
   return new Promise((ok, ko) => {
     const req = protocol.get(url, async res => {
       switch(res.statusCode) {
-        case 200:
+        case 200: {
           const data = new Array<Buffer>();
           res.on('data', chunk => data.push(chunk));
           res.once('end', () => ok(Buffer.concat(data).toString('utf-8')));
           res.once('error', ko);
           break;
+        }
 
         case 301:
-        case 302:
+        case 302: {
           if (res.headers.location) {
             await ok(get(res.headers.location, protocol));
           }
           break;
+        }
 
-        default:
+        default: {
           throw new Error(`${res.statusMessage}: ${url}`);
+        }
       }
     });
 

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -41,7 +41,7 @@ async function get(url: string, protocol: typeof http | typeof https = https): P
           res.once('error', ko);
           break;
         }
-        case 302: {
+        case 302: case 301: {
           if (res.headers.location) {
             await ok(get(res.headers.location, protocol));
           }

--- a/packages/cdk8s-cli/lib/util.ts
+++ b/packages/cdk8s-cli/lib/util.ts
@@ -32,14 +32,25 @@ export async function withTempDir(dirname: string, closure: () => Promise<void>)
 
 async function get(url: string, protocol: typeof http | typeof https = https): Promise<string> {
   return new Promise((ok, ko) => {
-    const req = protocol.get(url, res => {
-      if (res.statusCode !== 200) {
-        throw new Error(`${res.statusMessage}: ${url}`);
+    const req = protocol.get(url, async res => {
+      switch(res.statusCode) {
+        case 200: {
+          const data = new Array<Buffer>();
+          res.on('data', chunk => data.push(chunk));
+          res.once('end', () => ok(Buffer.concat(data).toString('utf-8')));
+          res.once('error', ko);
+          break;
+        }
+        case 302: {
+          if (res.headers.location) {
+            await ok(get(res.headers.location, protocol));
+          }
+          break;
+        }
+        default: {
+          throw new Error(`${res.statusMessage}: ${url}`);
+        }
       }
-      const data = new Array<Buffer>();
-      res.on('data', chunk => data.push(chunk));
-      res.once('end', () => ok(Buffer.concat(data).toString('utf-8')));
-      res.once('error', ko);
     });
 
     req.once('error', ko);


### PR DESCRIPTION
Looks like sometimes Github artifacts redirect... for example:

https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml 

--> 

https://github-production-release-asset-2e65be.s3.amazonaws.com/118828329/3c637300-7e2d-11ea-8546-4be9f0554e5b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200502%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200502T045903Z&X-Amz-Expires=300&X-Amz-Signature=2024809ec2f7868b96eae650106117f9c6a00b9f8d21a2c1827c201013f507e6&X-Amz-SignedHeaders=host&actor_id=0&repo_id=118828329&response-content-disposition=attachment%3B%20filename%3Dserving-crds.yaml&response-content-type=application%2Foctet-stream

---

As far as testing goes.. got as far as `TypeError: Cannot read property 'kind' of null` (from https://github.com/awslabs/cdk8s/issues/129). This indicates to me that we can download it properly and get to the next broken part.

If you know of any CRDs that we parse correctly and hosted similarly, let me know, and we'll add it to the tests!

Fixes part of https://github.com/awslabs/cdk8s/issues/129

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
