### PR TITLE
fix: java importing crd fails

### DIFF
--- a/packages/cdk8s-cli/lib/import/base.ts
+++ b/packages/cdk8s-cli/lib/import/base.ts
@@ -44,7 +44,7 @@ export abstract class ImportBase {
 
     for (const name of this.moduleNames) {
       // output the name of the imported resource
-      console.error(name);
+      console.log(name);
 
       const fileName = moduleNamePrefix ? `${moduleNamePrefix}-${name}.ts` : `${name}.ts`;
       code.openFile(fileName);
@@ -87,9 +87,10 @@ export abstract class ImportBase {
 
           // java!
           if (options.targetLanguage === Language.JAVA) {
+            const javaName = name.replace('/', '.')
             opts.java = {
               outdir: '.',
-              package: `imports.${moduleNamePrefix ? moduleNamePrefix + '.' + name : name}`
+              package: `imports.${moduleNamePrefix ? moduleNamePrefix + '.' + javaName : javaName}`
             };
           }
 

--- a/packages/cdk8s-cli/lib/import/base.ts
+++ b/packages/cdk8s-cli/lib/import/base.ts
@@ -87,7 +87,7 @@ export abstract class ImportBase {
 
           // java!
           if (options.targetLanguage === Language.JAVA) {
-            const javaName = name.replace('/', '.')
+            const javaName = name.replace(/\//g, '.')
             opts.java = {
               outdir: '.',
               package: `imports.${moduleNamePrefix ? moduleNamePrefix + '.' + javaName : javaName}`


### PR DESCRIPTION
Fixes https://github.com/awslabs/cdk8s/issues/234

Replace `/` with `.`

Tested locally with the CRD example I'm writing for Java.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
