### PR TITLE
chore(test): pin CRDs in integ test to a specific commit

### DIFF
--- a/test/test-imports/python/cdk8s.yaml
+++ b/test/test-imports/python/cdk8s.yaml
@@ -3,5 +3,7 @@ language: typescript
 imports:
   - k8s@1.17.0
   - mattermost:=mattermost_crd.yaml
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+
+  # pin to a specific commit, otherwise we have a non-deterministic test
+  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
   - example_multiple_crd.yaml

--- a/test/test-imports/typescript/cdk8s.yaml
+++ b/test/test-imports/typescript/cdk8s.yaml
@@ -2,6 +2,8 @@ app: node index.js
 language: typescript
 imports:
   - k8s@1.17.0
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+
+  # pin to a specific commit, otherwise we have a non-deterministic test
+  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost:=mattermost_crd.yaml
   - example_multiple_crd.yaml


### PR DESCRIPTION
Otherwise we will have a non-deterministic test when the CRD changes

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
