### PR TITLE
chore(cdk8s+): compile after running tests to restore lib/ directory

### DIFF
--- a/packages/cdk8s-plus/.projenrc.js
+++ b/packages/cdk8s-plus/.projenrc.js
@@ -45,7 +45,8 @@ const project = new JsiiProject({
 // override the default "build" from projen because currently in this
 // repo it means "compile"
 project.addScripts({
-  build: 'jsii --silence-warnings=reserved-word && yarn docgen'
+  build: 'jsii --silence-warnings=reserved-word && yarn docgen',
+  test: 'yarn eslint && rm -fr lib/ && jest --passWithNoTests && yarn run compile'
 });
 
 project.synth();

--- a/packages/cdk8s-plus/package.json
+++ b/packages/cdk8s-plus/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "projen": "node .projenrc.js && yarn install",
     "projen:upgrade": "yarn upgrade projen && yarn projen",
-    "test": "yarn eslint && rm -fr lib/ && jest --passWithNoTests",
+    "test": "yarn eslint && rm -fr lib/ && jest --passWithNoTests && yarn run compile",
     "bump": "standard-version",
     "release": "yarn bump && git push --follow-tags origin master",
     "compile": "jsii --silence-warnings=reserved-word && jsii-docgen",


### PR DESCRIPTION
We still want to ensure that tests do not take a dependency on `lib/`, so the `rm -fr lib/` is relevant. We just want to *also* recompile if all tests pass to make sure we still have build artifacts.

Not super efficient, but good for now.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
