### PR TITLE
fix(cli): unable to import CRDs with non-trivial "xxxOf" constraints

### DIFF
--- a/packages/cdk8s-cli/test/import/__snapshots__/type-generator.test.js.snap
+++ b/packages/cdk8s-cli/test/import/__snapshots__/type-generator.test.js.snap
@@ -178,6 +178,86 @@ export interface MyType {
 "
 `;
 
+exports[`unions constraints are ignored for objects 1`] = `
+"/**
+ * @schema TestType
+ */
+export interface TestType {
+    /**
+     * Fault injection policy to apply on HTTP traffic at
+the client side.
+     *
+     * @schema TestType#fault
+     */
+    readonly fault?: TestTypeFault;
+
+}
+
+/**
+ * Fault injection policy to apply on HTTP traffic at
+the client side.
+ *
+ * @schema TestTypeFault
+ */
+export interface TestTypeFault {
+    /**
+     * @schema TestTypeFault#delay
+     */
+    readonly delay?: TestTypeFaultDelay;
+
+}
+
+/**
+ * @schema TestTypeFaultDelay
+ */
+export interface TestTypeFaultDelay {
+    /**
+     * @schema TestTypeFaultDelay#exponentialDelay
+     */
+    readonly exponentialDelay?: string;
+
+    /**
+     * Add a fixed delay before forwarding the request.
+     *
+     * @schema TestTypeFaultDelay#fixedDelay
+     */
+    readonly fixedDelay?: string;
+
+    /**
+     * Percentage of requests on which the delay
+will be injected (0-100).
+     *
+     * @schema TestTypeFaultDelay#percent
+     */
+    readonly percent?: number;
+
+    /**
+     * Percentage of requests on which the delay
+will be injected.
+     *
+     * @schema TestTypeFaultDelay#percentage
+     */
+    readonly percentage?: TestTypeFaultDelayPercentage;
+
+}
+
+/**
+ * Percentage of requests on which the delay
+will be injected.
+ *
+ * @schema TestTypeFaultDelayPercentage
+ */
+export interface TestTypeFaultDelayPercentage {
+    /**
+     * @schema TestTypeFaultDelayPercentage#value
+     */
+    readonly value?: number;
+
+}
+
+"
+`;
+
 exports[`unions include primitives 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/packages/cdk8s-cli/test/import/type-generator.test.ts
+++ b/packages/cdk8s-cli/test/import/type-generator.test.ts
@@ -17,6 +17,59 @@ describe('unions', () => {
     ]
   });
 
+  which('constraints are ignored for objects', {
+    "description": "An ordered list of route rules for HTTP traffic.",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "fault": {
+          "type": "object",
+          "description": "Fault injection policy to apply on HTTP traffic at\nthe client side.",
+          "properties": {
+            "delay": {
+              "oneOf": [
+                {
+                  "anyOf": [
+                    { "required": [ "fixedDelay" ] },
+                    { "required": [ "exponentialDelay" ] }
+                  ]
+                },
+                { "required": [ "fixedDelay" ] },
+                { "required": [ "exponentialDelay" ] }
+              ],
+              "properties": {
+                "exponentialDelay": {
+                  "type": "string"
+                },
+                "fixedDelay": {
+                  "description": "Add a fixed delay before forwarding the request.",
+                  "type": "string"
+                },
+                "percent": {
+                  "description": "Percentage of requests on which the delay\nwill be injected (0-100).",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "percentage": {
+                  "description": "Percentage of requests on which the delay\nwill be injected.",
+                  "properties": {
+                    "value": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+        }
+      },
+    },
+  });
+
 });
 
 


### PR DESCRIPTION
We currently only support `anyOf` and `oneOf` that include a list of type names by generating a union-like class.

Modify the generator such that if it cannot parse the schema, it will continue to evaluate it and generate types based on other aspects such as struct specification.

Fixes #171

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
