### PR TITLE
chore: allow release scope for semantic releases

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -9,6 +9,7 @@ scopes:
   - readme
   - docs
   - website
+  - release
   
 # only allow these types
 types:


### PR DESCRIPTION
So bumping version with [standard-version](https://github.com/conventional-changelog/standard-version#readme) passes the semantic pull request check :)

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
