### PR TITLE
chore: resurrect pre release support

### DIFF
--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -8,7 +8,7 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
-console.log(`suffix: ${versionSuffix}`)
+console.log(`version: ${repoVersion}`)
 console.log(`files: ${files}`)
 
 for (const file of files) {

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -5,8 +5,7 @@
 const fs = require('fs');
 
 const marker = require('./get-version-marker');
-const repoVersion = require('./get-version');
-const versionSuffix = process.argv[2]
+const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
 console.log(`suffix: ${versionSuffix}`)
@@ -19,21 +18,20 @@ for (const file of files) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  const newVersion = `${repoVersion}${versionSuffix}`;
-  pkg.version = newVersion;
+  pkg.version = repoVersion;
 
-  processSection(pkg.dependencies || { }, newVersion);
-  processSection(pkg.devDependencies || { }, newVersion);
-  processSection(pkg.peerDependencies || { }, newVersion);
+  processSection(pkg.dependencies || { });
+  processSection(pkg.devDependencies || { });
+  processSection(pkg.peerDependencies || { });
 
-  console.error(`${file} => ${newVersion}`);
+  console.error(`${file} => ${repoVersion}`);
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, newVersion) {
+function processSection(section) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, newVersion);
+      section[name] = version.replace(marker, repoVersion);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -8,9 +8,6 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
-console.log(`version: ${repoVersion}`)
-console.log(`files: ${files}`)
-
 for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -30,10 +30,10 @@ for (const file of files) {
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, version) {
+function processSection(section, newVersion) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, version);
+      section[name] = version.replace(marker, newVersion);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -19,20 +19,21 @@ for (const file of files) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  pkg.version = `${repoVersion}${versionSuffix}`;
+  const newVersion = `${repoVersion}${versionSuffix}`;
+  pkg.version = newVersion;
 
-  processSection(pkg.dependencies || { }, file);
-  processSection(pkg.devDependencies || { }, file);
-  processSection(pkg.peerDependencies || { }, file);
+  processSection(pkg.dependencies || { }, newVersion);
+  processSection(pkg.devDependencies || { }, newVersion);
+  processSection(pkg.peerDependencies || { }, newVersion);
 
-  console.error(`${file} => ${repoVersion}`);
+  console.error(`${file} => ${newVersion}`);
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, file) {
+function processSection(section, version) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, repoVersion);
+      section[name] = version.replace(marker, version);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -6,15 +6,20 @@ const fs = require('fs');
 
 const marker = require('./get-version-marker');
 const repoVersion = require('./get-version');
+const versionSuffix = process.argv[2]
+const files = process.argv.splice(3);
 
-for (const file of process.argv.splice(2)) {
+console.log(`suffix: ${versionSuffix}`)
+console.log(`files: ${files}`)
+
+for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
   if (pkg.version !== marker) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  pkg.version = repoVersion;
+  pkg.version = `${repoVersion}${versionSuffix}`;
 
   processSection(pkg.dependencies || { }, file);
   processSection(pkg.devDependencies || { }, file);

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -10,8 +10,10 @@ scriptdir=$(cd $(dirname $0) && pwd)
 cd ${scriptdir}/..
 
 suffix="${1:-}"
+
+version = $(node -p "require('./get-version')");
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
-${scriptdir}/align-version.js ${suffix} ${files}
+${scriptdir}/align-version.js ${version}${suffix} ${files}
 
 # validation
 marker=$(node -p "require('./tools/get-version-marker').replace(/\./g, '\\\.')")

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -11,7 +11,7 @@ cd ${scriptdir}/..
 
 suffix="${1:-}"
 
-version = $(node -p "require('./get-version')");
+version=$(node -p "require('./tools/get-version')")
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
 ${scriptdir}/align-version.js ${version}${suffix} ${files}
 

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -9,8 +9,9 @@ scriptdir=$(cd $(dirname $0) && pwd)
 # go to repo root
 cd ${scriptdir}/..
 
+suffix="${1:-}"
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
-${scriptdir}/align-version.js ${files}
+${scriptdir}/align-version.js ${suffix} ${files}
 
 # validation
 marker=$(node -p "require('./tools/get-version-marker').replace(/\./g, '\\\.')")


### PR DESCRIPTION
Pre-release support broke when introducing the new `align-version` script since it didn't support a version suffix.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
