### PR TITLE
chore(cdk8s+): replace spec classes input with interfaces

### DIFF
--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -7,18 +7,18 @@ Name|Description
 [ConfigMap](#cdk8s-plus-configmap)|ConfigMap holds configuration data for pods to consume.
 [Container](#cdk8s-plus-container)|A single application container that you want to run within a pod.
 [Deployment](#cdk8s-plus-deployment)|A Deployment provides declarative updates for Pods and ReplicaSets.
-[DeploymentSpec](#cdk8s-plus-deploymentspec)|DeploymentSpec is the specification of the desired behavior of the Deployment.
+[DeploymentSpecDefinition](#cdk8s-plus-deploymentspecdefinition)|DeploymentSpec is the specification of the desired behavior of the Deployment.
 [Duration](#cdk8s-plus-duration)|Represents a length of time.
 [EnvValue](#cdk8s-plus-envvalue)|Utility class for creating reading env values from various sources.
 [Job](#cdk8s-plus-job)|A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
-[JobSpec](#cdk8s-plus-jobspec)|*No description*
+[JobSpecDefinition](#cdk8s-plus-jobspecdefinition)|*No description*
 [Pod](#cdk8s-plus-pod)|Pod is a collection of containers that can run on a host.
-[PodSpec](#cdk8s-plus-podspec)|A description of a pod.
+[PodSpecDefinition](#cdk8s-plus-podspecdefinition)|A description of a pod.
 [Resource](#cdk8s-plus-resource)|Base class for all Kubernetes objects in stdk8s.
 [Secret](#cdk8s-plus-secret)|Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 [Service](#cdk8s-plus-service)|An abstract way to expose an application running on a set of Pods as a network service.
 [ServiceAccount](#cdk8s-plus-serviceaccount)|A service account provides an identity for processes that run in a Pod.
-[ServiceSpec](#cdk8s-plus-servicespec)|A description of a service.
+[ServiceSpecDefinition](#cdk8s-plus-servicespecdefinition)|A description of a service.
 [Size](#cdk8s-plus-size)|Represents the amount of digital storage.
 [Volume](#cdk8s-plus-volume)|Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -32,25 +32,25 @@ Name|Description
 [ConfigMapVolumeOptions](#cdk8s-plus-configmapvolumeoptions)|Options for the ConfigMap-based volume.
 [ContainerProps](#cdk8s-plus-containerprops)|Properties for creating a container.
 [DeploymentProps](#cdk8s-plus-deploymentprops)|Properties for initialization of `Deployment`.
-[DeploymentSpecProps](#cdk8s-plus-deploymentspecprops)|Properties for initialization of `DeploymentSpec`.
+[DeploymentSpec](#cdk8s-plus-deploymentspec)|Properties for initialization of `DeploymentSpec`.
 [EmptyDirVolumeOptions](#cdk8s-plus-emptydirvolumeoptions)|Options for volumes populated with an empty directory.
 [EnvValueFromConfigMapOptions](#cdk8s-plus-envvaluefromconfigmapoptions)|Options to specify an envionment variable value from a ConfigMap key.
 [EnvValueFromProcessOptions](#cdk8s-plus-envvaluefromprocessoptions)|Options to specify an environment variable value from the process environment.
 [EnvValueFromSecretOptions](#cdk8s-plus-envvaluefromsecretoptions)|Options to specify an environment variable value from a Secret.
 [ExposeOptions](#cdk8s-plus-exposeoptions)|Options for exposing a deployment via a service.
 [JobProps](#cdk8s-plus-jobprops)|Properties for initialization of `Job`.
-[JobSpecProps](#cdk8s-plus-jobspecprops)|Properties for initialization of `JobSpec`.
+[JobSpec](#cdk8s-plus-jobspec)|Properties for initialization of `JobSpec`.
 [MountOptions](#cdk8s-plus-mountoptions)|Options for mounts.
 [PathMapping](#cdk8s-plus-pathmapping)|Maps a string key to a path within a volume.
 [PodProps](#cdk8s-plus-podprops)|Properties for initialization of `Pod`.
-[PodSpecProps](#cdk8s-plus-podspecprops)|Properties for initialization of `PodSpec`.
+[PodSpec](#cdk8s-plus-podspec)|Properties for initialization of `PodSpec`.
 [ResourceProps](#cdk8s-plus-resourceprops)|Initialization properties for resources.
 [SecretProps](#cdk8s-plus-secretprops)|*No description*
 [ServiceAccountProps](#cdk8s-plus-serviceaccountprops)|Properties for initialization of `ServiceAccount`.
 [ServicePort](#cdk8s-plus-serviceport)|Definition of a service port.
 [ServicePortOptions](#cdk8s-plus-serviceportoptions)|*No description*
 [ServiceProps](#cdk8s-plus-serviceprops)|Properties for initialization of `Service`.
-[ServiceSpecProps](#cdk8s-plus-servicespecprops)|Properties for initialization of `ServiceSpec`.
+[ServiceSpec](#cdk8s-plus-servicespec)|Properties for initialization of `ServiceSpec`.
 [SizeConversionOptions](#cdk8s-plus-sizeconversionoptions)|Options for how to convert time to a different unit.
 [TimeConversionOptions](#cdk8s-plus-timeconversionoptions)|Options for how to convert time to a different unit.
 [VolumeMount](#cdk8s-plus-volumemount)|Mount a volume from the pod to the container.
@@ -356,7 +356,7 @@ new Deployment(scope: Construct, id: string, props?: DeploymentProps)
 Name | Type | Description 
 -----|------|-------------
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
-**spec**🔹 | <code>[DeploymentSpec](#cdk8s-plus-deploymentspec)</code> | Provides access to the underlying spec.
+**spec**🔹 | <code>[DeploymentSpecDefinition](#cdk8s-plus-deploymentspecdefinition)</code> | Provides access to the underlying spec.
 
 ### Methods
 
@@ -383,7 +383,7 @@ expose(options: ExposeOptions): Service
 
 
 
-## class DeploymentSpec 🔹 <a id="cdk8s-plus-deploymentspec"></a>
+## class DeploymentSpecDefinition 🔹 <a id="cdk8s-plus-deploymentspecdefinition"></a>
 
 DeploymentSpec is the specification of the desired behavior of the Deployment.
 
@@ -396,13 +396,13 @@ DeploymentSpec is the specification of the desired behavior of the Deployment.
 <span style="text-decoration: underline">Usage:</span>
 
 ```ts
-new DeploymentSpec(props?: DeploymentSpecProps)
+new DeploymentSpecDefinition(props?: DeploymentSpec)
 ```
 
 <span style="text-decoration: underline">Parameters:</span>
-* **props** (<code>[DeploymentSpecProps](#cdk8s-plus-deploymentspecprops)</code>)  *No description*
+* **props** (<code>[DeploymentSpec](#cdk8s-plus-deploymentspec)</code>)  *No description*
   * **podMetadataTemplate** (<code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code>)  Template for pod metadata. <span style="text-decoration: underline">*Optional*</span>
-  * **podSpecTemplate** (<code>[PodSpecProps](#cdk8s-plus-podspecprops)</code>)  Template for pod specs. <span style="text-decoration: underline">*Optional*</span>
+  * **podSpecTemplate** (<code>[PodSpec](#cdk8s-plus-podspec)</code>)  Template for pod specs. <span style="text-decoration: underline">*Optional*</span>
   * **replicas** (<code>number</code>)  Number of desired pods. <span style="text-decoration: underline">*Default*</span>: 1
 
 
@@ -414,13 +414,13 @@ Name | Type | Description
 -----|------|-------------
 **labelSelector**🔹 | <code>Map<string, string></code> | The labels this deployment will match against in order to select pods.
 **podMetadataTemplate**🔹 | <code>[ApiObjectMetadataDefinition](#cdk8s-apiobjectmetadatadefinition)</code> | Template for pod metadata.
-**podSpecTemplate**🔹 | <code>[PodSpec](#cdk8s-plus-podspec)</code> | Provides access to the underlying pod template spec.
+**podSpecTemplate**🔹 | <code>[PodSpecDefinition](#cdk8s-plus-podspecdefinition)</code> | Provides access to the underlying pod template spec.
 **replicas**?🔹 | <code>number</code> | Number of desired pods.<br/><span style="text-decoration: underline">*Optional*</span>
 
 ### Methods
 
 
-#### selectByLabel(key, value)🔹 <a id="cdk8s-plus-deploymentspec-selectbylabel"></a>
+#### selectByLabel(key, value)🔹 <a id="cdk8s-plus-deploymentspecdefinition-selectbylabel"></a>
 
 Configure a label selector to this deployment.
 
@@ -831,11 +831,11 @@ new Job(scope: Construct, id: string, props?: JobProps)
 Name | Type | Description 
 -----|------|-------------
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
-**spec**🔹 | <code>[JobSpec](#cdk8s-plus-jobspec)</code> | <span></span>
+**spec**🔹 | <code>[JobSpecDefinition](#cdk8s-plus-jobspecdefinition)</code> | <span></span>
 
 
 
-## class JobSpec 🔹 <a id="cdk8s-plus-jobspec"></a>
+## class JobSpecDefinition 🔹 <a id="cdk8s-plus-jobspecdefinition"></a>
 
 
 
@@ -848,13 +848,13 @@ Name | Type | Description
 <span style="text-decoration: underline">Usage:</span>
 
 ```ts
-new JobSpec(props?: JobSpecProps)
+new JobSpecDefinition(props?: JobSpec)
 ```
 
 <span style="text-decoration: underline">Parameters:</span>
-* **props** (<code>[JobSpecProps](#cdk8s-plus-jobspecprops)</code>)  *No description*
+* **props** (<code>[JobSpec](#cdk8s-plus-jobspec)</code>)  *No description*
   * **podMetadataTemplate** (<code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code>)  The metadata of pods created by this job. <span style="text-decoration: underline">*Optional*</span>
-  * **podSpecTemplate** (<code>[PodSpecProps](#cdk8s-plus-podspecprops)</code>)  The spec of pods created by this job. <span style="text-decoration: underline">*Optional*</span>
+  * **podSpecTemplate** (<code>[PodSpec](#cdk8s-plus-podspec)</code>)  The spec of pods created by this job. <span style="text-decoration: underline">*Optional*</span>
   * **ttlAfterFinished** (<code>[Duration](#cdk8s-plus-duration)</code>)  Limits the lifetime of a Job that has finished execution (either Complete or Failed). <span style="text-decoration: underline">*Default*</span>: If this field is unset, the Job won't be automatically deleted.
 
 
@@ -865,7 +865,7 @@ new JobSpec(props?: JobSpecProps)
 Name | Type | Description 
 -----|------|-------------
 **podMetadataTemplate**🔹 | <code>[ApiObjectMetadataDefinition](#cdk8s-apiobjectmetadatadefinition)</code> | The metadata for pods created by this job.
-**podSpecTemplate**🔹 | <code>[PodSpec](#cdk8s-plus-podspec)</code> | The spec for pods created by this job.
+**podSpecTemplate**🔹 | <code>[PodSpecDefinition](#cdk8s-plus-podspecdefinition)</code> | The spec for pods created by this job.
 **ttlAfterFinished**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | TTL before the job is deleted after it is finished.<br/><span style="text-decoration: underline">*Optional*</span>
 
 
@@ -906,11 +906,11 @@ new Pod(scope: Construct, id: string, props?: PodProps)
 Name | Type | Description 
 -----|------|-------------
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
-**spec**🔹 | <code>[PodSpec](#cdk8s-plus-podspec)</code> | Provides access to the underlying spec.
+**spec**🔹 | <code>[PodSpecDefinition](#cdk8s-plus-podspecdefinition)</code> | Provides access to the underlying spec.
 
 
 
-## class PodSpec 🔹 <a id="cdk8s-plus-podspec"></a>
+## class PodSpecDefinition 🔹 <a id="cdk8s-plus-podspecdefinition"></a>
 
 A description of a pod.
 
@@ -923,11 +923,11 @@ A description of a pod.
 <span style="text-decoration: underline">Usage:</span>
 
 ```ts
-new PodSpec(props?: PodSpecProps)
+new PodSpecDefinition(props?: PodSpec)
 ```
 
 <span style="text-decoration: underline">Parameters:</span>
-* **props** (<code>[PodSpecProps](#cdk8s-plus-podspecprops)</code>)  *No description*
+* **props** (<code>[PodSpec](#cdk8s-plus-podspec)</code>)  *No description*
   * **containers** (<code>Array<[Container](#cdk8s-plus-container)></code>)  List of containers belonging to the pod. <span style="text-decoration: underline">*Default*</span>: No containers. Note that a pod spec must include at least one container.
   * **restartPolicy** (<code>[RestartPolicy](#cdk8s-plus-restartpolicy)</code>)  Restart policy for all containers within the pod. <span style="text-decoration: underline">*Default*</span>: RestartPolicy.ALWAYS
   * **serviceAccount** (<code>[IServiceAccount](#cdk8s-plus-iserviceaccount)</code>)  A service account provides an identity for processes that run in a Pod. <span style="text-decoration: underline">*Default*</span>: No service account.
@@ -948,7 +948,7 @@ Name | Type | Description
 ### Methods
 
 
-#### addContainer(container)🔹 <a id="cdk8s-plus-podspec-addcontainer"></a>
+#### addContainer(container)🔹 <a id="cdk8s-plus-podspecdefinition-addcontainer"></a>
 
 Adds a container to this pod.
 
@@ -964,7 +964,7 @@ addContainer(container: Container): void
 
 
 
-#### addVolume(volume)🔹 <a id="cdk8s-plus-podspec-addvolume"></a>
+#### addVolume(volume)🔹 <a id="cdk8s-plus-podspecdefinition-addvolume"></a>
 
 Adds a volume to this pod.
 
@@ -1160,7 +1160,7 @@ new Service(scope: Construct, id: string, props?: ServiceProps)
 Name | Type | Description 
 -----|------|-------------
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
-**spec**🔹 | <code>[ServiceSpec](#cdk8s-plus-servicespec)</code> | Provides access to the underlying spec.
+**spec**🔹 | <code>[ServiceSpecDefinition](#cdk8s-plus-servicespecdefinition)</code> | Provides access to the underlying spec.
 
 
 
@@ -1243,7 +1243,7 @@ static fromServiceAccountName(name: string): IServiceAccount
 
 
 
-## class ServiceSpec 🔹 <a id="cdk8s-plus-servicespec"></a>
+## class ServiceSpecDefinition 🔹 <a id="cdk8s-plus-servicespecdefinition"></a>
 
 A description of a service.
 
@@ -1256,11 +1256,11 @@ A description of a service.
 <span style="text-decoration: underline">Usage:</span>
 
 ```ts
-new ServiceSpec(props?: ServiceSpecProps)
+new ServiceSpecDefinition(props?: ServiceSpec)
 ```
 
 <span style="text-decoration: underline">Parameters:</span>
-* **props** (<code>[ServiceSpecProps](#cdk8s-plus-servicespecprops)</code>)  *No description*
+* **props** (<code>[ServiceSpec](#cdk8s-plus-servicespec)</code>)  *No description*
   * **clusterIP** (<code>string</code>)  The IP address of the service and is usually assigned randomly by the master. <span style="text-decoration: underline">*Default*</span>: Automatically assigned.
   * **externalIPs** (<code>Array<string></code>)  A list of IP addresses for which nodes in the cluster will also accept traffic for this service. <span style="text-decoration: underline">*Default*</span>: No external IPs.
   * **ports** (<code>Array<[ServicePort](#cdk8s-plus-serviceport)></code>)  The port exposed by this service. <span style="text-decoration: underline">*Optional*</span>
@@ -1280,7 +1280,7 @@ Name | Type | Description
 ### Methods
 
 
-#### addSelector(label, value)🔹 <a id="cdk8s-plus-servicespec-addselector"></a>
+#### addSelector(label, value)🔹 <a id="cdk8s-plus-servicespecdefinition-addselector"></a>
 
 Services defined using this spec will select pods according the provided label.
 
@@ -1297,7 +1297,7 @@ addSelector(label: string, value: string): void
 
 
 
-#### serve(port, options?)🔹 <a id="cdk8s-plus-servicespec-serve"></a>
+#### serve(port, options?)🔹 <a id="cdk8s-plus-servicespecdefinition-serve"></a>
 
 Configure a port the service will bind to.
 
@@ -1708,7 +1708,7 @@ Name | Type | Description
 
 
 
-## struct DeploymentSpecProps 🔹 <a id="cdk8s-plus-deploymentspecprops"></a>
+## struct DeploymentSpec 🔹 <a id="cdk8s-plus-deploymentspec"></a>
 
 
 Properties for initialization of `DeploymentSpec`.
@@ -1718,7 +1718,7 @@ Properties for initialization of `DeploymentSpec`.
 Name | Type | Description 
 -----|------|-------------
 **podMetadataTemplate**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Template for pod metadata.<br/><span style="text-decoration: underline">*Optional*</span>
-**podSpecTemplate**?🔹 | <code>[PodSpecProps](#cdk8s-plus-podspecprops)</code> | Template for pod specs.<br/><span style="text-decoration: underline">*Optional*</span>
+**podSpecTemplate**?🔹 | <code>[PodSpec](#cdk8s-plus-podspec)</code> | Template for pod specs.<br/><span style="text-decoration: underline">*Optional*</span>
 **replicas**?🔹 | <code>number</code> | Number of desired pods.<br/><span style="text-decoration: underline">*Default*</span>: 1
 
 
@@ -1867,7 +1867,7 @@ Name | Type | Description
 
 
 
-## struct JobSpecProps 🔹 <a id="cdk8s-plus-jobspecprops"></a>
+## struct JobSpec 🔹 <a id="cdk8s-plus-jobspec"></a>
 
 
 Properties for initialization of `JobSpec`.
@@ -1877,7 +1877,7 @@ Properties for initialization of `JobSpec`.
 Name | Type | Description 
 -----|------|-------------
 **podMetadataTemplate**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | The metadata of pods created by this job.<br/><span style="text-decoration: underline">*Optional*</span>
-**podSpecTemplate**?🔹 | <code>[PodSpecProps](#cdk8s-plus-podspecprops)</code> | The spec of pods created by this job.<br/><span style="text-decoration: underline">*Optional*</span>
+**podSpecTemplate**?🔹 | <code>[PodSpec](#cdk8s-plus-podspec)</code> | The spec of pods created by this job.<br/><span style="text-decoration: underline">*Optional*</span>
 **ttlAfterFinished**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Limits the lifetime of a Job that has finished execution (either Complete or Failed).<br/><span style="text-decoration: underline">*Default*</span>: If this field is unset, the Job won't be automatically deleted.
 
 
@@ -1926,7 +1926,7 @@ Name | Type | Description
 
 
 
-## struct PodSpecProps 🔹 <a id="cdk8s-plus-podspecprops"></a>
+## struct PodSpec 🔹 <a id="cdk8s-plus-podspec"></a>
 
 
 Properties for initialization of `PodSpec`.
@@ -2032,7 +2032,7 @@ Name | Type | Description
 
 
 
-## struct ServiceSpecProps 🔹 <a id="cdk8s-plus-servicespecprops"></a>
+## struct ServiceSpec 🔹 <a id="cdk8s-plus-servicespec"></a>
 
 
 Properties for initialization of `ServiceSpec`.

--- a/packages/cdk8s-plus/README.md
+++ b/packages/cdk8s-plus/README.md
@@ -51,12 +51,12 @@ container.mount(appPath, appVolume);
 
 // now lets create a deployment to run a few instances of this container
 const deployment = new kplus.Deployment(chart, 'Deployment', {
-  spec: new kplus.DeploymentSpec({
+  spec: {
     replicas: 3,
     podSpecTemplate: {
       containers: [ container ]
     }
-  }),
+  },
 });
 
 // finally, we expose the deployment as a load balancer service and make it run
@@ -271,9 +271,9 @@ import * as k from 'cdk8s';
 import * as kplus from 'cdk8s-plus';
 
 // let's define a job spec, and set a 1 second TTL.
-const jobSpec = new kplus.JobSpec({
+const jobSpec = {
   ttlAfterFinished: kplus.Duration.seconds(1),
-});
+};
 
 // now add a container to all the pods created by this job
 jobSpec.podSpecTemplate.addContainer(new kplus.Container({
@@ -346,11 +346,11 @@ const app = new k.App();
 const chart = new k.Chart(app, 'Chart');
 
 new kplus.Deployment(chart, 'FrontEnds', {
-  spec: new kplus.DeploymentSpec({
+  spec: {
     podSpecTemplate: {
       containers: [ new kplus.Container({ image: 'node' }) ],
     }
-  }),
+  },
 });
 ```
 

--- a/packages/cdk8s-plus/package.json
+++ b/packages/cdk8s-plus/package.json
@@ -37,7 +37,7 @@
     "jsii": "^1.6.0",
     "jsii-diff": "^1.6.0",
     "jsii-pacmak": "^1.6.0",
-    "jsii-release": "^0.1.6",
+    "jsii-release": "^0.1.7",
     "@types/node": "^10.17.0",
     "typescript": "^3.8.3",
     "@typescript-eslint/eslint-plugin": "^2.31.0",

--- a/packages/cdk8s-plus/src/job.ts
+++ b/packages/cdk8s-plus/src/job.ts
@@ -3,7 +3,7 @@ import { ApiObject, ApiObjectMetadata, ApiObjectMetadataDefinition } from 'cdk8s
 import { Construct } from 'constructs';
 
 import * as k8s from './imports/k8s';
-import { RestartPolicy, PodSpecProps, PodSpec } from './pod';
+import { RestartPolicy, PodSpec, PodSpecDefinition } from './pod';
 import { Duration } from './duration';
 import { lazy } from './utils';
 
@@ -31,12 +31,12 @@ export interface JobProps extends ResourceProps {
 export class Job extends Resource {
 
   protected readonly apiObject: ApiObject;
-  public readonly spec: JobSpec;
+  public readonly spec: JobSpecDefinition;
 
   constructor(scope: Construct, id: string, props: JobProps = {}) {
     super(scope, id, props);
 
-    this.spec = props.spec ?? new JobSpec();
+    this.spec = new JobSpecDefinition(props.spec);
 
     this.apiObject = new k8s.Job(this, 'Default', {
       metadata: props.metadata,
@@ -48,11 +48,11 @@ export class Job extends Resource {
 /**
  * Properties for initialization of `JobSpec`.
  */
-export interface JobSpecProps {
+export interface JobSpec {
   /**
    * The spec of pods created by this job.
    */
-  readonly podSpecTemplate?: PodSpecProps;
+  readonly podSpecTemplate?: PodSpec;
 
   /**
    * The metadata of pods created by this job.
@@ -73,11 +73,11 @@ export interface JobSpecProps {
   readonly ttlAfterFinished?: Duration;
 }
 
-export class JobSpec {
+export class JobSpecDefinition {
   /**
    * The spec for pods created by this job.
    */
-  public readonly podSpecTemplate: PodSpec;
+  public readonly podSpecTemplate: PodSpecDefinition;
 
   /**
    * The metadata for pods created by this job.
@@ -89,8 +89,8 @@ export class JobSpec {
    */
   public readonly ttlAfterFinished?: Duration;
 
-  constructor(props: JobSpecProps = {}) {
-    this.podSpecTemplate = new PodSpec({
+  constructor(props: JobSpec = {}) {
+    this.podSpecTemplate = new PodSpecDefinition({
       restartPolicy: props.podSpecTemplate?.restartPolicy ?? RestartPolicy.NEVER,
       ...props.podSpecTemplate,
     });

--- a/packages/cdk8s-plus/src/pod.ts
+++ b/packages/cdk8s-plus/src/pod.ts
@@ -34,12 +34,12 @@ export class Pod extends Resource {
    * You can use this field to apply post instantiation mutations
    * to the spec.
    */
-  public readonly spec: PodSpec;
+  public readonly spec: PodSpecDefinition;
 
   constructor(scope: Construct, id: string, props: PodProps = {}) {
     super(scope, id, props);
 
-    this.spec = props.spec ?? new PodSpec();
+    this.spec = new PodSpecDefinition(props.spec);
 
     this.apiObject = new k8s.Pod(this, 'Pod', {
       metadata: props.metadata,
@@ -51,7 +51,7 @@ export class Pod extends Resource {
 /**
  * Properties for initialization of `PodSpec`.
  */
-export interface PodSpecProps {
+export interface PodSpec {
 
   /**
    * List of containers belonging to the pod. Containers cannot currently be
@@ -123,7 +123,7 @@ export enum RestartPolicy {
 /**
  * A description of a pod.
  */
-export class PodSpec {
+export class PodSpecDefinition {
   /**
    * Restart policy for all containers within the pod.
    */
@@ -137,7 +137,7 @@ export class PodSpec {
   private readonly _containers: Container[];
   private readonly _volumes: Volume[];
 
-  constructor(props: PodSpecProps = {}) {
+  constructor(props: PodSpec = {}) {
     this._containers = props.containers ?? [];
     this._volumes = props.volumes ?? [];
     this.restartPolicy = props.restartPolicy;

--- a/packages/cdk8s-plus/src/service.ts
+++ b/packages/cdk8s-plus/src/service.ts
@@ -82,12 +82,12 @@ export class Service extends Resource {
    * You can use this field to apply post instantiation mutations
    * to the spec.
    */
-  public readonly spec: ServiceSpec;
+  public readonly spec: ServiceSpecDefinition;
 
   constructor(scope: Construct, id: string, props: ServiceProps = {}) {
     super(scope, id, props);
 
-    this.spec = props.spec ?? new ServiceSpec();
+    this.spec = new ServiceSpecDefinition(props.spec);
 
     this.apiObject = new k8s.Service(this, 'Pod', {
       metadata: props.metadata,
@@ -155,7 +155,7 @@ export interface ServicePort extends ServicePortOptions {
 /**
  * Properties for initialization of `ServiceSpec`.
  */
-export interface ServiceSpecProps {
+export interface ServiceSpec {
 
   /**
    * The IP address of the service and is usually assigned randomly by the
@@ -203,7 +203,7 @@ export interface ServiceSpecProps {
 /**
  * A description of a service.
  */
-export class ServiceSpec {
+export class ServiceSpecDefinition {
   /**
    * The IP address of the service and is usually assigned randomly by the
    * master.
@@ -225,7 +225,7 @@ export class ServiceSpec {
 
   private readonly _ports: ServicePort[];
 
-  constructor(props: ServiceSpecProps = {}) {
+  constructor(props: ServiceSpec = {}) {
     this.clusterIP = props.clusterIP;
     this.externalIPs = props.externalIPs ?? [];
     this.type = props.type ?? ServiceType.CLUSTER_IP;

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -3,12 +3,12 @@ import * as k8s from '../src/imports/k8s';
 import { Testing } from 'cdk8s';
 import { Node } from 'constructs';
 
-describe('DeploymentSpec', () => {
+describe('DeploymentSpecDefinition', () => {
 
   test('Instantiation properties are all respected', () => {
     const chart = Testing.chart();
     const deployment = new kplus.Deployment(chart, 'Deployment');
-    const spec = new kplus.DeploymentSpec({
+    const spec = new kplus.DeploymentSpecDefinition({
       replicas: 3,
       podSpecTemplate: {
         serviceAccount: kplus.ServiceAccount.fromServiceAccountName('my-service-account'),
@@ -26,7 +26,7 @@ describe('DeploymentSpec', () => {
   });
 
   test('Can select labels', () => {
-    const spec = new kplus.DeploymentSpec();
+    const spec = new kplus.DeploymentSpecDefinition();
 
     spec.podSpecTemplate.addContainer(
       new kplus.Container({
@@ -138,14 +138,14 @@ describe('Deployment', () => {
 
   test('Can be instantiated with an existing spec', () => {
 
-    const spec = new kplus.DeploymentSpec({
+    const spec = {
       podSpecTemplate: {
         containers: [new kplus.Container({
           image: 'image',
           port: 9300,
         })],
       },
-    });
+    };
 
     const chart = Testing.chart();
     new kplus.Deployment(chart, 'Deployment', {

--- a/packages/cdk8s-plus/test/job.test.ts
+++ b/packages/cdk8s-plus/test/job.test.ts
@@ -2,9 +2,9 @@ import * as kplus from '../src';
 import * as k from '../src/imports/k8s';
 import { Testing } from 'cdk8s';
 
-describe('JobSpec', () => {
+describe('JobSpecDefinition', () => {
   test('Instantiation properties are all respected', () => {
-    const spec = new kplus.JobSpec({
+    const spec = new kplus.JobSpecDefinition({
       podSpecTemplate: {
         containers: [
           new kplus.Container({
@@ -22,7 +22,7 @@ describe('JobSpec', () => {
   });
 
   test('Does not modify existing restart policy of pod spec', () => {
-    const spec = new kplus.JobSpec({
+    const spec = new kplus.JobSpecDefinition({
       podSpecTemplate: {
         containers: [ new kplus.Container({ image: 'image' }) ],
         restartPolicy: kplus.RestartPolicy.ALWAYS,
@@ -36,7 +36,7 @@ describe('JobSpec', () => {
   });
 
   test('Applies default restart policy to pod spec', () => {
-    const spec = new kplus.JobSpec({
+    const spec = new kplus.JobSpecDefinition({
       podSpecTemplate: {
         containers: [ new kplus.Container({ image: 'image' }) ],
       },
@@ -49,17 +49,19 @@ describe('JobSpec', () => {
   });
 });
 
-describe('Pod', () => {
+describe('Job', () => {
   test('Can provide existing spec', () => {
     const chart = Testing.chart();
 
-    const jobSpec = new kplus.JobSpec();
+    const jobSpec: kplus.JobSpec = {
+      ttlAfterFinished: kplus.Duration.seconds(5),
+    };
 
     const job = new kplus.Job(chart, 'Job', {
       spec: jobSpec,
     });
 
-    expect(job.spec).toBe(jobSpec);
+    expect(job.spec.ttlAfterFinished?.toSeconds()).toEqual(5);
   });
 
   test('Generates spec lazily', () => {

--- a/packages/cdk8s-plus/test/pod.test.ts
+++ b/packages/cdk8s-plus/test/pod.test.ts
@@ -3,9 +3,9 @@ import * as k8s from '../src/imports/k8s';
 import { RestartPolicy } from '../src';
 import { Testing } from 'cdk8s';
 
-describe('PodSpec', () => {
+describe('PodSpecDefinition', () => {
   test('Can add container post instantiation', () => {
-    const spec = new kplus.PodSpec();
+    const spec = new kplus.PodSpecDefinition();
 
     const container = new kplus.Container({
       image: 'image',
@@ -19,7 +19,7 @@ describe('PodSpec', () => {
   });
 
   test('Must have at least one container', () => {
-    const spec = new kplus.PodSpec();
+    const spec = new kplus.PodSpecDefinition();
 
     expect(() => spec._toKube()).toThrow(
       'PodSpec must have at least 1 container',
@@ -27,7 +27,7 @@ describe('PodSpec', () => {
   });
 
   test('Can add volume post instantiation', () => {
-    const spec = new kplus.PodSpec();
+    const spec = new kplus.PodSpecDefinition();
 
     const volume = kplus.Volume.fromEmptyDir('volume');
 
@@ -47,7 +47,7 @@ describe('PodSpec', () => {
   });
 
   test('Instantiation properties are all respected', () => {
-    const spec = new kplus.PodSpec({
+    const spec = new kplus.PodSpecDefinition({
       containers: [
         new kplus.Container({
           image: 'image',
@@ -92,7 +92,7 @@ describe('PodSpec', () => {
   });
 
   test('Automatically adds volumes from container mounts', () => {
-    const spec = new kplus.PodSpec();
+    const spec = new kplus.PodSpecDefinition();
 
     const volume = kplus.Volume.fromEmptyDir('volume');
 
@@ -124,13 +124,13 @@ describe('Pod', () => {
   });
 
   test('Can instantiate with props', () => {
-    const spec = new kplus.PodSpec({
+    const spec = {
       containers: [
         new kplus.Container({
           image: 'image',
         }),
       ],
-    });
+    };
 
     const chart = Testing.chart();
 
@@ -139,7 +139,7 @@ describe('Pod', () => {
       spec: spec,
     });
 
-    expect(pod.spec).toBeDefined();
+    expect(pod.spec.containers[0].image).toEqual('image');
     expect(pod.name).toEqual('name');
   });
 

--- a/packages/cdk8s-plus/test/service.test.ts
+++ b/packages/cdk8s-plus/test/service.test.ts
@@ -2,11 +2,11 @@ import * as kplus from '../src';
 import * as k from '../src/imports/k8s';
 import { Testing } from 'cdk8s';
 
-describe('ServiceSpec', () => {
+describe('ServiceSpecDefinition', () => {
   test('Instantiation properties are all accepted', () => {
     const ports = [{ port: 9000, targetPort: 80 }];
     const externalIPs = ['ExternalIP'];
-    const spec = new kplus.ServiceSpec({
+    const spec = new kplus.ServiceSpecDefinition({
       clusterIP: 'IP',
       externalIPs: externalIPs,
       ports: ports,
@@ -22,7 +22,7 @@ describe('ServiceSpec', () => {
   });
 
   test('Must be configured with at least one port', () => {
-    const spec = new kplus.ServiceSpec();
+    const spec = new kplus.ServiceSpecDefinition();
 
     expect(() => spec._toKube()).toThrowError(
       'A service must be configured with a port',
@@ -30,7 +30,7 @@ describe('ServiceSpec', () => {
   });
 
   test('Can select by label', () => {
-    const spec = new kplus.ServiceSpec({
+    const spec = new kplus.ServiceSpecDefinition({
       ports: [{ port: 9000, targetPort: 80 }],
     });
 
@@ -42,7 +42,7 @@ describe('ServiceSpec', () => {
   });
 
   test('Can serve by port', () => {
-    const spec = new kplus.ServiceSpec();
+    const spec = new kplus.ServiceSpecDefinition();
 
     spec.serve(9000, { targetPort: 80 });
 
@@ -55,12 +55,14 @@ describe('ServiceSpec', () => {
 describe('Service', () => {
   test('Can accept an existing spec', () => {
     const chart = Testing.chart();
-    const spec = new kplus.ServiceSpec();
+    const spec: kplus.ServiceSpec = {
+      clusterIP: 'cluster-ip',
+    }
     const service = new kplus.Service(chart, 'Service', {
       spec: spec,
     });
 
-    expect(service.spec).toBe(spec);
+    expect(service.spec.clusterIP).toEqual('cluster-ip');
   });
 
   test('Generates spec lazily', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6035,10 +6035,10 @@ jsii-reflect@^1.6.0:
     oo-ascii-tree "^1.6.0"
     yargs "^15.3.1"
 
-jsii-release@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.1.6.tgz#8881bb86f2d612f1b1c2d5b352e99037e796d897"
-  integrity sha512-o0gO3QQtYrBZNU87CEX7AORAcEmGobNJPIJufbxwmd5EAQxO02Q1KYIp6fBsppXYLaIkY9h14s/rl2rlmKO7Lw==
+jsii-release@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.1.7.tgz#2e58aa6e9ee2743aeb7f9944c52311eaaf785498"
+  integrity sha512-wWoYpDikr2QhLfuefRRHfJK03D46M5YUJVlgSShEqgh9MRimnNMgRBxSGzZLxNMp3ink6+M3qIrC5PhvWLrH4Q==
 
 jsii-rosetta@^1.1.0, jsii-rosetta@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Inputs are now pure structs and resources exposes an API class over that struct for mutations.

Also upgraded `jsii-release` version to fix multi package maven publishing

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
