### PR TITLE
chore: add mergify dismiss_reviews rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,3 +11,4 @@ pull_request_rules:
         strict_method: merge
         commit_message: title+body
       delete_head_branch: {}
+      dismiss_reviews: {}


### PR DESCRIPTION
Fixes things like this PR: https://github.com/awslabs/cdk8s/pull/221

So that approvals get dismissed with PR updates.

Rule: https://doc.mergify.io/actions.html#dismiss-reviews

Another example here: https://github.com/aws/aws-cdk/blob/master/.mergify.yml#L63

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
