### PR TITLE
fix(lib): unable to express empty objects and array

### DIFF
--- a/packages/cdk8s/lib/_util.ts
+++ b/packages/cdk8s/lib/_util.ts
@@ -6,26 +6,13 @@ export function removeEmpty(obj: any): any {
   if (typeof(obj) !== 'object') {
     return obj;
   }
-  
-  if (Array.isArray(obj)) {
-    if (obj.length === 0) {
-      return undefined;
-    }
 
-    return obj.map(x => {
-      // do not remove "{}" and "[]" if they are array elements.
-      if (Array.isArray(x) && x.length === 0) { return x; }
-      if (x != null && typeof(x) === 'object' && Object.keys(x).length === 0) { return x; }
-      return removeEmpty(x)
-    });
+  if (Array.isArray(obj)) {
+    return obj.map(x => removeEmpty(x));
   }
 
   if (obj.constructor.name !== 'Object') {
     throw new Error(`can't render non-simple object of type '${obj.constructor.name}'`);
-  }
-
-  if (Object.keys(obj).length === 0) {
-    return undefined;
   }
 
   const newObj: { [key: string]: any } = { };

--- a/packages/cdk8s/test/util.test.ts
+++ b/packages/cdk8s/test/util.test.ts
@@ -3,14 +3,14 @@ import { removeEmpty } from "../lib/_util";
 test('removeEmpty', () => {
   expect(removeEmpty(null)).toBe(undefined);
   expect(removeEmpty(undefined)).toBe(undefined);
-  expect(removeEmpty({ })).toBe(undefined);
-  expect(removeEmpty([ ])).toBe(undefined);
+  expect(removeEmpty({ })).toStrictEqual({ });
+  expect(removeEmpty([ ])).toStrictEqual([ ]);
   expect(removeEmpty(1)).toBe(1);
   expect(removeEmpty({ hello: 123 })).toStrictEqual({ hello: 123 });
   expect(removeEmpty([ 1, 2, 3 ])).toStrictEqual([ 1, 2, 3 ]);
-  expect(removeEmpty({ xoo: 123, foo: [] })).toStrictEqual({ xoo: 123 });
-  expect(removeEmpty({ xoo: { }, foo: { bar: { zoo: undefined, hey: { }, me: 123 }} })).toStrictEqual({ foo: { bar: { me: 123 } } });
-  expect(removeEmpty({ xoo: 123, foo: [ 1, 2, { foo: 123, bar: undefined, zoo: [] }, 3 ] })).toStrictEqual({ xoo: 123, foo: [ 1, 2, { foo: 123 }, 3 ] });
+  expect(removeEmpty({ xoo: 123, foo: [] })).toStrictEqual({ xoo: 123, foo: [] });
+  expect(removeEmpty({ xoo: { }, foo: { bar: { zoo: undefined, hey: { }, me: 123 }} })).toStrictEqual({ xoo: { }, foo: { bar: { hey: { }, me: 123 } } });
+  expect(removeEmpty({ xoo: 123, foo: [ 1, 2, { foo: 123, bar: undefined, zoo: [] }, 3 ] })).toStrictEqual({ xoo: 123, foo: [ 1, 2, { foo: 123, zoo: [ ] }, 3 ] });
   expect(removeEmpty([ 1, 2, 3, [ ], { }, 4 ])).toStrictEqual([ 1, 2, 3, [ ], { }, 4 ]); // special case
 
   expect(() => removeEmpty(new Dummy())).toThrow(/can't render non-simple object of type 'Dummy'/);


### PR DESCRIPTION
We used to remove all empty objects and array from synthesized objects. This is a problem in the k8s world since empty objects are sometimes used to represent a value.

For example, the [`volumes.emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) field.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
