### PR TITLE
fix(cli): import doesn't work on windows

### DIFF
--- a/packages/cdk8s-cli/lib/import/base.ts
+++ b/packages/cdk8s-cli/lib/import/base.ts
@@ -56,7 +56,7 @@ export abstract class ImportBase {
         });
 
         const pacmak = require.resolve('jsii-pacmak/bin/jsii-pacmak');
-        await shell(pacmak, [ '--target', options.targetLanguage, '--code-only' ]);
+        await shell(pacmak, [ '--target', options.targetLanguage, '--code-only' ], { shell: true });
         await this.harvestCode(options, outdir, name);
       });
     }

--- a/packages/cdk8s-cli/lib/import/jsii.ts
+++ b/packages/cdk8s-cli/lib/import/jsii.ts
@@ -78,7 +78,8 @@ export async function jsiiCompile(workdir: string, options: JsiiCompileOptions) 
 
   await fs.writeFile(path.join(workdir, 'package.json'), JSON.stringify(pkg, undefined, 2));
 
-  await shell(compiler, args, { 
+  await shell(compiler, args, {
+    shell: true,
     cwd: workdir,
     stdio: [ 'inherit', stdout ? 'inherit' : 'ignore', 'inherit' ]
   });


### PR DESCRIPTION
Might help with https://github.com/awslabs/cdk8s/issues/182 according to https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows

(PS: currently working on adding `macos-latest` and `windows-latest` to github actions build).

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
