### PR TITLE
feat(examples): add kubernetes-dashboard python example

### DIFF
--- a/examples/python/kubernetes-dashboard/.gitignore
+++ b/examples/python/kubernetes-dashboard/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist/
+imports/

--- a/examples/python/kubernetes-dashboard/Pipfile
+++ b/examples/python/kubernetes-dashboard/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+cdk8s = "*"
+
+[requires]
+python_version = "3.7"

--- a/examples/python/kubernetes-dashboard/Pipfile.lock
+++ b/examples/python/kubernetes-dashboard/Pipfile.lock
@@ -1,0 +1,86 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "120a66ade6e754c93097441cb494163c3ebbd0dd66a45680f5a492b7f6057d74"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "cattrs": {
+            "hashes": [
+                "sha256:616972ae3dfa6e623a40ad3cb845420e64942989152774ab055e5c2b2f89f997",
+                "sha256:b7ab5cf8ad127c42eefd01410c1c6e28569a45a255ea80ed968511873c433c7a"
+            ],
+            "version": "==1.0.0"
+        },
+        "cdk8s": {
+            "hashes": [
+                "sha256:1e56b2867f0ec8e2c0c07346afe30a3c208ad012f17e7d2ab8e01ea494f155ae",
+                "sha256:69e55842d4caeeb2f3502b499f72ea32bb60ea341f0e835557cdba077176a917"
+            ],
+            "index": "pypi",
+            "version": "==0.21.0"
+        },
+        "constructs": {
+            "hashes": [
+                "sha256:078b4d2257f3f7277e8413c43337d91eddf8d214e6255f7daaf0bb54a8f79e7c",
+                "sha256:bfa62be5b10a64cbc9b8e6c0f27ceb6015699ff72f470c985acdf82ff94b70d5"
+            ],
+            "version": "==2.0.1"
+        },
+        "jsii": {
+            "hashes": [
+                "sha256:37146cf6955a040d99c80ab9cb53ec00ca49e73a324d35b3c28c0d089c8e16f1",
+                "sha256:4e07058471876c40d50cb29f81f0f8a9d766c3fb6d9eb2b1c1b3d499cc17df65"
+            ],
+            "version": "==1.1.1"
+        },
+        "publication": {
+            "hashes": [
+                "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6",
+                "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4"
+            ],
+            "version": "==0.0.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+            ],
+            "version": "==3.7.4.2"
+        }
+    },
+    "develop": {}
+}

--- a/examples/python/kubernetes-dashboard/README.md
+++ b/examples/python/kubernetes-dashboard/README.md
@@ -1,0 +1,22 @@
+# Kubernetes Dashboard Construct Example (in Python!)
+
+This example application deploys [kubernetesui/dashboard](https://github.com/kubernetes/dashboard) by using a custom KubernetesDashboard construct with cdk8s.
+
+You can apply this example into your own cluster with these step by step commands:
+
+#### Import
+
+```console
+$ pipenv install
+$ cdk8s import --language python
+```
+
+#### Synthesize the CDK into a k8s template
+```console
+$ cdk8s synth
+```
+
+#### Apply the k8s template to your cluster
+```console
+$ kubectl apply -f dist/kubernetesdashboardpython.k8s.yaml
+```

--- a/examples/python/kubernetes-dashboard/cdk8s.yaml
+++ b/examples/python/kubernetes-dashboard/cdk8s.yaml
@@ -1,0 +1,4 @@
+language: python
+app: pipenv run ./main.py
+imports:
+  - k8s

--- a/examples/python/kubernetes-dashboard/kubernetes_dashboard.py
+++ b/examples/python/kubernetes-dashboard/kubernetes_dashboard.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+
+from constructs import Construct
+
+from imports.k8s import *
+
+
+class KubernetesDashboard(Construct):
+
+    def __init__(self, scope: Construct, id: str, **kwargs):
+        super().__init__(scope, id)
+
+        label = {"app": "kubernetes-dashboard"}
+
+        namespace = Namespace(self, "kubernetes-dashboard",
+                              metadata=ObjectMeta(name="kubernetes-dashboard"))
+
+        ServiceAccount(self, "service-account",
+                       metadata=ObjectMeta(
+                           name="kubernetes-dashboard",
+                           namespace=namespace.name,
+                           labels=label))
+
+        Service(self, "service",
+                metadata=ObjectMeta(
+                    labels=label,
+                    name="kubernetes-dashboard",
+                    namespace="kubernetes-dashboard"
+                ),
+                spec=ServiceSpec(
+                    ports=[
+                        ServicePort(
+                            port=443,
+                            target_port=IntOrString.from_number(8443))],
+                    selector=label))
+
+        Secret(self, "secret",
+               metadata=ObjectMeta(
+                   name="kubernetes-dashboard-certs",
+                   namespace=namespace.name,
+                   labels=label),
+               type="Opaque")
+
+        Secret(self, "secret-csrf",
+               metadata=ObjectMeta(
+                   name="kubernetes-dashboard-csrf",
+                   namespace=namespace.name,
+                   labels=label),
+               type="Opaque",
+               data={"csrf": ""})
+
+        Secret(self, "secret-key-holder",
+               metadata=ObjectMeta(
+                   name="kubernetes-dashboard-key-holder",
+                   namespace=namespace.name,
+                   labels=label),
+               type="Opaque")
+
+        ConfigMap(self, "config",
+                  metadata=ObjectMeta(
+                      name="kubernetes-dashboard-settings",
+                      namespace=namespace.name,
+                      labels=label)
+                  )
+
+        Role(
+            self,
+            "role",
+            metadata=ObjectMeta(
+                labels=label,
+                name="kubernetes-dashboard",
+                namespace="kubernetes-dashboard"
+            ),
+            rules=[
+                PolicyRule(
+                    api_groups=[""],
+                    resources=["secrets"],
+                    resource_names=["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs",
+                                    "kubernetes-dashboard-csrf"],
+                    verbs=["get", "update", "delete"],
+                ),
+                PolicyRule(
+                    api_groups=[""],
+                    resources=["configmaps"],
+                    resource_names=["kubernetes-dashboard-settings"],
+                    verbs=["get", "update"]
+                ),
+                PolicyRule(
+                    api_groups=[""],
+                    resources=["services"],
+                    resource_names=["heapster", "dashboard-metrics-scraper"],
+                    verbs=["proxy"]
+                ),
+                PolicyRule(
+                    api_groups=[""],
+                    resources=["services/proxy"],
+                    resource_names=["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper",
+                                    "http:dashboard-metrics-scraper"],
+                    verbs=["get"])])
+
+        ClusterRole(
+            self,
+            "cluster-role",
+            metadata=ObjectMeta(
+                labels=label,
+                name="kubernetes-dashboard"
+            ),
+            rules=[
+                PolicyRule(
+                    api_groups=["metrics.io"],
+                    resources=["pods", "nodes"],
+                    verbs=["get", "list", "watch"])])
+
+        RoleBinding(
+            self,
+            "role-binding",
+            metadata=ObjectMeta(
+                labels=label,
+                name="kubernetes-dashboard",
+                namespace="kubernetes-dashboard"
+            ),
+            role_ref=RoleRef(
+                api_group="rbac.authorization.k8s.io",
+                kind="Role",
+                name="kubernetes-dashboard"
+            ),
+            subjects=[
+                Subject(
+                    kind="ServiceAccount",
+                    name="kubernetes-dashboard",
+                    namespace="kubernetes-dashboard")])
+
+        ClusterRoleBinding(
+            self,
+            "cluster-role-binding",
+            metadata=ObjectMeta(
+                name="kubernetes-dashboard"
+            ),
+            role_ref=RoleRef(
+                api_group="rbac.authorization.k8s.io",
+                kind="ClusterRole",
+                name="kubernetes-dashboard"
+            ),
+            subjects=[
+                Subject(
+                    kind="ServiceAccount",
+                    name="kubernetes-dashboard",
+                    namespace="kubernetes-dashboard")])
+
+        Deployment(
+            self,
+            "deployment",
+            metadata=ObjectMeta(
+                labels=label,
+                name="kubernetes-dashboard",
+                namespace="kubernetes-dashboard"
+            ),
+            spec=DeploymentSpec(
+                replicas=1,
+                revision_history_limit=10,
+                selector=LabelSelector(
+                    match_labels=label
+                ),
+                template=PodTemplateSpec(
+                    metadata=ObjectMeta(
+                        labels=label
+                    ),
+                    spec=PodSpec(
+                        containers=[
+                            Container(
+                                name="kubernetes-dashboard",
+                                image="kubernetesui/dashboard:v2.0.0",
+                                image_pull_policy="Always",
+                                ports=[
+                                    ContainerPort(
+                                        container_port=8443,
+                                        protocol="TCP"
+                                    )
+                                ],
+                                args=[
+                                    "--auto-generate-certificates",
+                                    "--namespace=kubernetes-dashboard",
+                                ],
+                                volume_mounts=[
+                                    VolumeMount(
+                                        name="kubernetes-dashboard-certs",
+                                        mount_path="/certs"
+                                    ),
+                                    VolumeMount(
+                                        name="tmp-volume",
+                                        mount_path="/tmp"
+                                    )
+                                ],
+                                liveness_probe=Probe(
+                                    http_get=HTTPGetAction(
+                                        scheme="HTTPS",
+                                        path="/",
+                                        port=IntOrString.from_number(8443)
+                                    ),
+                                    initial_delay_seconds=30,
+                                    timeout_seconds=30
+                                ),
+                                security_context=SecurityContext(
+                                    allow_privilege_escalation=False,
+                                    read_only_root_filesystem=True,
+                                    run_as_user=1001,
+                                    run_as_group=2001
+                                )
+                            )
+                        ],
+                        volumes=[
+                            Volume(
+                                name="kubernetes-dashboard-certs",
+                                secret=SecretVolumeSource(secret_name="kubernetes-dashboard-certs")
+                            ),
+                            Volume(
+                                name="tmp-volume",
+                                empty_dir=EmptyDirVolumeSource()
+                            )
+                        ],
+                        service_account_name="kubernetes-dashboard",
+                        node_selector={
+                            "kubernetes.io/os": "linux"
+                        },
+                        tolerations=[
+                            Toleration(
+                                key="node-role.kubernetes.io/master",
+                                effect="NoSchedule")]))))
+
+        Service(
+            self,
+            "scraper-service",
+            metadata=ObjectMeta(
+                labels={"app": "dashboard-metrics-scraper"},
+                name="dashboard-metrics-scraper",
+                namespace="kubernetes-dashboard"
+            ),
+            spec=ServiceSpec(
+                ports=[
+                    ServicePort(
+                        port=8000,
+                        target_port=IntOrString.from_number(8000)
+                    )
+                ],
+                selector={"app": "dashboard-metrics-scraper"}))
+
+        Deployment(
+            self,
+            "scraper-deployment",
+            metadata=ObjectMeta(
+                labels=label,
+                name="dashboard-metrics-scraper",
+                namespace="kubernetes-dashboard"
+            ),
+            spec=DeploymentSpec(
+                replicas=1,
+                revision_history_limit=10,
+                selector=LabelSelector(
+                    match_labels={"app": "dashboard-metrics-scraper"}),
+                template=PodTemplateSpec(
+                    metadata=ObjectMeta(
+                        labels={"app": "dashboard-metrics-scraper"},
+                        annotations={"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"}
+                    ),
+                    spec=PodSpec(
+                        containers=[
+                            Container(
+                                name="dashboard-metrics-scraper",
+                                image="kubernetesui/metrics-scraper:v1.0.4",
+                                ports=[
+                                    ContainerPort(
+                                        container_port=8000,
+                                        protocol="TCP"
+                                    )
+                                ],
+                                liveness_probe=Probe(
+                                    http_get=HTTPGetAction(
+                                        scheme="HTTP",
+                                        path="/",
+                                        port=IntOrString.from_number(8000)
+                                    )
+                                ),
+                                volume_mounts=[
+                                    VolumeMount(
+                                        mount_path="/tmp",
+                                        name="tmp-volume"
+                                    )
+                                ],
+                                security_context=SecurityContext(
+                                    allow_privilege_escalation=False,
+                                    read_only_root_filesystem=True,
+                                    run_as_user=1001,
+                                    run_as_group=2001))],
+                        service_account_name="kubernetes-dashboard",
+                        node_selector={
+                            "kubernetes.io/os": "linux"
+                        },
+                        tolerations=[
+                            Toleration(
+                                key="node-role.kubernetes.io/master",
+                                effect="NoSchedule"
+                            )
+                        ],
+                        volumes=[
+                            Volume(
+                                name="tmp-volume",
+                                empty_dir=EmptyDirVolumeSource())]))))

--- a/examples/python/kubernetes-dashboard/main.py
+++ b/examples/python/kubernetes-dashboard/main.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from cdk8s import App, Chart
+from constructs import Construct
+
+from kubernetes_dashboard import KubernetesDashboard
+
+
+class MyChart(Chart):
+    def __init__(self, scope: Construct, ns: str):
+        super().__init__(scope, ns)
+
+        KubernetesDashboard(self, "kubernetes-dashboard")
+
+
+app = App()
+MyChart(app, "kubernetes-dashboard-python")
+app.synth()

--- a/examples/python/kubernetes-dashboard/package.json
+++ b/examples/python/kubernetes-dashboard/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kubernetes-dashboard-python",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "build": "cdk8s import --language python",
+    "synth": "cdk8s synth",
+    "test": "echo 'no test for python yet.'"
+  },
+  "dependencies": {
+    "cdk8s": "0.0.0",
+    "constructs": "^2.0.1"
+  },
+  "devDependencies": {
+    "cdk8s-cli": "0.0.0"
+  }
+}


### PR DESCRIPTION
Adding Python Construct example to deploy Kubernetes Dashboard, this is a direct translation of https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
