### PR TITLE
fix: move output of java imports into /src/main/java

### DIFF
--- a/examples/java/hello/pom.xml
+++ b/examples/java/hello/pom.xml
@@ -9,13 +9,6 @@
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.cdk8s/cdk8s -->
-    <dependency>
       <groupId>org.cdk8s</groupId>
       <artifactId>cdk8s</artifactId>
       <version>0.24.0</version>
@@ -29,12 +22,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>29.0-jre</version>
-  </dependency>  
-  <dependency>
-    <groupId>software.amazon.jsii</groupId>
-    <artifactId>jsii-runtime</artifactId>
-    <version>1.5.0</version>
-</dependency>
+    </dependency>  
+    <dependency>
+      <groupId>software.amazon.jsii</groupId>
+      <artifactId>jsii-runtime</artifactId>
+      <version>1.5.0</version>
+    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -43,43 +36,5 @@
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <testSourceDirectory>src/test/java</testSourceDirectory>
-    <resources>
-      <resource>
-        <directory>imports/src/main/k8s/main/java</directory>
-      </resource>
-      <resource>
-        <directory>imports/src/main/k8s/main/resources</directory>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-            <execution>
-                <phase>generate-sources</phase>
-                <goals>
-                    <goal>add-source</goal>
-                </goals>
-                <configuration>
-                    <sources>
-                        <source>imports/src/main/k8s/main/java</source>
-                    </sources>
-                </configuration>
-            </execution>
-        </executions>
-    </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.4</version>
-        <configuration>
-          <additionalClasspathElements>
-            <additionalClasspathElement>imports/src/main/k8s/main/java</additionalClasspathElement>
-          </additionalClasspathElements>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/examples/java/hello/src/main/java/com/mycompany/app/HelloKube.java
+++ b/examples/java/hello/src/main/java/com/mycompany/app/HelloKube.java
@@ -11,20 +11,20 @@ import org.cdk8s.App;
 import org.cdk8s.Chart;
 import org.cdk8s.ChartOptions;
 
-import k8s.IntOrString;
-import k8s.LabelSelector;
-import k8s.ObjectMeta;
-import k8s.PodTemplateSpec;
-import k8s.Service;
-import k8s.ServiceOptions;
-import k8s.ServicePort;
-import k8s.ServiceSpec;
-import k8s.DeploymentSpec;
-import k8s.PodSpec;
-import k8s.Container;
-import k8s.ContainerPort;
-import k8s.Deployment;
-import k8s.DeploymentOptions;
+import imports.k8s.IntOrString;
+import imports.k8s.LabelSelector;
+import imports.k8s.ObjectMeta;
+import imports.k8s.PodTemplateSpec;
+import imports.k8s.Service;
+import imports.k8s.ServiceOptions;
+import imports.k8s.ServicePort;
+import imports.k8s.ServiceSpec;
+import imports.k8s.DeploymentSpec;
+import imports.k8s.PodSpec;
+import imports.k8s.Container;
+import imports.k8s.ContainerPort;
+import imports.k8s.Deployment;
+import imports.k8s.DeploymentOptions;
 
 /**
  * Hello world!

--- a/packages/cdk8s-cli/lib/import/base.ts
+++ b/packages/cdk8s-cli/lib/import/base.ts
@@ -88,8 +88,8 @@ export abstract class ImportBase {
           // java!
           if (options.targetLanguage === Language.JAVA) {
             opts.java = {
-              outdir: outdir,
-              package: moduleNamePrefix ? `${moduleNamePrefix}.${name}` : name
+              outdir: '.',
+              package: `imports.${moduleNamePrefix ? moduleNamePrefix + '.' + name : name}`
             };
           }
 


### PR DESCRIPTION
As discussed offline, we want java imports to fall under `/src/main/java`. This PR does 2 things:

1. Fixes the outdir for java, so new file structure looks like this:

```
├── src
|  └── main
|     ├── java
|     |  ├── com
|     |  |  └── mycompany
|     |  └── imports
|     |     └── k8s
|     └── resources
|        └── imports
|           └── k8s
```

and you import with `import imports.k8s`

2. Also simplifies the `pom.xml`, with no need for maven magic

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
