### PR TITLE
chore: ignore python for repository linguist analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py linguist-detectable=false


### PR DESCRIPTION
Fixes https://github.com/awslabs/cdk8s/issues/260

Alternatively, we can ignore paths like `examples` and all the various test directories using 

https://github.com/github/linguist#vendored-code

like:

```
examples/* linguist-vendored
```

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
