### PR TITLE
feat(lib): omit duplicate components in generated names

### DIFF
--- a/packages/cdk8s-plus/test/pod.test.ts
+++ b/packages/cdk8s-plus/test/pod.test.ts
@@ -166,7 +166,7 @@ describe('Pod', () => {
           "apiVersion": "v1",
           "kind": "Pod",
           "metadata": Object {
-            "name": "test-pod-pod-cc5a4f6a",
+            "name": "test-pod-cc5a4f6a",
           },
           "spec": Object {
             "containers": Array [

--- a/packages/cdk8s-plus/test/secret.test.ts
+++ b/packages/cdk8s-plus/test/secret.test.ts
@@ -19,7 +19,7 @@ test('Can add data to new secrets', () => {
         "apiVersion": "v1",
         "kind": "Secret",
         "metadata": Object {
-          "name": "test-secret-secret-081177f7",
+          "name": "test-secret-081177f7",
         },
         "stringData": Object {
           "key": "value",

--- a/packages/cdk8s/src/names.ts
+++ b/packages/cdk8s/src/names.ts
@@ -51,9 +51,9 @@ export class Names {
 
     components.push(calcHash(path, HASH_LEN));
 
-    components = omitDuplicates(components);
-
     return components
+      .reverse()
+      .filter(omitDuplicates)
       .join('/')
       .slice(0, maxLen)
       .split('/')
@@ -68,8 +68,8 @@ export class Names {
   }
 }
 
-function omitDuplicates(components: string[]) {
-  return components.reverse().filter((value, index, components) => value !== components[index-1])
+function omitDuplicates(value: string, index: number, components: string[]) {
+  return value !== components[index-1];
 }
 
 function normalizeToDnsName(c: string, maxLen: number) {

--- a/packages/cdk8s/src/names.ts
+++ b/packages/cdk8s/src/names.ts
@@ -53,6 +53,7 @@ export class Names {
 
     return components
       .reverse()
+      .filter(((value, index, components) => value !== components[index-1]))
       .join('/')
       .slice(0, maxLen)
       .split('/')

--- a/packages/cdk8s/src/names.ts
+++ b/packages/cdk8s/src/names.ts
@@ -51,9 +51,9 @@ export class Names {
 
     components.push(calcHash(path, HASH_LEN));
 
+    components = omitDuplicates(components);
+
     return components
-      .reverse()
-      .filter(((value, index, components) => value !== components[index-1]))
       .join('/')
       .slice(0, maxLen)
       .split('/')
@@ -66,6 +66,10 @@ export class Names {
   private constructor() {
     return;
   }
+}
+
+function omitDuplicates(components: string[]) {
+  return components.reverse().filter((value, index, components) => value !== components[index-1])
 }
 
 function normalizeToDnsName(c: string, maxLen: number) {

--- a/packages/cdk8s/test/names.test.ts
+++ b/packages/cdk8s/test/names.test.ts
@@ -23,7 +23,9 @@ test('single term is not decorated with a hash', () => {
 
 test('multiple terms are separated by "." and a hash is appended', () => {
   expect(toDnsName('hello-foo-world')).toEqual('hello-foo-world'); // this is actually a single term
+  expect(toDnsName('hello-hello-foo-world')).toEqual('hello-hello-foo-world'); // intentionally duplicated
   expect(toDnsName('hello-foo/world')).toEqual('hello-foo-world-54700203'); // two terms
+  expect(toDnsName('hello-foo/foo')).toEqual('hello-foo-foo-e078a973'); // two terms, intentionally duplicated
   expect(toDnsName('hello/foo/world')).toEqual('hello-foo-world-4f6e4fd8'); // three terms
 });
 
@@ -37,10 +39,20 @@ test('invalid max length (minimum is 8 - for hash)', () => {
   expect(toDnsName('foo', 9)).toEqual('foo');
 });
 
+test('omit duplicate components in names', () => {
+  expect(toDnsName('hello/hello/foo/world')).toEqual('hello-foo-world-1d4999d0');
+  expect(toDnsName('hello/hello/hello/foo/world')).toEqual('hello-foo-world-d3ebcda3');
+  expect(toDnsName('hello/hello/hello/hello/hello')).toEqual('hello-456bb9d7');
+  expect(toDnsName('hello/cool/cool/cool/cool')).toEqual('hello-cool-83150e81');
+  expect(toDnsName('hello/world/world/world/cool')).toEqual('hello-world-cool-0148a798');
+})
+
 test('trimming (prioritize last component)', () => {
   expect(toDnsName('hello/world', 8)).toEqual('761e91eb');
   expect(toDnsName('hello/world/this/is/cool', 8)).toEqual('a7c39f00');
   expect(toDnsName('hello/world/this/is/cool', 12)).toEqual('coo-a7c39f00');
+  expect(toDnsName('hello/hello/this/is/cool', 12)).toEqual('coo-8751188b');
+  expect(toDnsName('hello/cool/cool/cool/cool', 15)).toEqual('h-cool-83150e81');
   expect(toDnsName('hello/world/this/is/cool', 14)).toEqual('cool-a7c39f00');
   expect(toDnsName('hello/world/this/is/cool', 15)).toEqual('i-cool-a7c39f00');
   expect(toDnsName('hello/world/this/is/cool', 25)).toEqual('wor-this-is-cool-a7c39f00');


### PR DESCRIPTION
For better readability, now omit adjacent duplicate components when generating resources names. Something like `redrive-redrive-app-configmap-e2d51b95` becomes `redrive-app-configmap-e2d51b95`.

Resolves https://github.com/awslabs/cdk8s/issues/236

BREAKING CHANGE: resource names will now be rendered differently, omitting adjacent duplicate components.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
