### PR TITLE
chore: pin pre release dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "devDependencies": {
     "changelog-parser": "^2.8.0",
     "lerna": "^3.20.2",
-    "standard-version": "^7.1.0"
+    "standard-version": "^7.1.0",
+    "semver": "7.3.2"
   },
   "jest": {
     "clearMocks": true,

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -9,7 +9,7 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
-const preRelease = semver.prerelease(repoVersion) == true
+const preRelease = semver.prerelease(repoVersion) ? true : false
 
 for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -3,6 +3,7 @@
 // align the version in a package.json file to the version of the repo
 //
 const fs = require('fs');
+const semver = require('semver');
 
 const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
@@ -28,7 +29,15 @@ for (const file of files) {
 function processSection(section) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, repoVersion);
+
+      if (semver.prerelease(repoVersion)) {
+        // pre-release doesn't work with caret dependencies.
+        // so we forcefully use pinned versions.
+        section[name] = repoVersion;
+      } else {
+        section[name] = version.replace(marker, repoVersion);
+      }
+
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -8,7 +8,7 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
-console.log(`suffix: ${versionSuffix}`)
+console.log(`version: ${repoVersion}`)
 console.log(`files: ${files}`)
 
 for (const file of files) {

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -9,6 +9,8 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
+const preRelease = semver.prerelease(repoVersion) == true
+
 for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
@@ -30,7 +32,7 @@ function processSection(section) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
 
-      if (semver.prerelease(repoVersion)) {
+      if (preRelease) {
         // pre-release doesn't work with caret dependencies.
         // so we forcefully use pinned versions.
         section[name] = repoVersion;

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -5,8 +5,7 @@
 const fs = require('fs');
 
 const marker = require('./get-version-marker');
-const repoVersion = require('./get-version');
-const versionSuffix = process.argv[2]
+const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
 console.log(`suffix: ${versionSuffix}`)
@@ -19,21 +18,20 @@ for (const file of files) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  const newVersion = `${repoVersion}${versionSuffix}`;
-  pkg.version = newVersion;
+  pkg.version = repoVersion;
 
-  processSection(pkg.dependencies || { }, newVersion);
-  processSection(pkg.devDependencies || { }, newVersion);
-  processSection(pkg.peerDependencies || { }, newVersion);
+  processSection(pkg.dependencies || { });
+  processSection(pkg.devDependencies || { });
+  processSection(pkg.peerDependencies || { });
 
-  console.error(`${file} => ${newVersion}`);
+  console.error(`${file} => ${repoVersion}`);
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, newVersion) {
+function processSection(section) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, newVersion);
+      section[name] = version.replace(marker, repoVersion);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -8,9 +8,6 @@ const marker = require('./get-version-marker');
 const repoVersion = process.argv[2]
 const files = process.argv.splice(3);
 
-console.log(`version: ${repoVersion}`)
-console.log(`files: ${files}`)
-
 for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -30,10 +30,10 @@ for (const file of files) {
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, version) {
+function processSection(section, newVersion) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, version);
+      section[name] = version.replace(marker, newVersion);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -19,20 +19,21 @@ for (const file of files) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  pkg.version = `${repoVersion}${versionSuffix}`;
+  const newVersion = `${repoVersion}${versionSuffix}`;
+  pkg.version = newVersion;
 
-  processSection(pkg.dependencies || { }, file);
-  processSection(pkg.devDependencies || { }, file);
-  processSection(pkg.peerDependencies || { }, file);
+  processSection(pkg.dependencies || { }, newVersion);
+  processSection(pkg.devDependencies || { }, newVersion);
+  processSection(pkg.peerDependencies || { }, newVersion);
 
-  console.error(`${file} => ${repoVersion}`);
+  console.error(`${file} => ${newVersion}`);
   fs.writeFileSync(file, JSON.stringify(pkg, undefined, 2));
 }
 
-function processSection(section, file) {
+function processSection(section, version) {
   for (const [ name, version ] of Object.entries(section)) {
     if (version === marker || version === '^' + marker) {
-      section[name] = version.replace(marker, repoVersion);
+      section[name] = version.replace(marker, version);
     }
   }
 }

--- a/tools/align-version.js
+++ b/tools/align-version.js
@@ -6,15 +6,20 @@ const fs = require('fs');
 
 const marker = require('./get-version-marker');
 const repoVersion = require('./get-version');
+const versionSuffix = process.argv[2]
+const files = process.argv.splice(3);
 
-for (const file of process.argv.splice(2)) {
+console.log(`suffix: ${versionSuffix}`)
+console.log(`files: ${files}`)
+
+for (const file of files) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
   if (pkg.version !== marker) {
     throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
   }
 
-  pkg.version = repoVersion;
+  pkg.version = `${repoVersion}${versionSuffix}`;
 
   processSection(pkg.dependencies || { }, file);
   processSection(pkg.devDependencies || { }, file);

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -10,8 +10,10 @@ scriptdir=$(cd $(dirname $0) && pwd)
 cd ${scriptdir}/..
 
 suffix="${1:-}"
+
+version = $(node -p "require('./get-version')");
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
-${scriptdir}/align-version.js ${suffix} ${files}
+${scriptdir}/align-version.js ${version}${suffix} ${files}
 
 # validation
 marker=$(node -p "require('./tools/get-version-marker').replace(/\./g, '\\\.')")

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -11,7 +11,7 @@ cd ${scriptdir}/..
 
 suffix="${1:-}"
 
-version = $(node -p "require('./get-version')");
+version=$(node -p "require('./tools/get-version')")
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
 ${scriptdir}/align-version.js ${version}${suffix} ${files}
 

--- a/tools/align-version.sh
+++ b/tools/align-version.sh
@@ -9,8 +9,9 @@ scriptdir=$(cd $(dirname $0) && pwd)
 # go to repo root
 cd ${scriptdir}/..
 
+suffix="${1:-}"
 files="./package.json $(npx lerna ls -p -a | xargs -n1 -I@ echo @/package.json)"
-${scriptdir}/align-version.js ${files}
+${scriptdir}/align-version.js ${suffix} ${files}
 
 # validation
 marker=$(node -p "require('./tools/get-version-marker').replace(/\./g, '\\\.')")

--- a/yarn.lock
+++ b/yarn.lock
@@ -8278,7 +8278,7 @@ semver@7.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
   integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
-semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
+semver@7.3.2, semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==


### PR DESCRIPTION
Pre releases do not support caret dependencies.

This means that `^0.25.0-pre1` doesn't actually intersect with `0.25.0-pre1`. This causes a build failure after the `align-version` script has executed for pre-releases:

```console
Declared dependency on version ^0.25.0-pre.cd2871bf17b461d4c707438689eddf433a860847 of cdk8s, but version 0.25.0-pre.cd2871bf17b461d4c707438689eddf433a860847 was found
```

This PR makes the `align-version.js` script aware of pre-releases and only use pinned versions for those dependencies. 

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
