### PR TITLE
chore: fix lerna build globbing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,4 @@
 {
-  "packages": [
-    "packages/*",
-    "examples/**/*"
-  ],
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "workspaces": {
     "packages": [
       "packages/*",
-      "examples/*"
+      "examples/**/*"
     ],
     "nohoist": [
       "cdk8s/yaml",


### PR DESCRIPTION
Recent changes to the `examples/` directory stopped building the example packages.

This fixes that.

Also described here: https://github.com/awslabs/cdk8s/pull/175

```
Lerna package globbing is overridden by yarn workspaces, so removed that and fixed globbing there. Docs - https://github.com/lerna/lerna/blob/master/commands/bootstrap/README.md#--use-workspaces
```

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
