### PR TITLE
chore: bump min python version to 3.7.7

### DIFF
--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -4,7 +4,7 @@ Let's walk through a simple "Hello, World!" example in Python.
 
 ## Prerequisites
 
-* [Python >= 3.7](https://www.python.org/downloads/release/python-377)
+* [Python >= 3.7.7](https://www.python.org/downloads/release/python-377/)
 * [pipenv](https://pipenv.pypa.io/en/latest) version 2018.11.26 or above.
 
 ## Install the CLI


### PR DESCRIPTION
Strictly speaking, any python `3.7.X` version should work, however, we've seen [issues](https://github.com/awslabs/cdk8s/issues/166) when using the **stock** python 3.7.3 version of MacOS. 

Those issues were resolved when upgrading to `3.7.7`, which is the latest *bugfix* release of the `3.7` minor version line. 

This PR bumps the minimum python version requirement in the getting started to `3.7.7`, as more of a safe-guard than anything else.  

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
