### PR TITLE
feat(cli): import - support enum string fields

### DIFF
--- a/packages/cdk8s-cli/lib/import/type-generator.ts
+++ b/packages/cdk8s-cli/lib/import/type-generator.ts
@@ -145,6 +145,10 @@ export class TypeGenerator {
         return 'Date';
       }
 
+      if (Array.isArray(def.enum) && def.enum.length > 0 && !def.enum.find(x => typeof(x) !== 'string')) {
+        return this.emitEnum(typeName, def, structFqn);
+      }
+
       return 'string';
     }
     
@@ -256,6 +260,40 @@ export class TypeGenerator {
 
     code.line(`readonly ${name}${optional}: ${propertyType};`);
     code.line();
+  }
+
+  private emitEnum(typeName: string, def: JSONSchema4, structFqn: string) {
+
+    this.emitLater(typeName, code => {
+
+      if (!def.enum || def.enum.length === 0) {
+        throw new Error(`definition is not an enum: ${JSON.stringify(def)}`);
+      }
+
+      if (def.type !== 'string') {
+        throw new Error(`can only generate string enums`);
+      }
+
+      this.emitDescription(code, structFqn, def.description);
+
+      code.openBlock(`export enum ${typeName}`);
+
+      for (const value of def.enum) {
+        if (typeof(value) !== 'string') {
+          throw new Error(`can only generate enums for string values`);
+        }
+
+        // sluggify and turn to UPPER_SNAKE_CASE
+        const memberName = code.toSnakeCase(value.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+
+        code.line(`/** ${value} */`);
+        code.line(`${memberName} = "${value}",`);
+      }
+
+      code.closeBlock();
+    });
+
+    return typeName;
   }
 
   private emitDescription(code: CodeMaker, fqn: string, description?: string, annotations: { [type: string]: string } = { }) {

--- a/packages/cdk8s-cli/test/import/__snapshots__/type-generator.test.js.snap
+++ b/packages/cdk8s-cli/test/import/__snapshots__/type-generator.test.js.snap
@@ -1,10 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`documentation "*/" is is escaped 1`] = `""`;
+exports[`documentation "*/" is is escaped 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+    /**
+     * hello _/world
+     *
+     * @schema fqn.of.TestType#field
+     */
+    readonly field?: string;
 
-exports[`documentation does not render if not defined 1`] = `""`;
+}
 
-exports[`documentation renders based on description 1`] = `""`;
+"
+`;
+
+exports[`documentation does not render if not defined 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+    /**
+     * @schema fqn.of.TestType#field
+     */
+    readonly field?: boolean;
+
+}
+
+"
+`;
+
+exports[`documentation renders based on description 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+    /**
+     * hello, description
+     *
+     * @schema fqn.of.TestType#field
+     */
+    readonly field?: string;
+
+}
+
+"
+`;
+
+exports[`enums renders a typescript enum 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+    /**
+     * description of first enum
+     *
+     * @schema fqn.of.TestType#firstEnum
+     */
+    readonly firstEnum: FqnOfTestTypeFirstEnum;
+
+    /**
+     * @schema fqn.of.TestType#child
+     */
+    readonly child?: FqnOfTestTypeChild;
+
+}
+
+/**
+ * description of first enum
+ *
+ * @schema FqnOfTestTypeFirstEnum
+ */
+export enum FqnOfTestTypeFirstEnum {
+    /** value1 */
+    VALUE1 = \\"value1\\",
+    /** value2 */
+    VALUE2 = \\"value2\\",
+    /** value-of-three */
+    VALUE_OF_THREE = \\"value-of-three\\",
+    /** valueOfFour */
+    VALUE_OF_FOUR = \\"valueOfFour\\",
+}
+
+/**
+ * @schema FqnOfTestTypeChild
+ */
+export interface FqnOfTestTypeChild {
+    /**
+     * description of second enum
+     *
+     * @schema FqnOfTestTypeChild#secondEnum
+     */
+    readonly secondEnum?: FqnOfTestTypeChildSecondEnum;
+
+}
+
+/**
+ * description of second enum
+ *
+ * @schema FqnOfTestTypeChildSecondEnum
+ */
+export enum FqnOfTestTypeChildSecondEnum {
+    /** hey */
+    HEY = \\"hey\\",
+    /** enum values can be crazy */
+    ENUM_VALUES_CAN_BE_CRAZY = \\"enum values can be crazy\\",
+    /** yes>>123 */
+    YES_123 = \\"yes>>123\\",
+}
+
+"
+`;
 
 exports[`structs array of structs is considered optional 1`] = `
 "/**

--- a/packages/cdk8s-cli/test/import/type-generator.test.ts
+++ b/packages/cdk8s-cli/test/import/type-generator.test.ts
@@ -140,17 +140,58 @@ describe('structs', () => {
 describe('documentation', () => {
 
   which('does not render if not defined', {
-    type: 'boolean'
+    type: 'object',
+    properties: {
+      field: {
+        type: 'boolean'
+      }
+    }
   });
 
   which('renders based on description', {
-    description: 'hello, description',
-    type: 'string'
+    type: 'object',
+    properties: {
+      field: {
+        description: 'hello, description',
+        type: 'string'
+      }
+    }
   });
 
   which('"*/" is is escaped', {
-    description: 'hello */world',
-    type: 'string'
+    type: 'object',
+    properties: {
+      field: {
+        description: 'hello */world',
+        type: 'string'
+      }
+    }
+  });
+
+});
+
+describe('enums', () => {
+
+  which('renders a typescript enum', {
+    type: 'object',
+    required: [ 'firstEnum' ],
+    properties: {
+      firstEnum: {
+        description: 'description of first enum',
+        type: 'string',
+        enum: [ 'value1', 'value2', 'value-of-three', 'valueOfFour' ]
+      },
+      child: {
+        type: 'object',
+        properties: {
+          secondEnum: {
+            description: 'description of second enum',
+            type: 'string',
+            enum: [ 'hey', 'enum values can be crazy', 'yes>>123' ]
+          }
+        }
+      }
+    }
   });
 
 });

--- a/test/test-imports/python/expected-from-config/k8s/__init__.py
+++ b/test/test-imports/python/expected-from-config/k8s/__init__.py
@@ -5243,7 +5243,7 @@ class DaemonSetUpdateStrategy():
 
 @jsii.data_type(jsii_type="generated.DeleteOptions", jsii_struct_bases=[], name_mapping={'api_version': 'apiVersion', 'dry_run': 'dryRun', 'grace_period_seconds': 'gracePeriodSeconds', 'kind': 'kind', 'orphan_dependents': 'orphanDependents', 'preconditions': 'preconditions', 'propagation_policy': 'propagationPolicy'})
 class DeleteOptions():
-    def __init__(self, *, api_version: typing.Optional[str]=None, dry_run: typing.Optional[typing.List[str]]=None, grace_period_seconds: typing.Optional[jsii.Number]=None, kind: typing.Optional[str]=None, orphan_dependents: typing.Optional[bool]=None, preconditions: typing.Optional["Preconditions"]=None, propagation_policy: typing.Optional[str]=None) -> None:
+    def __init__(self, *, api_version: typing.Optional[str]=None, dry_run: typing.Optional[typing.List[str]]=None, grace_period_seconds: typing.Optional[jsii.Number]=None, kind: typing.Optional["IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind"]=None, orphan_dependents: typing.Optional[bool]=None, preconditions: typing.Optional["Preconditions"]=None, propagation_policy: typing.Optional[str]=None) -> None:
         """DeleteOptions may be provided when deleting an API object.
 
         :param api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -5305,7 +5305,7 @@ class DeleteOptions():
         return self._values.get('grace_period_seconds')
 
     @builtins.property
-    def kind(self) -> typing.Optional[str]:
+    def kind(self) -> typing.Optional["IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind"]:
         """Kind is a string value representing the REST resource this object represents.
 
         Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -9527,6 +9527,18 @@ class IntOrString(metaclass=jsii.JSIIMeta, jsii_type="generated.IntOrString"):
         """
         return jsii.sinvoke(cls, "fromString", [value])
 
+
+@jsii.enum(jsii_type="generated.IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind")
+class IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind(enum.Enum):
+    """Kind is a string value representing the REST resource this object represents.
+
+    Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+    schema:
+    :schema:: IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind
+    """
+    DELETE_OPTIONS = "DELETE_OPTIONS"
+    """DeleteOptions."""
 
 @jsii.data_type(jsii_type="generated.IpBlock", jsii_struct_bases=[], name_mapping={'cidr': 'cidr', 'except_': 'except'})
 class IpBlock():
@@ -26124,6 +26136,7 @@ __all__ = [
     "IngressSpec",
     "IngressTLS",
     "IntOrString",
+    "IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind",
     "IpBlock",
     "IscsiPersistentVolumeSource",
     "IscsiVolumeSource",

--- a/test/test-imports/typescript/expected-from-config/k8s.ts
+++ b/test/test-imports/typescript/expected-from-config/k8s.ts
@@ -7436,7 +7436,7 @@ export interface DeleteOptions {
    *
    * @schema io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions#kind
    */
-  readonly kind?: string;
+  readonly kind?: IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind;
 
   /**
    * Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.
@@ -10881,6 +10881,16 @@ bigger numbers of ACS mean more reserved concurrent requests (at the expense of 
    */
   readonly limitResponse?: LimitResponse;
 
+}
+
+/**
+ * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+ *
+ * @schema IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind
+ */
+export enum IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind {
+  /** DeleteOptions */
+  DELETE_OPTIONS = "DeleteOptions",
 }
 
 /**


### PR DESCRIPTION
When a JSON schema includes an `enum` string value list, generate a typescript `enum` to offer usability.

Resolves #196

BREAKING CHANGE: enum string values are now proper enums instead of just `string`s.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
