### PR TITLE
chore: pin constructs dep

### DIFF
--- a/examples/java/hello/package.json
+++ b/examples/java/hello/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "cdk8s-cli": "0.0.0"

--- a/examples/python/crd/package.json
+++ b/examples/python/crd/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "cdk8s-cli": "0.0.0"

--- a/examples/python/hello/package.json
+++ b/examples/python/hello/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "cdk8s-cli": "0.0.0"

--- a/examples/python/web-service/package.json
+++ b/examples/python/web-service/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "cdk8s-cli": "0.0.0"

--- a/examples/typescript/crd/package.json
+++ b/examples/typescript/crd/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/typescript/hello/package.json
+++ b/examples/typescript/hello/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/typescript/include-dashboard/package.json
+++ b/examples/typescript/include-dashboard/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/typescript/podinfo/package.json
+++ b/examples/typescript/podinfo/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/examples/typescript/web-service/package.json
+++ b/examples/typescript/web-service/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cdk8s": "0.0.0",
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "changelog-parser": "^2.8.0",
     "lerna": "^3.20.2",
     "standard-version": "^7.1.0",
-    "semver": "7.3.2"
+    "semver": "7.3.2",
+    "jsii-release": "^0.1.8"
   },
   "jest": {
     "clearMocks": true,

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -33,7 +33,7 @@
     "@types/node": "13.7.0",
     "cdk8s": "0.0.0",
     "codemaker": "^0.22.0",
-    "constructs": "^2.0.1",
+    "constructs": "2.0.1",
     "fs-extra": "^8.1.0",
     "jsii-srcmak": "^0.1.4",
     "sscaff": "^1.2.0",

--- a/packages/cdk8s-plus/.projenrc.js
+++ b/packages/cdk8s-plus/.projenrc.js
@@ -49,4 +49,7 @@ project.addScripts({
   test: 'yarn eslint && rm -fr lib/ && jest --passWithNoTests && yarn run compile'
 });
 
+// jsii-release is declared at the root level, we don't need it here.
+delete project.devDependencies['jsii-release']
+
 project.synth();

--- a/packages/cdk8s-plus/.projenrc.js
+++ b/packages/cdk8s-plus/.projenrc.js
@@ -1,6 +1,6 @@
 const { JsiiProject, Semver } = require('projen');
 
-const constructsDependency = Semver.caret('2.0.1')
+const constructsDependency = Semver.pinned('2.0.1')
 const cdk8sDependency = Semver.caret('0.0.0')
 
 const project = new JsiiProject({

--- a/packages/cdk8s-plus/package.json
+++ b/packages/cdk8s-plus/package.json
@@ -52,7 +52,7 @@
     "ts-jest": "^26.1.0"
   },
   "peerDependencies": {
-    "constructs": "^2.0.1",
+    "constructs": "2.0.1",
     "cdk8s": "^0.0.0"
   },
   "dependencies": {

--- a/packages/cdk8s-plus/package.json
+++ b/packages/cdk8s-plus/package.json
@@ -37,7 +37,6 @@
     "jsii": "^1.6.0",
     "jsii-diff": "^1.6.0",
     "jsii-pacmak": "^1.6.0",
-    "jsii-release": "^0.1.7",
     "@types/node": "^10.17.0",
     "typescript": "^3.8.3",
     "@typescript-eslint/eslint-plugin": "^2.31.0",

--- a/packages/cdk8s/package.json
+++ b/packages/cdk8s/package.json
@@ -105,7 +105,7 @@
     "yaml": "^1.7.2"
   },
   "peerDependencies": {
-    "constructs": "^2.0.1"
+    "constructs": "2.0.1"
   },
   "stability": "experimental"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,7 +2758,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@2.0.1, constructs@^2.0.1:
+constructs@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-2.0.1.tgz#274d6b8ce6a698813495c444466b0c745349ddb5"
   integrity sha512-edR85YFGI9TBT9byAo5vAfI0PRi+jFGzinwN3RAJwKfv6Yc9x9kALYfoEmgotp95qT7/k/iUQWHrH9BMJeqpdg==
@@ -6035,10 +6035,10 @@ jsii-reflect@^1.6.0:
     oo-ascii-tree "^1.6.0"
     yargs "^15.3.1"
 
-jsii-release@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.1.7.tgz#2e58aa6e9ee2743aeb7f9944c52311eaaf785498"
-  integrity sha512-wWoYpDikr2QhLfuefRRHfJK03D46M5YUJVlgSShEqgh9MRimnNMgRBxSGzZLxNMp3ink6+M3qIrC5PhvWLrH4Q==
+jsii-release@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.1.8.tgz#5433b139577eae342bb537f9e48434214122a6b2"
+  integrity sha512-3+8afEanKi2pttf1QtApPa6xMDrBKgRk1OIWdF1s0lP8tQBcBe2cntps0HRnPfkPOAjr1r3/ngv4A8wp9J2tPw==
 
 jsii-rosetta@^1.1.0, jsii-rosetta@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Using a caret dependency in a module built with `jsii < 1.3.2` results in an invalid version range in the package manifest file for dotnet artifacts:

See: `[2.0.1, 3.0.0-0)`

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Org.Cdk8s</id>
    <version>0.25.0</version>
    <authors>Amazon Web Services</authors>
    <owners>Amazon Web Services</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <license type="expression">Apache-2.0</license>
    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
    <description>Cloud Development Kit for Kubernetes (Stability: Experimental)</description>
    <tags>cdk kubernetes k8s constructs</tags>
    <repository type="git" url="https://github.com/awslabs/cdk8s.git" />
    <dependencies>
      <group targetFramework=".NETCoreApp3.1">
        <dependency id="Amazon.JSII.Runtime" version="[1.1.0, 2.0.0)" exclude="Build,Analyzers" />
        <dependency id="Constructs" version="[2.0.1, 3.0.0-0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```

This results in the following error when trying to publish:

```console
error: Response status code does not indicate success: 400 (The NuGet package contains an invalid .nuspec file. The error encountered was: 'The package manifest contains an invalid Version: '3.0.0-0''. Correct the error and try again.)
```

This issue was [fixed](https://github.com/aws/jsii/commit/9ef8f17e11fa3403043c3237463c16e08020c696) in `jsii` a while back. The problem is that we cannot upgrade the `jsii` version because it will conflict with the `jsii` version of `constructs`. We can't upgrade `constructs` because it introduces some breaking changes with regards to tokenization, and would require some non trivial effort.

As a work around, I suggest to *pin* constructs dependency to `2.0.1`, avoiding the whole caret invalid version range issue.
In practice, this pinning has no real affect since the next version of constructs is `3.0.0`, there is no version in between. 

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
