### PR TITLE
fix(cli): Conform python and java package names to language standards (no hyphens)

### DIFF
--- a/examples/python/crd/main.py
+++ b/examples/python/crd/main.py
@@ -2,8 +2,8 @@
 from constructs import Construct
 from cdk8s import App, Chart
 
-from imports import jenkins
-from imports import clusterinstallation
+from imports.jenkins.io import jenkins
+from imports.mattermost.com import clusterinstallation
 
 class MyChart(Chart):
     def __init__(self, scope: Construct, ns: str):

--- a/examples/python/crd/version.yaml
+++ b/examples/python/crd/version.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: foos.samplecontroller.k8s.io
 spec:
-  group: samplecontroller.k8s.io
+  group: sample-controller.k8s.io
   version: v1alpha1
   names:
     kind: Foo

--- a/packages/cdk8s-cli/src/import/base.ts
+++ b/packages/cdk8s-cli/src/import/base.ts
@@ -69,6 +69,7 @@ export abstract class ImportBase {
 
           const opts: srcmak.Options = {
             entrypoint: fileName,
+            moduleKey: name,
             deps: deps.map(dep => path.dirname(require.resolve(`${dep}/package.json`))),
           };
 
@@ -79,15 +80,16 @@ export abstract class ImportBase {
 
           // python!
           if (options.targetLanguage === Language.PYTHON) {
+            const moduleName = `${moduleNamePrefix ? `${moduleNamePrefix}.${name}` : name}`.replace(/-/g, '_');
             opts.python = {
               outdir: outdir,
-              moduleName: moduleNamePrefix ? `${moduleNamePrefix}.${name}` : name,
+              moduleName,
             };
           }
 
           // java!
           if (options.targetLanguage === Language.JAVA) {
-            const javaName = name.replace(/\//g, '.')
+            const javaName = name.replace(/\//g, '.').replace(/-/g, '_');
             opts.java = {
               outdir: '.',
               package: `imports.${moduleNamePrefix ? moduleNamePrefix + '.' + javaName : javaName}`,

--- a/packages/cdk8s-cli/test/import/__snapshots__/import-crd.test.ts.snap
+++ b/packages/cdk8s-cli/test/import/__snapshots__/import-crd.test.ts.snap
@@ -58,12 +58,12 @@ Object {
       },
     },
   },
-  "description": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+  "description": "elasticsearchk8selasticcoelasticsearch",
   "fingerprint": "<fingerprint>",
   "homepage": "http://generated",
   "jsiiVersion": "1.5.0 (build 46538f8)",
   "license": "Apache-2.0",
-  "name": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+  "name": "elasticsearchk8selasticcoelasticsearch",
   "repository": Object {
     "type": "git",
     "url": "http://generated",
@@ -71,12 +71,12 @@ Object {
   "schema": "jsii/0.10.0",
   "targets": Object {
     "js": Object {
-      "npm": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+      "npm": "elasticsearchk8selasticcoelasticsearch",
     },
   },
   "types": Object {
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.Elasticsearch": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.Elasticsearch": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "base": "cdk8s.ApiObject",
       "docs": Object {
         "custom": Object {
@@ -84,7 +84,7 @@ Object {
         },
         "summary": "Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.Elasticsearch",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.Elasticsearch",
       "initializer": Object {
         "docs": Object {
           "summary": "Defines a \\"Elasticsearch\\" API object.",
@@ -115,7 +115,7 @@ Object {
             "name": "options",
             "optional": true,
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchOptions",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchOptions",
             },
           },
         ],
@@ -127,8 +127,8 @@ Object {
       },
       "name": "Elasticsearch",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchOptions": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchOptions": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -136,7 +136,7 @@ Object {
         },
         "summary": "Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchOptions",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -178,13 +178,13 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpec",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpec",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpec": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpec": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -192,7 +192,7 @@ Object {
         },
         "summary": "ElasticsearchSpec holds the specification of an Elasticsearch cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpec",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -218,7 +218,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSets",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSets",
               },
               "kind": "array",
             },
@@ -258,7 +258,7 @@ Object {
           "name": "auth",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuth",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuth",
           },
         },
         Object {
@@ -277,7 +277,7 @@ Object {
           "name": "http",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttp",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttp",
           },
         },
         Object {
@@ -316,7 +316,7 @@ Object {
           "name": "podDisruptionBudget",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudget",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudget",
           },
         },
         Object {
@@ -337,7 +337,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClusters",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClusters",
               },
               "kind": "array",
             },
@@ -361,7 +361,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettings",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettings",
               },
               "kind": "array",
             },
@@ -403,7 +403,7 @@ Object {
           "name": "transport",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransport",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransport",
           },
         },
         Object {
@@ -422,13 +422,13 @@ Object {
           "name": "updateStrategy",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategy",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategy",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuth": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuth": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -436,7 +436,7 @@ Object {
         },
         "summary": "Auth contains user authentication and authorization security settings for Elasticsearch.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuth",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuth",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -462,7 +462,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthFileRealm",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthFileRealm",
               },
               "kind": "array",
             },
@@ -486,7 +486,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthRoles",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthRoles",
               },
               "kind": "array",
             },
@@ -494,8 +494,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthFileRealm": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthFileRealm": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -503,7 +503,7 @@ Object {
         },
         "summary": "FileRealmSource references users to create in the Elasticsearch cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthFileRealm",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthFileRealm",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -532,8 +532,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthRoles": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthRoles": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -541,7 +541,7 @@ Object {
         },
         "summary": "RoleSource references roles to create in the Elasticsearch cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecAuthRoles",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecAuthRoles",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -570,8 +570,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttp": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttp": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -579,7 +579,7 @@ Object {
         },
         "summary": "HTTP holds HTTP layer settings for Elasticsearch.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttp",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttp",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -603,7 +603,7 @@ Object {
           "name": "service",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpService",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpService",
           },
         },
         Object {
@@ -622,13 +622,13 @@ Object {
           "name": "tls",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTls",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTls",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpService": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpService": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -636,7 +636,7 @@ Object {
         },
         "summary": "Service defines the template for the associated Kubernetes Service object.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpService",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpService",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -680,13 +680,13 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpec",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpec",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpec": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpec": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -694,7 +694,7 @@ Object {
         },
         "summary": "Spec is the specification of the service.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpec",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -890,7 +890,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPorts",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPorts",
               },
               "kind": "array",
             },
@@ -978,7 +978,7 @@ Object {
           "name": "sessionAffinityConfig",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig",
           },
         },
         Object {
@@ -1029,8 +1029,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPorts": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPorts": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1038,7 +1038,7 @@ Object {
         },
         "summary": "ServicePort contains information on service's port.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPorts",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPorts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1143,13 +1143,13 @@ Object {
           "name": "targetPort",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPortsTargetPort": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPortsTargetPort": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecHttpServiceSpecPortsTargetPort",
@@ -1157,7 +1157,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
         "summary": "Number or name of the port to access on the pods targeted by the service.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1180,7 +1180,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
             },
           },
           "static": true,
@@ -1201,7 +1201,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecPortsTargetPort",
             },
           },
           "static": true,
@@ -1209,8 +1209,8 @@ Object {
       ],
       "name": "ElasticsearchSpecHttpServiceSpecPortsTargetPort",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1218,7 +1218,7 @@ Object {
         },
         "summary": "sessionAffinityConfig contains the configurations of session affinity.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1242,13 +1242,13 @@ Object {
           "name": "clientIP",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1256,7 +1256,7 @@ Object {
         },
         "summary": "clientIP contains the configurations of Client IP based session affinity.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpServiceSpecSessionAffinityConfigClientIp",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1286,8 +1286,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTls": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTls": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1295,7 +1295,7 @@ Object {
         },
         "summary": "TLS defines options for configuring TLS for HTTP.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTls",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTls",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1321,7 +1321,7 @@ Object {
           "name": "certificate",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsCertificate",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsCertificate",
           },
         },
         Object {
@@ -1340,13 +1340,13 @@ Object {
           "name": "selfSignedCertificate",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificate",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificate",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsCertificate": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsCertificate": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1356,7 +1356,7 @@ Object {
 - \`ca.crt\`: The certificate authority (optional). - \`tls.crt\`: The certificate (or a chain). - \`tls.key\`: The private key to the first certificate in the certificate chain.",
         "summary": "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsCertificate",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsCertificate",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1385,8 +1385,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificate": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificate": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1394,7 +1394,7 @@ Object {
         },
         "summary": "SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificate",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificate",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1439,7 +1439,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames",
               },
               "kind": "array",
             },
@@ -1447,8 +1447,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1456,7 +1456,7 @@ Object {
         },
         "summary": "SubjectAlternativeName represents a SAN entry in a x509 certificate.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecHttpTlsSelfSignedCertificateSubjectAltNames",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1504,8 +1504,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSets": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSets": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1513,7 +1513,7 @@ Object {
         },
         "summary": "NodeSet is the specification for a group of Elasticsearch nodes sharing the same configuration and a Pod template.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSets",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSets",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1615,7 +1615,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplates",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplates",
               },
               "kind": "array",
             },
@@ -1623,8 +1623,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplates": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplates": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1632,7 +1632,7 @@ Object {
         },
         "summary": "PersistentVolumeClaim is a user's request for and claim to a persistent volume.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplates",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplates",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1717,7 +1717,7 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec",
           },
         },
         Object {
@@ -1737,13 +1737,13 @@ Object {
           "name": "status",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1752,7 +1752,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "Spec defines the desired characteristics of a volume requested by a pod author.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1802,7 +1802,7 @@ Object {
           "name": "dataSource",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource",
           },
         },
         Object {
@@ -1822,7 +1822,7 @@ Object {
           "name": "resources",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources",
           },
         },
         Object {
@@ -1841,7 +1841,7 @@ Object {
           "name": "selector",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector",
           },
         },
         Object {
@@ -1905,8 +1905,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1915,7 +1915,7 @@ Object {
         "remarks": "If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
         "summary": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecDataSource",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -1981,8 +1981,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -1991,7 +1991,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
         "summary": "Resources represents the minimum resources the volume should have.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2018,7 +2018,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
               },
               "kind": "map",
             },
@@ -2043,7 +2043,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
               },
               "kind": "map",
             },
@@ -2051,14 +2051,14 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
         },
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2081,7 +2081,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
             },
           },
           "static": true,
@@ -2102,7 +2102,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
             },
           },
           "static": true,
@@ -2110,14 +2110,14 @@ Object {
       ],
       "name": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesLimits",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
         },
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2140,7 +2140,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
             },
           },
           "static": true,
@@ -2161,7 +2161,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
             },
           },
           "static": true,
@@ -2169,8 +2169,8 @@ Object {
       ],
       "name": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecResourcesRequests",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2178,7 +2178,7 @@ Object {
         },
         "summary": "A label query over volumes to consider for binding.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2205,7 +2205,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -2238,8 +2238,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2247,7 +2247,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesSpecSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2319,8 +2319,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2329,7 +2329,7 @@ Object {
         "remarks": "Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "Status represents the current information/status of a persistent volume claim.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatus",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2380,7 +2380,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
               },
               "kind": "map",
             },
@@ -2405,7 +2405,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions",
               },
               "kind": "array",
             },
@@ -2432,14 +2432,14 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
         },
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2462,7 +2462,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
             },
           },
           "static": true,
@@ -2483,7 +2483,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
             },
           },
           "static": true,
@@ -2491,8 +2491,8 @@ Object {
       ],
       "name": "ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusCapacity",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2500,7 +2500,7 @@ Object {
         },
         "summary": "PersistentVolumeClaimCondition contails details about state of pvc.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecNodeSetsVolumeClaimTemplatesStatusConditions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2622,8 +2622,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudget": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudget": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2632,7 +2632,7 @@ Object {
         "remarks": "The default budget selects all cluster pods and sets \`maxUnavailable\` to 1. To disable, set \`PodDisruptionBudget\` to the empty value (\`{}\` in YAML).",
         "summary": "PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudget",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudget",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2676,13 +2676,13 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpec",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpec",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpec": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpec": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2690,7 +2690,7 @@ Object {
         },
         "summary": "Spec is the specification of the PDB.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpec",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2714,7 +2714,7 @@ Object {
           "name": "maxUnavailable",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
           },
         },
         Object {
@@ -2733,7 +2733,7 @@ Object {
           "name": "minAvailable",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
           },
         },
         Object {
@@ -2752,20 +2752,20 @@ Object {
           "name": "selector",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelector",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelector",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
         },
         "summary": "An eviction is allowed if at most \\"maxUnavailable\\" pods selected by \\"selector\\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \\"minAvailable\\".",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2788,7 +2788,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
             },
           },
           "static": true,
@@ -2809,7 +2809,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
             },
           },
           "static": true,
@@ -2817,15 +2817,15 @@ Object {
       ],
       "name": "ElasticsearchSpecPodDisruptionBudgetSpecMaxUnavailable",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
         },
         "summary": "An eviction is allowed if at least \\"minAvailable\\" pods selected by \\"selector\\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \\"100%\\".",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2848,7 +2848,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
             },
           },
           "static": true,
@@ -2869,7 +2869,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
             },
           },
           "static": true,
@@ -2877,8 +2877,8 @@ Object {
       ],
       "name": "ElasticsearchSpecPodDisruptionBudgetSpecMinAvailable",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelector": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelector": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2886,7 +2886,7 @@ Object {
         },
         "summary": "Label query over pods whose evictions are managed by the disruption budget.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelector",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -2913,7 +2913,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -2946,8 +2946,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -2955,7 +2955,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecPodDisruptionBudgetSpecSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3027,8 +3027,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClusters": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClusters": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3036,7 +3036,7 @@ Object {
         },
         "summary": "RemoteCluster declares a remote Elasticsearch cluster connection.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClusters",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClusters",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3079,13 +3079,13 @@ Object {
           "name": "elasticsearchRef",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClustersElasticsearchRef",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClustersElasticsearchRef",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClustersElasticsearchRef": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClustersElasticsearchRef": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3093,7 +3093,7 @@ Object {
         },
         "summary": "ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecRemoteClustersElasticsearchRef",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecRemoteClustersElasticsearchRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3141,8 +3141,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettings": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettings": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3150,7 +3150,7 @@ Object {
         },
         "summary": "SecretSource defines a data source based on a Kubernetes Secret.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettings",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettings",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3195,7 +3195,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettingsEntries",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettingsEntries",
               },
               "kind": "array",
             },
@@ -3203,8 +3203,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettingsEntries": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettingsEntries": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3212,7 +3212,7 @@ Object {
         },
         "summary": "KeyToPath defines how to map a key in a Secret object to a filesystem path.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecSecureSettingsEntries",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecSecureSettingsEntries",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3260,8 +3260,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransport": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransport": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3269,7 +3269,7 @@ Object {
         },
         "summary": "Transport holds transport layer settings for Elasticsearch.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransport",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransport",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3293,13 +3293,13 @@ Object {
           "name": "service",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportService",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportService",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportService": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportService": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3307,7 +3307,7 @@ Object {
         },
         "summary": "Service defines the template for the associated Kubernetes Service object.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportService",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportService",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3351,13 +3351,13 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpec",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpec",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpec": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpec": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3365,7 +3365,7 @@ Object {
         },
         "summary": "Spec is the specification of the service.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpec",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3561,7 +3561,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPorts",
+                "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPorts",
               },
               "kind": "array",
             },
@@ -3649,7 +3649,7 @@ Object {
           "name": "sessionAffinityConfig",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig",
           },
         },
         Object {
@@ -3700,8 +3700,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPorts": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPorts": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3709,7 +3709,7 @@ Object {
         },
         "summary": "ServicePort contains information on service's port.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPorts",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPorts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3814,13 +3814,13 @@ Object {
           "name": "targetPort",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPortsTargetPort": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPortsTargetPort": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "docs": Object {
         "custom": Object {
           "schema": "ElasticsearchSpecTransportServiceSpecPortsTargetPort",
@@ -3828,7 +3828,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
         "summary": "Number or name of the port to access on the pods targeted by the service.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3851,7 +3851,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
             },
           },
           "static": true,
@@ -3872,7 +3872,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
+              "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecPortsTargetPort",
             },
           },
           "static": true,
@@ -3880,8 +3880,8 @@ Object {
       ],
       "name": "ElasticsearchSpecTransportServiceSpecPortsTargetPort",
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3889,7 +3889,7 @@ Object {
         },
         "summary": "sessionAffinityConfig contains the configurations of session affinity.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3913,13 +3913,13 @@ Object {
           "name": "clientIP",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3927,7 +3927,7 @@ Object {
         },
         "summary": "clientIP contains the configurations of Client IP based session affinity.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecTransportServiceSpecSessionAffinityConfigClientIp",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3957,8 +3957,8 @@ Object {
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategy": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategy": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -3966,7 +3966,7 @@ Object {
         },
         "summary": "UpdateStrategy specifies how updates to the cluster should be performed.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategy",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategy",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -3990,13 +3990,13 @@ Object {
           "name": "changeBudget",
           "optional": true,
           "type": Object {
-            "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategyChangeBudget",
+            "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategyChangeBudget",
           },
         },
       ],
     },
-    "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategyChangeBudget": Object {
-      "assembly": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818",
+    "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategyChangeBudget": Object {
+      "assembly": "elasticsearchk8selasticcoelasticsearch",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4004,7 +4004,7 @@ Object {
         },
         "summary": "ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.",
       },
-      "fqn": "b088ced0a0578668226239168b831800532809f5f3230c5c3623b0883f522818.ElasticsearchSpecUpdateStrategyChangeBudget",
+      "fqn": "elasticsearchk8selasticcoelasticsearch.ElasticsearchSpecUpdateStrategyChangeBudget",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "elasticsearch.k8s.elastic.co/elasticsearch.ts",
@@ -4119,12 +4119,12 @@ Object {
       },
     },
   },
-  "description": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+  "description": "jenkinsiojenkins",
   "fingerprint": "<fingerprint>",
   "homepage": "http://generated",
   "jsiiVersion": "1.5.0 (build 46538f8)",
   "license": "Apache-2.0",
-  "name": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+  "name": "jenkinsiojenkins",
   "repository": Object {
     "type": "git",
     "url": "http://generated",
@@ -4132,12 +4132,12 @@ Object {
   "schema": "jsii/0.10.0",
   "targets": Object {
     "js": Object {
-      "npm": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+      "npm": "jenkinsiojenkins",
     },
   },
   "types": Object {
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.Jenkins": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.Jenkins": Object {
+      "assembly": "jenkinsiojenkins",
       "base": "cdk8s.ApiObject",
       "docs": Object {
         "custom": Object {
@@ -4145,7 +4145,7 @@ Object {
         },
         "summary": "Jenkins is the Schema for the jenkins API.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.Jenkins",
+      "fqn": "jenkinsiojenkins.Jenkins",
       "initializer": Object {
         "docs": Object {
           "summary": "Defines a \\"Jenkins\\" API object.",
@@ -4176,7 +4176,7 @@ Object {
             "name": "options",
             "optional": true,
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsOptions",
+              "fqn": "jenkinsiojenkins.JenkinsOptions",
             },
           },
         ],
@@ -4188,8 +4188,8 @@ Object {
       },
       "name": "Jenkins",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsOptions": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsOptions": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4197,7 +4197,7 @@ Object {
         },
         "summary": "Jenkins is the Schema for the jenkins API.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsOptions",
+      "fqn": "jenkinsiojenkins.JenkinsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4239,13 +4239,13 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpec",
+            "fqn": "jenkinsiojenkins.JenkinsSpec",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4253,7 +4253,7 @@ Object {
         },
         "summary": "Spec defines the desired state of the Jenkins.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpec",
+      "fqn": "jenkinsiojenkins.JenkinsSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4276,7 +4276,7 @@ Object {
           },
           "name": "jenkinsAPISettings",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecJenkinsApiSettings",
+            "fqn": "jenkinsiojenkins.JenkinsSpecJenkinsApiSettings",
           },
         },
         Object {
@@ -4295,7 +4295,7 @@ Object {
           "name": "backup",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackup",
+            "fqn": "jenkinsiojenkins.JenkinsSpecBackup",
           },
         },
         Object {
@@ -4314,7 +4314,7 @@ Object {
           "name": "configurationAsCode",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCode",
+            "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCode",
           },
         },
         Object {
@@ -4333,7 +4333,7 @@ Object {
           "name": "groovyScripts",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScripts",
+            "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScripts",
           },
         },
         Object {
@@ -4353,7 +4353,7 @@ Object {
           "name": "master",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMaster",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMaster",
           },
         },
         Object {
@@ -4374,7 +4374,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotifications",
+                "fqn": "jenkinsiojenkins.JenkinsSpecNotifications",
               },
               "kind": "array",
             },
@@ -4396,7 +4396,7 @@ Object {
           "name": "restore",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestore",
+            "fqn": "jenkinsiojenkins.JenkinsSpecRestore",
           },
         },
         Object {
@@ -4417,7 +4417,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRoles",
+                "fqn": "jenkinsiojenkins.JenkinsSpecRoles",
               },
               "kind": "array",
             },
@@ -4441,7 +4441,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSeedJobs",
+                "fqn": "jenkinsiojenkins.JenkinsSpecSeedJobs",
               },
               "kind": "array",
             },
@@ -4464,7 +4464,7 @@ Object {
           "name": "service",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecService",
+            "fqn": "jenkinsiojenkins.JenkinsSpecService",
           },
         },
         Object {
@@ -4483,7 +4483,7 @@ Object {
           "name": "serviceAccount",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecServiceAccount",
+            "fqn": "jenkinsiojenkins.JenkinsSpecServiceAccount",
           },
         },
         Object {
@@ -4503,13 +4503,13 @@ Object {
           "name": "slaveService",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSlaveService",
+            "fqn": "jenkinsiojenkins.JenkinsSpecSlaveService",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackup": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecBackup": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4517,7 +4517,7 @@ Object {
         },
         "summary": "Backup defines configuration of Jenkins backup More info: https://github.com/jenkinsci/kubernetes-operator/blob/master/docs/getting-started.md#configure-backup-and-restore.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackup",
+      "fqn": "jenkinsiojenkins.JenkinsSpecBackup",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4540,7 +4540,7 @@ Object {
           },
           "name": "action",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupAction",
+            "fqn": "jenkinsiojenkins.JenkinsSpecBackupAction",
           },
         },
         Object {
@@ -4600,8 +4600,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupAction": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecBackupAction": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4609,7 +4609,7 @@ Object {
         },
         "summary": "Action defines action which performs backup in backup container sidecar.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupAction",
+      "fqn": "jenkinsiojenkins.JenkinsSpecBackupAction",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4633,13 +4633,13 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupActionExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecBackupActionExec",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupActionExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecBackupActionExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4647,7 +4647,7 @@ Object {
         },
         "summary": "Exec specifies the action to take.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupActionExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecBackupActionExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4682,8 +4682,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCode": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecConfigurationAsCode": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4691,7 +4691,7 @@ Object {
         },
         "summary": "ConfigurationAsCode defines configuration of Jenkins customization via Configuration as Code Jenkins plugin.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCode",
+      "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCode",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4715,7 +4715,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeConfigurations",
+                "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeConfigurations",
               },
               "kind": "array",
             },
@@ -4736,13 +4736,13 @@ Object {
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeConfigurations": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeConfigurations": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4750,7 +4750,7 @@ Object {
         },
         "summary": "ConfigMapRef is reference to Kubernetes ConfigMap.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeConfigurations",
+      "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeConfigurations",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4777,8 +4777,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4786,7 +4786,7 @@ Object {
         },
         "summary": "SecretRef is reference to Kubernetes secret.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecConfigurationAsCodeSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4813,8 +4813,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScripts": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecGroovyScripts": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4822,7 +4822,7 @@ Object {
         },
         "summary": "GroovyScripts defines configuration of Jenkins customization via groovy scripts.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScripts",
+      "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScripts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4846,7 +4846,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsConfigurations",
+                "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScriptsConfigurations",
               },
               "kind": "array",
             },
@@ -4867,13 +4867,13 @@ Object {
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScriptsSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsConfigurations": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecGroovyScriptsConfigurations": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4881,7 +4881,7 @@ Object {
         },
         "summary": "ConfigMapRef is reference to Kubernetes ConfigMap.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsConfigurations",
+      "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScriptsConfigurations",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4908,8 +4908,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecGroovyScriptsSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4917,7 +4917,7 @@ Object {
         },
         "summary": "SecretRef is reference to Kubernetes secret.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecGroovyScriptsSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4944,8 +4944,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecJenkinsApiSettings": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecJenkinsApiSettings": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4953,7 +4953,7 @@ Object {
         },
         "summary": "JenkinsAPISettings defines configuration used by the operator to gain admin access to the Jenkins API.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecJenkinsApiSettings",
+      "fqn": "jenkinsiojenkins.JenkinsSpecJenkinsApiSettings",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -4981,8 +4981,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMaster": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMaster": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -4991,7 +4991,7 @@ Object {
         "remarks": "Every single change here requires a pod restart.",
         "summary": "Master represents Jenkins master pod properties and Jenkins plugins.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMaster",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMaster",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5061,7 +5061,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterBasePlugins",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterBasePlugins",
               },
               "kind": "array",
             },
@@ -5087,7 +5087,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainers",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainers",
               },
               "kind": "array",
             },
@@ -5112,7 +5112,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterImagePullSecrets",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterImagePullSecrets",
               },
               "kind": "array",
             },
@@ -5211,7 +5211,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterPlugins",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterPlugins",
               },
               "kind": "array",
             },
@@ -5235,7 +5235,7 @@ Object {
           "name": "securityContext",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContext",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContext",
           },
         },
         Object {
@@ -5256,7 +5256,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterTolerations",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterTolerations",
               },
               "kind": "array",
             },
@@ -5281,7 +5281,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumes",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumes",
               },
               "kind": "array",
             },
@@ -5289,8 +5289,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterBasePlugins": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterBasePlugins": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5298,7 +5298,7 @@ Object {
         },
         "summary": "Plugin defines Jenkins plugin.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterBasePlugins",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterBasePlugins",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5344,8 +5344,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainers": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainers": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5353,7 +5353,7 @@ Object {
         },
         "summary": "Container defines Kubernetes container attributes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainers",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainers",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5435,7 +5435,7 @@ Object {
           },
           "name": "resources",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersResources",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersResources",
           },
         },
         Object {
@@ -5506,7 +5506,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnv",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnv",
               },
               "kind": "array",
             },
@@ -5531,7 +5531,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFrom",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFrom",
               },
               "kind": "array",
             },
@@ -5553,7 +5553,7 @@ Object {
           "name": "lifecycle",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecycle",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecycle",
           },
         },
         Object {
@@ -5573,7 +5573,7 @@ Object {
           "name": "livenessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbe",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbe",
           },
         },
         Object {
@@ -5595,7 +5595,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersPorts",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersPorts",
               },
               "kind": "array",
             },
@@ -5618,7 +5618,7 @@ Object {
           "name": "readinessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbe",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbe",
           },
         },
         Object {
@@ -5638,7 +5638,7 @@ Object {
           "name": "securityContext",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContext",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContext",
           },
         },
         Object {
@@ -5659,7 +5659,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersVolumeMounts",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersVolumeMounts",
               },
               "kind": "array",
             },
@@ -5687,8 +5687,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnv": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnv": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5696,7 +5696,7 @@ Object {
         },
         "summary": "EnvVar represents an environment variable present in a Container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnv",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnv",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5761,13 +5761,13 @@ Object {
           "name": "valueFrom",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFrom",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFrom",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFrom": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFrom": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5775,7 +5775,7 @@ Object {
         },
         "summary": "EnvFromSource represents the source of a set of ConfigMaps.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFrom",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5799,7 +5799,7 @@ Object {
           "name": "configMapRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromConfigMapRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromConfigMapRef",
           },
         },
         Object {
@@ -5838,13 +5838,13 @@ Object {
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromSecretRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromConfigMapRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromConfigMapRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5852,7 +5852,7 @@ Object {
         },
         "summary": "The ConfigMap to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromConfigMapRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromConfigMapRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5901,8 +5901,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5910,7 +5910,7 @@ Object {
         },
         "summary": "The Secret to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5959,8 +5959,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFrom": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFrom": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -5969,7 +5969,7 @@ Object {
         "remarks": "Cannot be used if value is not empty.",
         "summary": "Source for the environment variable's value.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFrom",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -5993,7 +5993,7 @@ Object {
           "name": "configMapKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
           },
         },
         Object {
@@ -6012,7 +6012,7 @@ Object {
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromFieldRef",
           },
         },
         Object {
@@ -6031,7 +6031,7 @@ Object {
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
           },
         },
         Object {
@@ -6050,13 +6050,13 @@ Object {
           "name": "secretKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6064,7 +6064,7 @@ Object {
         },
         "summary": "Selects a key of a ConfigMap.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6131,8 +6131,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6140,7 +6140,7 @@ Object {
         },
         "summary": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6187,8 +6187,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6196,7 +6196,7 @@ Object {
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6262,8 +6262,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6271,7 +6271,7 @@ Object {
         },
         "summary": "Selects a key of a secret in the pod's namespace.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6339,8 +6339,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecycle": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecycle": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6348,7 +6348,7 @@ Object {
         },
         "summary": "Actions that the management system should take in response to container lifecycle events.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecycle",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecycle",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6373,7 +6373,7 @@ Object {
           "name": "postStart",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStart",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStart",
           },
         },
         Object {
@@ -6393,13 +6393,13 @@ Object {
           "name": "preStop",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStop",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStop",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStart": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStart": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6408,7 +6408,7 @@ Object {
         "remarks": "If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PostStart is called immediately after a container is created.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStart",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStart",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6433,7 +6433,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartExec",
           },
         },
         Object {
@@ -6452,7 +6452,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
           },
         },
         Object {
@@ -6472,13 +6472,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6487,7 +6487,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6522,8 +6522,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGet": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGet": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6531,7 +6531,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6555,7 +6555,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
           },
         },
         Object {
@@ -6597,7 +6597,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -6645,8 +6645,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6654,7 +6654,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6700,8 +6700,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
@@ -6709,7 +6709,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6732,7 +6732,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -6753,7 +6753,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -6761,8 +6761,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6771,7 +6771,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6795,7 +6795,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
           },
         },
         Object {
@@ -6819,8 +6819,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
@@ -6828,7 +6828,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6851,7 +6851,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -6872,7 +6872,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -6880,8 +6880,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStop": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStop": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6890,7 +6890,7 @@ Object {
         "remarks": "The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStop",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStop",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -6915,7 +6915,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopExec",
           },
         },
         Object {
@@ -6934,7 +6934,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
           },
         },
         Object {
@@ -6954,13 +6954,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -6969,7 +6969,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7004,8 +7004,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGet": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGet": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7013,7 +7013,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7037,7 +7037,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
           },
         },
         Object {
@@ -7079,7 +7079,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -7127,8 +7127,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7136,7 +7136,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7182,8 +7182,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
@@ -7191,7 +7191,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7214,7 +7214,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -7235,7 +7235,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -7243,8 +7243,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7253,7 +7253,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7277,7 +7277,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
           },
         },
         Object {
@@ -7301,8 +7301,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
@@ -7310,7 +7310,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7333,7 +7333,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -7354,7 +7354,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -7362,8 +7362,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbe": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbe": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7372,7 +7372,7 @@ Object {
         "remarks": "Container will be restarted if the probe fails.",
         "summary": "Periodic probe of container liveness.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbe",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7397,7 +7397,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeExec",
           },
         },
         Object {
@@ -7437,7 +7437,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGet",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGet",
           },
         },
         Object {
@@ -7519,7 +7519,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
           },
         },
         Object {
@@ -7545,8 +7545,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7555,7 +7555,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7590,8 +7590,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGet": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGet": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7599,7 +7599,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGet",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7623,7 +7623,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
           },
         },
         Object {
@@ -7665,7 +7665,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -7713,8 +7713,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7722,7 +7722,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7768,8 +7768,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
@@ -7777,7 +7777,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7800,7 +7800,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -7821,7 +7821,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -7829,8 +7829,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocket": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocket": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7839,7 +7839,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7863,7 +7863,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
           },
         },
         Object {
@@ -7887,8 +7887,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
@@ -7896,7 +7896,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -7919,7 +7919,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -7940,7 +7940,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -7948,8 +7948,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersPorts": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersPorts": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -7957,7 +7957,7 @@ Object {
         },
         "summary": "ContainerPort represents a network port in a single container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersPorts",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersPorts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8066,8 +8066,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbe": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbe": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8076,7 +8076,7 @@ Object {
         "remarks": "Container will be removed from service endpoints if the probe fails.",
         "summary": "Periodic probe of container service readiness.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbe",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8101,7 +8101,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeExec",
           },
         },
         Object {
@@ -8141,7 +8141,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGet",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGet",
           },
         },
         Object {
@@ -8223,7 +8223,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
           },
         },
         Object {
@@ -8249,8 +8249,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8259,7 +8259,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8294,8 +8294,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGet": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGet": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8303,7 +8303,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGet",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8327,7 +8327,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
           },
         },
         Object {
@@ -8369,7 +8369,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -8417,8 +8417,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8426,7 +8426,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8472,8 +8472,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
@@ -8481,7 +8481,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8504,7 +8504,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -8525,7 +8525,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -8533,8 +8533,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocket": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocket": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8543,7 +8543,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8567,7 +8567,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
           },
         },
         Object {
@@ -8591,8 +8591,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort": Object {
+      "assembly": "jenkinsiojenkins",
       "docs": Object {
         "custom": Object {
           "schema": "JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
@@ -8600,7 +8600,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8623,7 +8623,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -8644,7 +8644,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
+              "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -8652,8 +8652,8 @@ Object {
       ],
       "name": "JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersResources": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersResources": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8662,7 +8662,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
         "summary": "Compute Resources required by this container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersResources",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8722,8 +8722,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContext": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContext": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8732,7 +8732,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
         "summary": "Security options the pod should run with.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContext",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContext",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -8778,7 +8778,7 @@ Object {
           "name": "capabilities",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextCapabilities",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextCapabilities",
           },
         },
         Object {
@@ -8921,7 +8921,7 @@ Object {
           "name": "seLinuxOptions",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
           },
         },
         Object {
@@ -8941,13 +8941,13 @@ Object {
           "name": "windowsOptions",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextCapabilities": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextCapabilities": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -8957,7 +8957,7 @@ Object {
         "remarks": "Defaults to the default set of capabilities granted by the container runtime.",
         "summary": "The capabilities to add/drop when running containers.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextCapabilities",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextCapabilities",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9015,8 +9015,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9025,7 +9025,7 @@ Object {
         "remarks": "If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The SELinux context to be applied to the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9111,8 +9111,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextWindowsOptions": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextWindowsOptions": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9121,7 +9121,7 @@ Object {
         "remarks": "If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The Windows specific settings applied to all containers.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9191,8 +9191,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersVolumeMounts": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterContainersVolumeMounts": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9200,7 +9200,7 @@ Object {
         },
         "summary": "VolumeMount describes a mounting of a Volume within a container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersVolumeMounts",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterContainersVolumeMounts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9330,8 +9330,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterImagePullSecrets": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterImagePullSecrets": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9339,7 +9339,7 @@ Object {
         },
         "summary": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterImagePullSecrets",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterImagePullSecrets",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9369,8 +9369,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterPlugins": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterPlugins": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9378,7 +9378,7 @@ Object {
         },
         "summary": "Plugin defines Jenkins plugin.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterPlugins",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterPlugins",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9424,8 +9424,8 @@ Object {
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContext": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterSecurityContext": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9435,7 +9435,7 @@ Object {
         "remarks": "As per kubernetes specification, it can be overridden for each container individually. Defaults to: runAsUser: 1000 fsGroup: 1000",
         "summary": "SecurityContext that applies to all the containers of the Jenkins Master.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContext",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContext",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9543,7 +9543,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "seLinuxOptions",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSeLinuxOptions",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSeLinuxOptions",
           },
         },
         Object {
@@ -9590,7 +9590,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSysctls",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSysctls",
               },
               "kind": "array",
             },
@@ -9613,13 +9613,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "windowsOptions",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextWindowsOptions",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextWindowsOptions",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSeLinuxOptions": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSeLinuxOptions": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9628,7 +9628,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
         "summary": "The SELinux context to be applied to all containers.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSeLinuxOptions",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSeLinuxOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9714,8 +9714,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSysctls": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSysctls": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9723,7 +9723,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Sysctl defines a kernel parameter to be set.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSysctls",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextSysctls",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9769,8 +9769,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextWindowsOptions": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterSecurityContextWindowsOptions": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9779,7 +9779,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The Windows specific settings applied to all containers.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextWindowsOptions",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterSecurityContextWindowsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9849,8 +9849,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterTolerations": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterTolerations": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9858,7 +9858,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterTolerations",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterTolerations",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -9969,8 +9969,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumes": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumes": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -9978,7 +9978,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumes",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumes",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -10022,7 +10022,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "awsElasticBlockStore",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAwsElasticBlockStore",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAwsElasticBlockStore",
           },
         },
         Object {
@@ -10041,7 +10041,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "azureDisk",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureDisk",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureDisk",
           },
         },
         Object {
@@ -10060,7 +10060,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "azureFile",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureFile",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureFile",
           },
         },
         Object {
@@ -10079,7 +10079,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "cephfs",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfs",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfs",
           },
         },
         Object {
@@ -10099,7 +10099,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "cinder",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinder",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCinder",
           },
         },
         Object {
@@ -10118,7 +10118,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMap",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMap",
           },
         },
         Object {
@@ -10137,7 +10137,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "csi",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsi",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCsi",
           },
         },
         Object {
@@ -10156,7 +10156,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "downwardAPI",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApi",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApi",
           },
         },
         Object {
@@ -10176,7 +10176,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "emptyDir",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesEmptyDir",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesEmptyDir",
           },
         },
         Object {
@@ -10195,7 +10195,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fc",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFc",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFc",
           },
         },
         Object {
@@ -10214,7 +10214,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "flexVolume",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolume",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolume",
           },
         },
         Object {
@@ -10234,7 +10234,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "flocker",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlocker",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlocker",
           },
         },
         Object {
@@ -10254,7 +10254,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "gcePersistentDisk",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGcePersistentDisk",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGcePersistentDisk",
           },
         },
         Object {
@@ -10274,7 +10274,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "gitRepo",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGitRepo",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGitRepo",
           },
         },
         Object {
@@ -10294,7 +10294,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "glusterfs",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGlusterfs",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGlusterfs",
           },
         },
         Object {
@@ -10314,7 +10314,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "hostPath",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesHostPath",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesHostPath",
           },
         },
         Object {
@@ -10334,7 +10334,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "iscsi",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsi",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsi",
           },
         },
         Object {
@@ -10353,7 +10353,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "nfs",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesNfs",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesNfs",
           },
         },
         Object {
@@ -10373,7 +10373,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "persistentVolumeClaim",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPersistentVolumeClaim",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPersistentVolumeClaim",
           },
         },
         Object {
@@ -10392,7 +10392,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "photonPersistentDisk",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPhotonPersistentDisk",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPhotonPersistentDisk",
           },
         },
         Object {
@@ -10411,7 +10411,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "portworxVolume",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPortworxVolume",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPortworxVolume",
           },
         },
         Object {
@@ -10430,7 +10430,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "projected",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjected",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjected",
           },
         },
         Object {
@@ -10449,7 +10449,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "quobyte",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesQuobyte",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesQuobyte",
           },
         },
         Object {
@@ -10469,7 +10469,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "rbd",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbd",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesRbd",
           },
         },
         Object {
@@ -10488,7 +10488,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "scaleIO",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIo",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIo",
           },
         },
         Object {
@@ -10508,7 +10508,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesSecret",
           },
         },
         Object {
@@ -10527,7 +10527,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "storageos",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageos",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageos",
           },
         },
         Object {
@@ -10546,13 +10546,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "vsphereVolume",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesVsphereVolume",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesVsphereVolume",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAwsElasticBlockStore": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesAwsElasticBlockStore": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -10561,7 +10561,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
         "summary": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAwsElasticBlockStore",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAwsElasticBlockStore",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -10650,8 +10650,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureDisk": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureDisk": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -10659,7 +10659,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureDisk",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -10785,8 +10785,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureFile": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureFile": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -10794,7 +10794,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureFile",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesAzureFile",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -10861,8 +10861,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfs": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfs": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -10870,7 +10870,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfs",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -10977,7 +10977,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfsSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfsSecretRef",
           },
         },
         Object {
@@ -11001,8 +11001,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfsSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfsSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11011,7 +11011,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
         "summary": "Optional: SecretRef is reference to the authentication secret for User, default is empty.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfsSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCephfsSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11041,8 +11041,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinder": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCinder": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11051,7 +11051,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
         "summary": "Cinder represents a cinder volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinder",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCinder",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11135,13 +11135,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinderSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCinderSecretRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinderSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCinderSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11149,7 +11149,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinderSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCinderSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11179,8 +11179,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMap": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMap": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11188,7 +11188,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "ConfigMap represents a configMap that should populate this volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMap",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11236,7 +11236,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMapItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMapItems",
               },
               "kind": "array",
             },
@@ -11283,8 +11283,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMapItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMapItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11292,7 +11292,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMapItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMapItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11359,8 +11359,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsi": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCsi": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11368,7 +11368,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsi",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCsi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11432,7 +11432,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "nodePublishSecretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
           },
         },
         Object {
@@ -11483,8 +11483,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsiNodePublishSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesCsiNodePublishSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11493,7 +11493,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
         "summary": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11523,8 +11523,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApi": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApi": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11532,7 +11532,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPI represents downward API about the pod that should populate this volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApi",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11579,7 +11579,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItems",
               },
               "kind": "array",
             },
@@ -11587,8 +11587,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11596,7 +11596,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPIVolumeFile represents information to create the file containing the pod field.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11639,7 +11639,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
           },
         },
         Object {
@@ -11678,13 +11678,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11692,7 +11692,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11739,8 +11739,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11748,7 +11748,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11814,8 +11814,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesEmptyDir": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesEmptyDir": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11824,7 +11824,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
         "summary": "EmptyDir represents a temporary directory that shares a pod's lifetime.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesEmptyDir",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesEmptyDir",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -11874,8 +11874,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFc": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesFc": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -11883,7 +11883,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFc",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFc",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12001,8 +12001,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolume": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolume": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12010,7 +12010,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolume",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12118,13 +12118,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolumeSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolumeSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12133,7 +12133,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
         "summary": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12163,8 +12163,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlocker": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesFlocker": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12173,7 +12173,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This depends on the Flocker control service being running",
         "summary": "Flocker represents a Flocker volume attached to a kubelet's host machine.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlocker",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesFlocker",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12222,8 +12222,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGcePersistentDisk": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesGcePersistentDisk": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12232,7 +12232,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
         "summary": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGcePersistentDisk",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGcePersistentDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12322,8 +12322,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGitRepo": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesGitRepo": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12332,7 +12332,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "summary": "GitRepo represents a git repository at a particular revision.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGitRepo",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGitRepo",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12399,8 +12399,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGlusterfs": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesGlusterfs": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12409,7 +12409,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/glusterfs/README.md",
         "summary": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGlusterfs",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesGlusterfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12478,8 +12478,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesHostPath": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesHostPath": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12488,7 +12488,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
         "summary": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesHostPath",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesHostPath",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12537,8 +12537,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsi": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsi": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12547,7 +12547,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/iscsi/README.md",
         "summary": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsi",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12771,13 +12771,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsiSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsiSecretRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsiSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsiSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12785,7 +12785,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CHAP Secret for iSCSI target and initiator authentication.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsiSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesIscsiSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12815,8 +12815,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesNfs": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesNfs": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12824,7 +12824,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesNfs",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesNfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12893,8 +12893,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPersistentVolumeClaim": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesPersistentVolumeClaim": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12903,7 +12903,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPersistentVolumeClaim",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPersistentVolumeClaim",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -12952,8 +12952,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPhotonPersistentDisk": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesPhotonPersistentDisk": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -12961,7 +12961,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPhotonPersistentDisk",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPhotonPersistentDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13009,8 +13009,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPortworxVolume": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesPortworxVolume": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13018,7 +13018,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPortworxVolume",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesPortworxVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13087,8 +13087,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjected": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjected": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13096,7 +13096,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Items for all in one resources secrets, configmaps, and downward API.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjected",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjected",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13121,7 +13121,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSources",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSources",
               },
               "kind": "array",
             },
@@ -13149,8 +13149,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSources": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSources": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13158,7 +13158,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Projection that may be projected along with other supported volume types.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSources",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13182,7 +13182,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
           },
         },
         Object {
@@ -13201,7 +13201,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "downwardAPI",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
           },
         },
         Object {
@@ -13220,7 +13220,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecret",
           },
         },
         Object {
@@ -13239,13 +13239,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "serviceAccountToken",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMap": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMap": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13253,7 +13253,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the configMap data to project.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13280,7 +13280,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
               },
               "kind": "array",
             },
@@ -13327,8 +13327,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13336,7 +13336,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13403,8 +13403,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13412,7 +13412,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the downwardAPI data to project.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13438,7 +13438,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
               },
               "kind": "array",
             },
@@ -13446,8 +13446,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13455,7 +13455,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPIVolumeFile represents information to create the file containing the pod field.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13498,7 +13498,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
           },
         },
         Object {
@@ -13537,13 +13537,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13551,7 +13551,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13598,8 +13598,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13607,7 +13607,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13673,8 +13673,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13682,7 +13682,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the secret data to project.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13709,7 +13709,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
               },
               "kind": "array",
             },
@@ -13756,8 +13756,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecretItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecretItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13765,7 +13765,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13832,8 +13832,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13841,7 +13841,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the serviceAccountToken data to project.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -13910,8 +13910,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesQuobyte": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesQuobyte": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -13919,7 +13919,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesQuobyte",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesQuobyte",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14045,8 +14045,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbd": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesRbd": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14055,7 +14055,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/rbd/README.md",
         "summary": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbd",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesRbd",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14207,7 +14207,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbdSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesRbdSecretRef",
           },
         },
         Object {
@@ -14233,8 +14233,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbdSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesRbdSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14244,7 +14244,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
         "summary": "SecretRef is name of the authentication secret for RBDUser.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbdSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesRbdSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14274,8 +14274,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIo": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIo": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14283,7 +14283,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIo",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIo",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14325,7 +14325,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secretRef",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIoSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIoSecretRef",
           },
         },
         Object {
@@ -14487,8 +14487,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIoSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIoSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14497,7 +14497,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If this is not provided, Login operation will fail.",
         "summary": "SecretRef references to the secret for ScaleIO user and other sensitive information.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIoSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIoSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14527,8 +14527,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14537,7 +14537,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
         "summary": "Secret represents a secret that should populate this volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14585,7 +14585,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecretItems",
+                "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesSecretItems",
               },
               "kind": "array",
             },
@@ -14632,8 +14632,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecretItems": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesSecretItems": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14641,7 +14641,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecretItems",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesSecretItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14708,8 +14708,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageos": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageos": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14717,7 +14717,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageos",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageos",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14783,7 +14783,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageosSecretRef",
+            "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageosSecretRef",
           },
         },
         Object {
@@ -14828,8 +14828,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageosSecretRef": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageosSecretRef": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14838,7 +14838,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If not specified, default values will be attempted.",
         "summary": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageosSecretRef",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesStorageosSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14868,8 +14868,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesVsphereVolume": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecMasterVolumesVsphereVolume": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14877,7 +14877,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesVsphereVolume",
+      "fqn": "jenkinsiojenkins.JenkinsSpecMasterVolumesVsphereVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -14963,8 +14963,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotifications": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotifications": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -14972,7 +14972,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Notification is a service configuration used to send notifications about Jenkins status.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotifications",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotifications",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15048,7 +15048,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "mailgun",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgun",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgun",
           },
         },
         Object {
@@ -15067,7 +15067,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "slack",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlack",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlack",
           },
         },
         Object {
@@ -15086,7 +15086,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "smtp",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtp",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtp",
           },
         },
         Object {
@@ -15105,13 +15105,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "teams",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeams",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeams",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgun": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsMailgun": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15119,7 +15119,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Mailgun is handler for Mailgun email service notification channel.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgun",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgun",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15142,7 +15142,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "apiKeySecretKeySelector",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
           },
         },
         Object {
@@ -15198,8 +15198,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15207,7 +15207,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "SecretKeySelector selects a key of a Secret.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15249,13 +15249,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15263,7 +15263,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The name of the secret in the pod's namespace to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15293,8 +15293,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlack": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSlack": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15302,7 +15302,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Slack is handler for Slack notification channel.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlack",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlack",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15325,13 +15325,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "webHookURLSecretKeySelector",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15339,7 +15339,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The web hook URL to Slack App.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15381,13 +15381,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15395,7 +15395,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The name of the secret in the pod's namespace to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15425,8 +15425,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtp": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSmtp": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15434,7 +15434,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "SMTP is handler for sending emails via this protocol.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtp",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtp",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15474,7 +15474,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "passwordSecretKeySelector",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
           },
         },
         Object {
@@ -15543,7 +15543,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "usernameSecretKeySelector",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
           },
         },
         Object {
@@ -15566,8 +15566,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15575,7 +15575,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "SecretKeySelector selects a key of a Secret.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15617,13 +15617,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15631,7 +15631,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The name of the secret in the pod's namespace to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15661,8 +15661,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15670,7 +15670,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "SecretKeySelector selects a key of a Secret.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15712,13 +15712,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15726,7 +15726,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The name of the secret in the pod's namespace to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15756,8 +15756,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeams": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsTeams": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15765,7 +15765,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "MicrosoftTeams is handler for Microsoft MicrosoftTeams notification channel.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeams",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeams",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15788,13 +15788,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "webHookURLSecretKeySelector",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15802,7 +15802,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The web hook URL to MicrosoftTeams App.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15844,13 +15844,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secret",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
+            "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15858,7 +15858,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The name of the secret in the pod's namespace to select from.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
+      "fqn": "jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15888,8 +15888,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestore": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecRestore": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15897,7 +15897,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Backup defines configuration of Jenkins backup restore More info: https://github.com/jenkinsci/kubernetes-operator/blob/master/docs/getting-started.md#configure-backup-and-restore.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestore",
+      "fqn": "jenkinsiojenkins.JenkinsSpecRestore",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15920,7 +15920,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "action",
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreAction",
+            "fqn": "jenkinsiojenkins.JenkinsSpecRestoreAction",
           },
         },
         Object {
@@ -15962,8 +15962,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreAction": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecRestoreAction": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -15971,7 +15971,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Action defines action which performs restore backup in restore container sidecar.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreAction",
+      "fqn": "jenkinsiojenkins.JenkinsSpecRestoreAction",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -15995,13 +15995,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreActionExec",
+            "fqn": "jenkinsiojenkins.JenkinsSpecRestoreActionExec",
           },
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreActionExec": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecRestoreActionExec": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16009,7 +16009,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Exec specifies the action to take.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreActionExec",
+      "fqn": "jenkinsiojenkins.JenkinsSpecRestoreActionExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16044,8 +16044,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRoles": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecRoles": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16053,7 +16053,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "RoleRef contains information that points to the role being used.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRoles",
+      "fqn": "jenkinsiojenkins.JenkinsSpecRoles",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16117,8 +16117,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSeedJobs": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecSeedJobs": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16126,7 +16126,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "SeedJob defines configuration for seed job More info: https://github.com/jenkinsci/kubernetes-operator/blob/master/docs/getting-started.md#configure-seed-jobs-and-pipelines.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSeedJobs",
+      "fqn": "jenkinsiojenkins.JenkinsSpecSeedJobs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16422,8 +16422,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecService": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecService": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16432,7 +16432,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "default": "port: 8080 type: ClusterIP",
         "summary": "Service is Kubernetes service of Jenkins master HTTP pod Defaults to : port: 8080 type: ClusterIP.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecService",
+      "fqn": "jenkinsiojenkins.JenkinsSpecService",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16599,8 +16599,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecServiceAccount": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecServiceAccount": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16608,7 +16608,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "ServiceAccount defines Jenkins master service account attributes.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecServiceAccount",
+      "fqn": "jenkinsiojenkins.JenkinsSpecServiceAccount",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16643,8 +16643,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSlaveService": Object {
-      "assembly": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
+    "jenkinsiojenkins.JenkinsSpecSlaveService": Object {
+      "assembly": "jenkinsiojenkins",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -16653,7 +16653,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "default": "port: 50000 type: ClusterIP",
         "summary": "Service is Kubernetes service of Jenkins slave pods Defaults to : port: 50000 type: ClusterIP.",
       },
-      "fqn": "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSlaveService",
+      "fqn": "jenkinsiojenkins.JenkinsSpecSlaveService",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "jenkins.io/jenkins.ts",
@@ -16883,12 +16883,12 @@ Object {
       },
     },
   },
-  "description": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+  "description": "stableexamplecomcrontab",
   "fingerprint": "<fingerprint>",
   "homepage": "http://generated",
   "jsiiVersion": "1.5.0 (build 46538f8)",
   "license": "Apache-2.0",
-  "name": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+  "name": "stableexamplecomcrontab",
   "repository": Object {
     "type": "git",
     "url": "http://generated",
@@ -16896,19 +16896,19 @@ Object {
   "schema": "jsii/0.10.0",
   "targets": Object {
     "js": Object {
-      "npm": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+      "npm": "stableexamplecomcrontab",
     },
   },
   "types": Object {
-    "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTab": Object {
-      "assembly": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+    "stableexamplecomcrontab.CronTab": Object {
+      "assembly": "stableexamplecomcrontab",
       "base": "cdk8s.ApiObject",
       "docs": Object {
         "custom": Object {
           "schema": "CronTab",
         },
       },
-      "fqn": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTab",
+      "fqn": "stableexamplecomcrontab.CronTab",
       "initializer": Object {
         "docs": Object {
           "summary": "Defines a \\"CronTab\\" API object.",
@@ -16939,7 +16939,7 @@ Object {
             "name": "options",
             "optional": true,
             "type": Object {
-              "fqn": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabOptions",
+              "fqn": "stableexamplecomcrontab.CronTabOptions",
             },
           },
         ],
@@ -16951,15 +16951,15 @@ Object {
       },
       "name": "CronTab",
     },
-    "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabOptions": Object {
-      "assembly": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+    "stableexamplecomcrontab.CronTabOptions": Object {
+      "assembly": "stableexamplecomcrontab",
       "datatype": true,
       "docs": Object {
         "custom": Object {
           "schema": "CronTab",
         },
       },
-      "fqn": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabOptions",
+      "fqn": "stableexamplecomcrontab.CronTabOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "stable.example.com/crontab.ts",
@@ -16982,20 +16982,20 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabSpec",
+            "fqn": "stableexamplecomcrontab.CronTabSpec",
           },
         },
       ],
     },
-    "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabSpec": Object {
-      "assembly": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+    "stableexamplecomcrontab.CronTabSpec": Object {
+      "assembly": "stableexamplecomcrontab",
       "datatype": true,
       "docs": Object {
         "custom": Object {
           "schema": "CronTabSpec",
         },
       },
-      "fqn": "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabSpec",
+      "fqn": "stableexamplecomcrontab.CronTabSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "stable.example.com/crontab.ts",
@@ -17122,12 +17122,12 @@ Object {
       },
     },
   },
-  "description": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+  "description": "stableexamplecomothercrontab",
   "fingerprint": "<fingerprint>",
   "homepage": "http://generated",
   "jsiiVersion": "1.5.0 (build 46538f8)",
   "license": "Apache-2.0",
-  "name": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+  "name": "stableexamplecomothercrontab",
   "repository": Object {
     "type": "git",
     "url": "http://generated",
@@ -17135,19 +17135,19 @@ Object {
   "schema": "jsii/0.10.0",
   "targets": Object {
     "js": Object {
-      "npm": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+      "npm": "stableexamplecomothercrontab",
     },
   },
   "types": Object {
-    "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTab": Object {
-      "assembly": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+    "stableexamplecomothercrontab.OtherCronTab": Object {
+      "assembly": "stableexamplecomothercrontab",
       "base": "cdk8s.ApiObject",
       "docs": Object {
         "custom": Object {
           "schema": "OtherCronTab",
         },
       },
-      "fqn": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTab",
+      "fqn": "stableexamplecomothercrontab.OtherCronTab",
       "initializer": Object {
         "docs": Object {
           "summary": "Defines a \\"OtherCronTab\\" API object.",
@@ -17178,7 +17178,7 @@ Object {
             "name": "options",
             "optional": true,
             "type": Object {
-              "fqn": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabOptions",
+              "fqn": "stableexamplecomothercrontab.OtherCronTabOptions",
             },
           },
         ],
@@ -17190,15 +17190,15 @@ Object {
       },
       "name": "OtherCronTab",
     },
-    "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabOptions": Object {
-      "assembly": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+    "stableexamplecomothercrontab.OtherCronTabOptions": Object {
+      "assembly": "stableexamplecomothercrontab",
       "datatype": true,
       "docs": Object {
         "custom": Object {
           "schema": "OtherCronTab",
         },
       },
-      "fqn": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabOptions",
+      "fqn": "stableexamplecomothercrontab.OtherCronTabOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "stable.example.com/othercrontab.ts",
@@ -17221,20 +17221,20 @@ Object {
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabSpec",
+            "fqn": "stableexamplecomothercrontab.OtherCronTabSpec",
           },
         },
       ],
     },
-    "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabSpec": Object {
-      "assembly": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9",
+    "stableexamplecomothercrontab.OtherCronTabSpec": Object {
+      "assembly": "stableexamplecomothercrontab",
       "datatype": true,
       "docs": Object {
         "custom": Object {
           "schema": "OtherCronTabSpec",
         },
       },
-      "fqn": "02934bed4c684833bdc8518251976f531359640e9babbf41b831b8224f2897e9.OtherCronTabSpec",
+      "fqn": "stableexamplecomothercrontab.OtherCronTabSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "stable.example.com/othercrontab.ts",
@@ -17361,12 +17361,12 @@ Object {
       },
     },
   },
-  "description": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+  "description": "monitoringcoreoscomthanosruler",
   "fingerprint": "<fingerprint>",
   "homepage": "http://generated",
   "jsiiVersion": "1.5.0 (build 46538f8)",
   "license": "Apache-2.0",
-  "name": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+  "name": "monitoringcoreoscomthanosruler",
   "repository": Object {
     "type": "git",
     "url": "http://generated",
@@ -17374,12 +17374,12 @@ Object {
   "schema": "jsii/0.10.0",
   "targets": Object {
     "js": Object {
-      "npm": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+      "npm": "monitoringcoreoscomthanosruler",
     },
   },
   "types": Object {
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRuler": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRuler": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "base": "cdk8s.ApiObject",
       "docs": Object {
         "custom": Object {
@@ -17387,7 +17387,7 @@ Object {
         },
         "summary": "ThanosRuler defines a ThanosRuler deployment.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRuler",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRuler",
       "initializer": Object {
         "docs": Object {
           "summary": "Defines a \\"ThanosRuler\\" API object.",
@@ -17417,7 +17417,7 @@ Object {
             },
             "name": "options",
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerOptions",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerOptions",
             },
           },
         ],
@@ -17429,8 +17429,8 @@ Object {
       },
       "name": "ThanosRuler",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -17438,7 +17438,7 @@ Object {
         },
         "summary": "ThanosRuler defines a ThanosRuler deployment.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -17462,7 +17462,7 @@ Object {
           },
           "name": "spec",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpec",
           },
         },
         Object {
@@ -17485,8 +17485,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -17495,7 +17495,7 @@ Object {
         "remarks": "More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
         "summary": "Specification of the desired behavior of the ThanosRuler cluster.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -17519,7 +17519,7 @@ Object {
           "name": "affinity",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinity",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinity",
           },
         },
         Object {
@@ -17564,7 +17564,7 @@ Object {
           "name": "alertmanagersConfig",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAlertmanagersConfig",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAlertmanagersConfig",
           },
         },
         Object {
@@ -17631,7 +17631,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainers",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainers",
               },
               "kind": "array",
             },
@@ -17713,7 +17713,7 @@ Object {
           "name": "grpcServerTlsConfig",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfig",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfig",
           },
         },
         Object {
@@ -17753,7 +17753,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecImagePullSecrets",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecImagePullSecrets",
               },
               "kind": "array",
             },
@@ -17778,7 +17778,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainers",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainers",
               },
               "kind": "array",
             },
@@ -17906,7 +17906,7 @@ Object {
           "name": "objectStorageConfig",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecObjectStorageConfig",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecObjectStorageConfig",
           },
         },
         Object {
@@ -17944,7 +17944,7 @@ Object {
           "name": "podMetadata",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecPodMetadata",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecPodMetadata",
           },
         },
         Object {
@@ -18003,7 +18003,7 @@ Object {
           "name": "queryConfig",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecQueryConfig",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecQueryConfig",
           },
         },
         Object {
@@ -18067,7 +18067,7 @@ Object {
           "name": "resources",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecResources",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecResources",
           },
         },
         Object {
@@ -18128,7 +18128,7 @@ Object {
           "name": "ruleNamespaceSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelector",
           },
         },
         Object {
@@ -18147,7 +18147,7 @@ Object {
           "name": "ruleSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelector",
           },
         },
         Object {
@@ -18167,7 +18167,7 @@ Object {
           "name": "securityContext",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContext",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContext",
           },
         },
         Object {
@@ -18205,7 +18205,7 @@ Object {
           "name": "storage",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorage",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorage",
           },
         },
         Object {
@@ -18226,7 +18226,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTolerations",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecTolerations",
               },
               "kind": "array",
             },
@@ -18249,7 +18249,7 @@ Object {
           "name": "tracingConfig",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTracingConfig",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecTracingConfig",
           },
         },
         Object {
@@ -18271,7 +18271,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumes",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumes",
               },
               "kind": "array",
             },
@@ -18279,8 +18279,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinity": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinity": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18288,7 +18288,7 @@ Object {
         },
         "summary": "If specified, the pod's scheduling constraints.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinity",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinity",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18312,7 +18312,7 @@ Object {
           "name": "nodeAffinity",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinity",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinity",
           },
         },
         Object {
@@ -18331,7 +18331,7 @@ Object {
           "name": "podAffinity",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinity",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinity",
           },
         },
         Object {
@@ -18350,13 +18350,13 @@ Object {
           "name": "podAntiAffinity",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinity",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinity",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinity": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinity": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18364,7 +18364,7 @@ Object {
         },
         "summary": "Describes node affinity scheduling rules for the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinity",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinity",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18391,7 +18391,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
               },
               "kind": "array",
             },
@@ -18414,13 +18414,13 @@ Object {
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18428,7 +18428,7 @@ Object {
         },
         "summary": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18451,7 +18451,7 @@ Object {
           },
           "name": "preference",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
           },
         },
         Object {
@@ -18474,8 +18474,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18483,7 +18483,7 @@ Object {
         },
         "summary": "A node selector term, associated with the corresponding weight.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18509,7 +18509,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
               },
               "kind": "array",
             },
@@ -18533,7 +18533,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
               },
               "kind": "array",
             },
@@ -18541,8 +18541,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18550,7 +18550,7 @@ Object {
         },
         "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18622,8 +18622,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18631,7 +18631,7 @@ Object {
         },
         "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18703,8 +18703,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18713,7 +18713,7 @@ Object {
         "remarks": "If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
         "summary": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18739,7 +18739,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
               },
               "kind": "array",
             },
@@ -18747,8 +18747,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18757,7 +18757,7 @@ Object {
         "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
         "summary": "A null or empty node selector term matches no objects.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18783,7 +18783,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
               },
               "kind": "array",
             },
@@ -18807,7 +18807,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
               },
               "kind": "array",
             },
@@ -18815,8 +18815,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18824,7 +18824,7 @@ Object {
         },
         "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18896,8 +18896,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18905,7 +18905,7 @@ Object {
         },
         "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -18977,8 +18977,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinity": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinity": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -18986,7 +18986,7 @@ Object {
         },
         "summary": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinity",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinity",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19013,7 +19013,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
               },
               "kind": "array",
             },
@@ -19038,7 +19038,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
               },
               "kind": "array",
             },
@@ -19046,8 +19046,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19055,7 +19055,7 @@ Object {
         },
         "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19079,7 +19079,7 @@ Object {
           },
           "name": "podAffinityTerm",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
           },
         },
         Object {
@@ -19102,8 +19102,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19112,7 +19112,7 @@ Object {
         "remarks": "A pod affinity term, associated with the corresponding weight.",
         "summary": "Required.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19155,7 +19155,7 @@ Object {
           "name": "labelSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
           },
         },
         Object {
@@ -19185,8 +19185,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19194,7 +19194,7 @@ Object {
         },
         "summary": "A label query over a set of resources, in this case pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19221,7 +19221,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -19254,8 +19254,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19263,7 +19263,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19335,8 +19335,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19344,7 +19344,7 @@ Object {
         },
         "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19387,7 +19387,7 @@ Object {
           "name": "labelSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
           },
         },
         Object {
@@ -19417,8 +19417,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19426,7 +19426,7 @@ Object {
         },
         "summary": "A label query over a set of resources, in this case pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19453,7 +19453,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -19486,8 +19486,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19495,7 +19495,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19567,8 +19567,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinity": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinity": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19576,7 +19576,7 @@ Object {
         },
         "summary": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinity",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinity",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19603,7 +19603,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
               },
               "kind": "array",
             },
@@ -19628,7 +19628,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
               },
               "kind": "array",
             },
@@ -19636,8 +19636,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19645,7 +19645,7 @@ Object {
         },
         "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19669,7 +19669,7 @@ Object {
           },
           "name": "podAffinityTerm",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
           },
         },
         Object {
@@ -19692,8 +19692,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19702,7 +19702,7 @@ Object {
         "remarks": "A pod affinity term, associated with the corresponding weight.",
         "summary": "Required.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19745,7 +19745,7 @@ Object {
           "name": "labelSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
           },
         },
         Object {
@@ -19775,8 +19775,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19784,7 +19784,7 @@ Object {
         },
         "summary": "A label query over a set of resources, in this case pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19811,7 +19811,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -19844,8 +19844,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19853,7 +19853,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19925,8 +19925,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -19934,7 +19934,7 @@ Object {
         },
         "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -19977,7 +19977,7 @@ Object {
           "name": "labelSelector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
           },
         },
         Object {
@@ -20007,8 +20007,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20016,7 +20016,7 @@ Object {
         },
         "summary": "A label query over a set of resources, in this case pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20043,7 +20043,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -20076,8 +20076,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20085,7 +20085,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20157,8 +20157,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAlertmanagersConfig": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecAlertmanagersConfig": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20167,7 +20167,7 @@ Object {
         "remarks": "Only available with thanos v0.10.0 and higher.  Maps to the \`alertmanagers.config\` arg.",
         "summary": "Define configuration for connecting to alertmanager.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecAlertmanagersConfig",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecAlertmanagersConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20235,8 +20235,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainers": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainers": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20244,7 +20244,7 @@ Object {
         },
         "summary": "A single application container that you want to run within a pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainers",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainers",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20340,7 +20340,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnv",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnv",
               },
               "kind": "array",
             },
@@ -20365,7 +20365,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFrom",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFrom",
               },
               "kind": "array",
             },
@@ -20429,7 +20429,7 @@ Object {
           "name": "lifecycle",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecycle",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecycle",
           },
         },
         Object {
@@ -20449,7 +20449,7 @@ Object {
           "name": "livenessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbe",
           },
         },
         Object {
@@ -20471,7 +20471,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersPorts",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersPorts",
               },
               "kind": "array",
             },
@@ -20494,7 +20494,7 @@ Object {
           "name": "readinessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbe",
           },
         },
         Object {
@@ -20514,7 +20514,7 @@ Object {
           "name": "resources",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersResources",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersResources",
           },
         },
         Object {
@@ -20534,7 +20534,7 @@ Object {
           "name": "securityContext",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContext",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContext",
           },
         },
         Object {
@@ -20554,7 +20554,7 @@ Object {
           "name": "startupProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbe",
           },
         },
         Object {
@@ -20680,7 +20680,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeDevices",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeDevices",
               },
               "kind": "array",
             },
@@ -20705,7 +20705,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeMounts",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeMounts",
               },
               "kind": "array",
             },
@@ -20733,8 +20733,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnv": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnv": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20742,7 +20742,7 @@ Object {
         },
         "summary": "EnvVar represents an environment variable present in a Container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnv",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnv",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20807,13 +20807,13 @@ Object {
           "name": "valueFrom",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFrom",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFrom",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFrom": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFrom": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20821,7 +20821,7 @@ Object {
         },
         "summary": "EnvFromSource represents the source of a set of ConfigMaps.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFrom",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20845,7 +20845,7 @@ Object {
           "name": "configMapRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromConfigMapRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromConfigMapRef",
           },
         },
         Object {
@@ -20884,13 +20884,13 @@ Object {
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromSecretRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromConfigMapRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromConfigMapRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20898,7 +20898,7 @@ Object {
         },
         "summary": "The ConfigMap to select from.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromConfigMapRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromConfigMapRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -20947,8 +20947,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -20956,7 +20956,7 @@ Object {
         },
         "summary": "The Secret to select from.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvFromSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvFromSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21005,8 +21005,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFrom": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFrom": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21015,7 +21015,7 @@ Object {
         "remarks": "Cannot be used if value is not empty.",
         "summary": "Source for the environment variable's value.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFrom",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21039,7 +21039,7 @@ Object {
           "name": "configMapKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef",
           },
         },
         Object {
@@ -21058,7 +21058,7 @@ Object {
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromFieldRef",
           },
         },
         Object {
@@ -21077,7 +21077,7 @@ Object {
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromResourceFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromResourceFieldRef",
           },
         },
         Object {
@@ -21096,13 +21096,13 @@ Object {
           "name": "secretKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromSecretKeyRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromSecretKeyRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21110,7 +21110,7 @@ Object {
         },
         "summary": "Selects a key of a ConfigMap.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromConfigMapKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21177,8 +21177,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21186,7 +21186,7 @@ Object {
         },
         "summary": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21233,8 +21233,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromResourceFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromResourceFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21242,7 +21242,7 @@ Object {
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromResourceFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21308,8 +21308,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromSecretKeyRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromSecretKeyRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21317,7 +21317,7 @@ Object {
         },
         "summary": "Selects a key of a secret in the pod's namespace.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersEnvValueFromSecretKeyRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersEnvValueFromSecretKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21385,8 +21385,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecycle": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecycle": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21395,7 +21395,7 @@ Object {
         "remarks": "Cannot be updated.",
         "summary": "Actions that the management system should take in response to container lifecycle events.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecycle",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecycle",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21420,7 +21420,7 @@ Object {
           "name": "postStart",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStart",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStart",
           },
         },
         Object {
@@ -21440,13 +21440,13 @@ Object {
           "name": "preStop",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStop",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStop",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStart": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStart": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21455,7 +21455,7 @@ Object {
         "remarks": "If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PostStart is called immediately after a container is created.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStart",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStart",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21480,7 +21480,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartExec",
           },
         },
         Object {
@@ -21499,7 +21499,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGet",
           },
         },
         Object {
@@ -21519,13 +21519,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocket",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21534,7 +21534,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21569,8 +21569,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21578,7 +21578,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21602,7 +21602,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
           },
         },
         Object {
@@ -21644,7 +21644,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -21692,8 +21692,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21701,7 +21701,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21747,8 +21747,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
@@ -21756,7 +21756,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21779,7 +21779,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -21800,7 +21800,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -21808,8 +21808,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLifecyclePostStartHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21818,7 +21818,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21842,7 +21842,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
           },
         },
         Object {
@@ -21866,8 +21866,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
@@ -21875,7 +21875,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21898,7 +21898,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -21919,7 +21919,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -21927,8 +21927,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLifecyclePostStartTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStop": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStop": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -21937,7 +21937,7 @@ Object {
         "remarks": "The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStop",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStop",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -21962,7 +21962,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopExec",
           },
         },
         Object {
@@ -21981,7 +21981,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGet",
           },
         },
         Object {
@@ -22001,13 +22001,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocket",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22016,7 +22016,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22051,8 +22051,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22060,7 +22060,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22084,7 +22084,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
           },
         },
         Object {
@@ -22126,7 +22126,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -22174,8 +22174,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22183,7 +22183,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22229,8 +22229,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
@@ -22238,7 +22238,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22261,7 +22261,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -22282,7 +22282,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -22290,8 +22290,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLifecyclePreStopHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22300,7 +22300,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22324,7 +22324,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
           },
         },
         Object {
@@ -22348,8 +22348,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
@@ -22357,7 +22357,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22380,7 +22380,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -22401,7 +22401,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -22409,8 +22409,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLifecyclePreStopTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22419,7 +22419,7 @@ Object {
         "remarks": "Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "Periodic probe of container liveness.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22444,7 +22444,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeExec",
           },
         },
         Object {
@@ -22484,7 +22484,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGet",
           },
         },
         Object {
@@ -22566,7 +22566,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocket",
           },
         },
         Object {
@@ -22592,8 +22592,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22602,7 +22602,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22637,8 +22637,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22646,7 +22646,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22670,7 +22670,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
           },
         },
         Object {
@@ -22712,7 +22712,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -22760,8 +22760,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22769,7 +22769,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22815,8 +22815,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLivenessProbeHttpGetPort",
@@ -22824,7 +22824,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22847,7 +22847,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -22868,7 +22868,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -22876,8 +22876,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLivenessProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -22886,7 +22886,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22910,7 +22910,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
           },
         },
         Object {
@@ -22934,8 +22934,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
@@ -22943,7 +22943,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -22966,7 +22966,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -22987,7 +22987,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -22995,8 +22995,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersLivenessProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersPorts": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersPorts": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23004,7 +23004,7 @@ Object {
         },
         "summary": "ContainerPort represents a network port in a single container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersPorts",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersPorts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23113,8 +23113,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23123,7 +23123,7 @@ Object {
         "remarks": "Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "Periodic probe of container service readiness.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23148,7 +23148,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeExec",
           },
         },
         Object {
@@ -23188,7 +23188,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGet",
           },
         },
         Object {
@@ -23270,7 +23270,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocket",
           },
         },
         Object {
@@ -23296,8 +23296,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23306,7 +23306,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23341,8 +23341,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23350,7 +23350,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23374,7 +23374,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
           },
         },
         Object {
@@ -23416,7 +23416,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -23464,8 +23464,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23473,7 +23473,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23519,8 +23519,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersReadinessProbeHttpGetPort",
@@ -23528,7 +23528,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23551,7 +23551,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -23572,7 +23572,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -23580,8 +23580,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersReadinessProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23590,7 +23590,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23614,7 +23614,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
           },
         },
         Object {
@@ -23638,8 +23638,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
@@ -23647,7 +23647,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23670,7 +23670,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -23691,7 +23691,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -23699,8 +23699,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersReadinessProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersResources": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersResources": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23709,7 +23709,7 @@ Object {
         "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
         "summary": "Compute Resources required by this container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersResources",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23769,8 +23769,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContext": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContext": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -23779,7 +23779,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
         "summary": "Security options the pod should run with.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContext",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContext",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -23825,7 +23825,7 @@ Object {
           "name": "capabilities",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextCapabilities",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextCapabilities",
           },
         },
         Object {
@@ -23968,7 +23968,7 @@ Object {
           "name": "seLinuxOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextSeLinuxOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextSeLinuxOptions",
           },
         },
         Object {
@@ -23988,13 +23988,13 @@ Object {
           "name": "windowsOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextWindowsOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextWindowsOptions",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextCapabilities": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextCapabilities": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24004,7 +24004,7 @@ Object {
         "remarks": "Defaults to the default set of capabilities granted by the container runtime.",
         "summary": "The capabilities to add/drop when running containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextCapabilities",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextCapabilities",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24062,8 +24062,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextSeLinuxOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextSeLinuxOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24072,7 +24072,7 @@ Object {
         "remarks": "If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The SELinux context to be applied to the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextSeLinuxOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextSeLinuxOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24158,8 +24158,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextWindowsOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextWindowsOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24168,7 +24168,7 @@ Object {
         "remarks": "If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The Windows specific settings applied to all containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersSecurityContextWindowsOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersSecurityContextWindowsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24237,8 +24237,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24247,7 +24247,7 @@ Object {
         "remarks": "If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "StartupProbe indicates that the Pod has successfully initialized.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24272,7 +24272,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeExec",
           },
         },
         Object {
@@ -24312,7 +24312,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGet",
           },
         },
         Object {
@@ -24394,7 +24394,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocket",
           },
         },
         Object {
@@ -24420,8 +24420,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24430,7 +24430,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24465,8 +24465,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24474,7 +24474,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24498,7 +24498,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetPort",
           },
         },
         Object {
@@ -24540,7 +24540,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -24588,8 +24588,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24597,7 +24597,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24643,8 +24643,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersStartupProbeHttpGetPort",
@@ -24652,7 +24652,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24675,7 +24675,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetPort",
             },
           },
           "static": true,
@@ -24696,7 +24696,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeHttpGetPort",
             },
           },
           "static": true,
@@ -24704,8 +24704,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersStartupProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24714,7 +24714,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24738,7 +24738,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
           },
         },
         Object {
@@ -24762,8 +24762,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecContainersStartupProbeTcpSocketPort",
@@ -24771,7 +24771,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24794,7 +24794,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -24815,7 +24815,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersStartupProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -24823,8 +24823,8 @@ Object {
       ],
       "name": "ThanosRulerSpecContainersStartupProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeDevices": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeDevices": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24832,7 +24832,7 @@ Object {
         },
         "summary": "volumeDevice describes a mapping of a raw block device within a container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeDevices",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeDevices",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -24878,8 +24878,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeMounts": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeMounts": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -24887,7 +24887,7 @@ Object {
         },
         "summary": "VolumeMount describes a mounting of a Volume within a container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecContainersVolumeMounts",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecContainersVolumeMounts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25017,8 +25017,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfig": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfig": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25027,7 +25027,7 @@ Object {
         "remarks": "Note: Currently only the CAFile, CertFile, and KeyFile fields are supported. Maps to the '--grpc-server-tls-*' CLI args.",
         "summary": "GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads recorded rule data.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfig",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25051,7 +25051,7 @@ Object {
           "name": "ca",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCa",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCa",
           },
         },
         Object {
@@ -25089,7 +25089,7 @@ Object {
           "name": "cert",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCert",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCert",
           },
         },
         Object {
@@ -25165,7 +25165,7 @@ Object {
           "name": "keySecret",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigKeySecret",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigKeySecret",
           },
         },
         Object {
@@ -25189,8 +25189,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCa": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCa": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25198,7 +25198,7 @@ Object {
         },
         "summary": "Stuct containing the CA cert to use for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCa",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCa",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25222,7 +25222,7 @@ Object {
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap",
           },
         },
         Object {
@@ -25241,13 +25241,13 @@ Object {
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaSecret",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaSecret",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25255,7 +25255,7 @@ Object {
         },
         "summary": "ConfigMap containing data to use for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25322,8 +25322,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaSecret": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaSecret": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25331,7 +25331,7 @@ Object {
         },
         "summary": "Secret containing data to use for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCaSecret",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCaSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25399,8 +25399,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCert": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCert": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25408,7 +25408,7 @@ Object {
         },
         "summary": "Struct containing the client cert file for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCert",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCert",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25432,7 +25432,7 @@ Object {
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap",
           },
         },
         Object {
@@ -25451,13 +25451,13 @@ Object {
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertSecret",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertSecret",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25465,7 +25465,7 @@ Object {
         },
         "summary": "ConfigMap containing data to use for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25532,8 +25532,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertSecret": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertSecret": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25541,7 +25541,7 @@ Object {
         },
         "summary": "Secret containing data to use for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigCertSecret",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigCertSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25609,8 +25609,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigKeySecret": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigKeySecret": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25618,7 +25618,7 @@ Object {
         },
         "summary": "Secret containing the client key file for the targets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecGrpcServerTlsConfigKeySecret",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecGrpcServerTlsConfigKeySecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25686,8 +25686,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecImagePullSecrets": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecImagePullSecrets": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25695,7 +25695,7 @@ Object {
         },
         "summary": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecImagePullSecrets",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecImagePullSecrets",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25725,8 +25725,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainers": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainers": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -25734,7 +25734,7 @@ Object {
         },
         "summary": "A single application container that you want to run within a pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainers",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainers",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -25830,7 +25830,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnv",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnv",
               },
               "kind": "array",
             },
@@ -25855,7 +25855,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFrom",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFrom",
               },
               "kind": "array",
             },
@@ -25919,7 +25919,7 @@ Object {
           "name": "lifecycle",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecycle",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecycle",
           },
         },
         Object {
@@ -25939,7 +25939,7 @@ Object {
           "name": "livenessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbe",
           },
         },
         Object {
@@ -25961,7 +25961,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersPorts",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersPorts",
               },
               "kind": "array",
             },
@@ -25984,7 +25984,7 @@ Object {
           "name": "readinessProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbe",
           },
         },
         Object {
@@ -26004,7 +26004,7 @@ Object {
           "name": "resources",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersResources",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersResources",
           },
         },
         Object {
@@ -26024,7 +26024,7 @@ Object {
           "name": "securityContext",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContext",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContext",
           },
         },
         Object {
@@ -26044,7 +26044,7 @@ Object {
           "name": "startupProbe",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbe",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbe",
           },
         },
         Object {
@@ -26170,7 +26170,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeDevices",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeDevices",
               },
               "kind": "array",
             },
@@ -26195,7 +26195,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeMounts",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeMounts",
               },
               "kind": "array",
             },
@@ -26223,8 +26223,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnv": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnv": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26232,7 +26232,7 @@ Object {
         },
         "summary": "EnvVar represents an environment variable present in a Container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnv",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnv",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26297,13 +26297,13 @@ Object {
           "name": "valueFrom",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFrom",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFrom",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFrom": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFrom": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26311,7 +26311,7 @@ Object {
         },
         "summary": "EnvFromSource represents the source of a set of ConfigMaps.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFrom",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26335,7 +26335,7 @@ Object {
           "name": "configMapRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromConfigMapRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromConfigMapRef",
           },
         },
         Object {
@@ -26374,13 +26374,13 @@ Object {
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromSecretRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromConfigMapRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromConfigMapRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26388,7 +26388,7 @@ Object {
         },
         "summary": "The ConfigMap to select from.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromConfigMapRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromConfigMapRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26437,8 +26437,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26446,7 +26446,7 @@ Object {
         },
         "summary": "The Secret to select from.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvFromSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvFromSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26495,8 +26495,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFrom": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFrom": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26505,7 +26505,7 @@ Object {
         "remarks": "Cannot be used if value is not empty.",
         "summary": "Source for the environment variable's value.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFrom",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFrom",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26529,7 +26529,7 @@ Object {
           "name": "configMapKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef",
           },
         },
         Object {
@@ -26548,7 +26548,7 @@ Object {
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromFieldRef",
           },
         },
         Object {
@@ -26567,7 +26567,7 @@ Object {
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef",
           },
         },
         Object {
@@ -26586,13 +26586,13 @@ Object {
           "name": "secretKeyRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26600,7 +26600,7 @@ Object {
         },
         "summary": "Selects a key of a ConfigMap.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromConfigMapKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26667,8 +26667,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26676,7 +26676,7 @@ Object {
         },
         "summary": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26723,8 +26723,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26732,7 +26732,7 @@ Object {
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26798,8 +26798,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26807,7 +26807,7 @@ Object {
         },
         "summary": "Selects a key of a secret in the pod's namespace.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersEnvValueFromSecretKeyRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26875,8 +26875,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecycle": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecycle": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26885,7 +26885,7 @@ Object {
         "remarks": "Cannot be updated.",
         "summary": "Actions that the management system should take in response to container lifecycle events.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecycle",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecycle",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26910,7 +26910,7 @@ Object {
           "name": "postStart",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStart",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStart",
           },
         },
         Object {
@@ -26930,13 +26930,13 @@ Object {
           "name": "preStop",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStop",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStop",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStart": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStart": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -26945,7 +26945,7 @@ Object {
         "remarks": "If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PostStart is called immediately after a container is created.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStart",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStart",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -26970,7 +26970,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartExec",
           },
         },
         Object {
@@ -26989,7 +26989,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet",
           },
         },
         Object {
@@ -27009,13 +27009,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27024,7 +27024,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27059,8 +27059,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27068,7 +27068,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27092,7 +27092,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
           },
         },
         Object {
@@ -27134,7 +27134,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -27182,8 +27182,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27191,7 +27191,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27237,8 +27237,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
@@ -27246,7 +27246,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27269,7 +27269,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -27290,7 +27290,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
             },
           },
           "static": true,
@@ -27298,8 +27298,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLifecyclePostStartHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27308,7 +27308,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27332,7 +27332,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
           },
         },
         Object {
@@ -27356,8 +27356,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
@@ -27365,7 +27365,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27388,7 +27388,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -27409,7 +27409,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
             },
           },
           "static": true,
@@ -27417,8 +27417,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLifecyclePostStartTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStop": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStop": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27427,7 +27427,7 @@ Object {
         "remarks": "The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
         "summary": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStop",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStop",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27452,7 +27452,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopExec",
           },
         },
         Object {
@@ -27471,7 +27471,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet",
           },
         },
         Object {
@@ -27491,13 +27491,13 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27506,7 +27506,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27541,8 +27541,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27550,7 +27550,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27574,7 +27574,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
           },
         },
         Object {
@@ -27616,7 +27616,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -27664,8 +27664,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27673,7 +27673,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27719,8 +27719,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
@@ -27728,7 +27728,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27751,7 +27751,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -27772,7 +27772,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
             },
           },
           "static": true,
@@ -27780,8 +27780,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLifecyclePreStopHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27790,7 +27790,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27814,7 +27814,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
           },
         },
         Object {
@@ -27838,8 +27838,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
@@ -27847,7 +27847,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27870,7 +27870,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -27891,7 +27891,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
             },
           },
           "static": true,
@@ -27899,8 +27899,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLifecyclePreStopTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -27909,7 +27909,7 @@ Object {
         "remarks": "Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "Periodic probe of container liveness.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -27934,7 +27934,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeExec",
           },
         },
         Object {
@@ -27974,7 +27974,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGet",
           },
         },
         Object {
@@ -28056,7 +28056,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocket",
           },
         },
         Object {
@@ -28082,8 +28082,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28092,7 +28092,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28127,8 +28127,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28136,7 +28136,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28160,7 +28160,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
           },
         },
         Object {
@@ -28202,7 +28202,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -28250,8 +28250,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28259,7 +28259,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28305,8 +28305,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
@@ -28314,7 +28314,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28337,7 +28337,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -28358,7 +28358,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -28366,8 +28366,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLivenessProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28376,7 +28376,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28400,7 +28400,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
           },
         },
         Object {
@@ -28424,8 +28424,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
@@ -28433,7 +28433,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28456,7 +28456,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -28477,7 +28477,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -28485,8 +28485,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersLivenessProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersPorts": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersPorts": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28494,7 +28494,7 @@ Object {
         },
         "summary": "ContainerPort represents a network port in a single container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersPorts",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersPorts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28603,8 +28603,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28613,7 +28613,7 @@ Object {
         "remarks": "Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "Periodic probe of container service readiness.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28638,7 +28638,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeExec",
           },
         },
         Object {
@@ -28678,7 +28678,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGet",
           },
         },
         Object {
@@ -28760,7 +28760,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocket",
           },
         },
         Object {
@@ -28786,8 +28786,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28796,7 +28796,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28831,8 +28831,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28840,7 +28840,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -28864,7 +28864,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
           },
         },
         Object {
@@ -28906,7 +28906,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -28954,8 +28954,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -28963,7 +28963,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29009,8 +29009,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
@@ -29018,7 +29018,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29041,7 +29041,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -29062,7 +29062,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
             },
           },
           "static": true,
@@ -29070,8 +29070,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersReadinessProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29080,7 +29080,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29104,7 +29104,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
           },
         },
         Object {
@@ -29128,8 +29128,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
@@ -29137,7 +29137,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29160,7 +29160,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -29181,7 +29181,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -29189,8 +29189,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersReadinessProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersResources": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersResources": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29199,7 +29199,7 @@ Object {
         "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
         "summary": "Compute Resources required by this container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersResources",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29259,8 +29259,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContext": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContext": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29269,7 +29269,7 @@ Object {
         "remarks": "More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
         "summary": "Security options the pod should run with.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContext",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContext",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29315,7 +29315,7 @@ Object {
           "name": "capabilities",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextCapabilities",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextCapabilities",
           },
         },
         Object {
@@ -29458,7 +29458,7 @@ Object {
           "name": "seLinuxOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions",
           },
         },
         Object {
@@ -29478,13 +29478,13 @@ Object {
           "name": "windowsOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextWindowsOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextWindowsOptions",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextCapabilities": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextCapabilities": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29494,7 +29494,7 @@ Object {
         "remarks": "Defaults to the default set of capabilities granted by the container runtime.",
         "summary": "The capabilities to add/drop when running containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextCapabilities",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextCapabilities",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29552,8 +29552,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29562,7 +29562,7 @@ Object {
         "remarks": "If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The SELinux context to be applied to the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextSeLinuxOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29648,8 +29648,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextWindowsOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextWindowsOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29658,7 +29658,7 @@ Object {
         "remarks": "If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The Windows specific settings applied to all containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersSecurityContextWindowsOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersSecurityContextWindowsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29727,8 +29727,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbe": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbe": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29737,7 +29737,7 @@ Object {
         "remarks": "If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
         "summary": "StartupProbe indicates that the Pod has successfully initialized.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbe",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbe",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29762,7 +29762,7 @@ Object {
           "name": "exec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeExec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeExec",
           },
         },
         Object {
@@ -29802,7 +29802,7 @@ Object {
           "name": "httpGet",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGet",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGet",
           },
         },
         Object {
@@ -29884,7 +29884,7 @@ Object {
           "name": "tcpSocket",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocket",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocket",
           },
         },
         Object {
@@ -29910,8 +29910,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeExec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeExec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29920,7 +29920,7 @@ Object {
         "remarks": "Exec specifies the action to take.",
         "summary": "One and only one of the following should be specified.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeExec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeExec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29955,8 +29955,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGet": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGet": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -29964,7 +29964,7 @@ Object {
         },
         "summary": "HTTPGet specifies the http request to perform.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGet",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGet",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -29988,7 +29988,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
           },
         },
         Object {
@@ -30030,7 +30030,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders",
               },
               "kind": "array",
             },
@@ -30078,8 +30078,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30087,7 +30087,7 @@ Object {
         },
         "summary": "HTTPHeader describes a custom header to be used in HTTP probes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetHttpHeaders",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30133,8 +30133,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
@@ -30142,7 +30142,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Name or number of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30165,7 +30165,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
             },
           },
           "static": true,
@@ -30186,7 +30186,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
             },
           },
           "static": true,
@@ -30194,8 +30194,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersStartupProbeHttpGetPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocket": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocket": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30204,7 +30204,7 @@ Object {
         "remarks": "TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook",
         "summary": "TCPSocket specifies an action involving a TCP port.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocket",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocket",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30228,7 +30228,7 @@ Object {
           },
           "name": "port",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
           },
         },
         Object {
@@ -30252,8 +30252,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "docs": Object {
         "custom": Object {
           "schema": "ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
@@ -30261,7 +30261,7 @@ Object {
         "remarks": "Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
         "summary": "Number or name of the port to access on the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
       "kind": "class",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30284,7 +30284,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -30305,7 +30305,7 @@ Object {
           ],
           "returns": Object {
             "type": Object {
-              "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
+              "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
             },
           },
           "static": true,
@@ -30313,8 +30313,8 @@ Object {
       ],
       "name": "ThanosRulerSpecInitContainersStartupProbeTcpSocketPort",
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeDevices": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeDevices": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30322,7 +30322,7 @@ Object {
         },
         "summary": "volumeDevice describes a mapping of a raw block device within a container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeDevices",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeDevices",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30368,8 +30368,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeMounts": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeMounts": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30377,7 +30377,7 @@ Object {
         },
         "summary": "VolumeMount describes a mounting of a Volume within a container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecInitContainersVolumeMounts",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecInitContainersVolumeMounts",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30507,8 +30507,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecObjectStorageConfig": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecObjectStorageConfig": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30516,7 +30516,7 @@ Object {
         },
         "summary": "ObjectStorageConfig configures object storage in Thanos.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecObjectStorageConfig",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecObjectStorageConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30584,8 +30584,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecPodMetadata": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecPodMetadata": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30593,7 +30593,7 @@ Object {
         },
         "summary": "PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecPodMetadata",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecPodMetadata",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30673,8 +30673,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecQueryConfig": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecQueryConfig": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30683,7 +30683,7 @@ Object {
         "remarks": "If this is defined, the QueryEndpoints field will be ignored. Maps to the \`query.config\` CLI argument. Only available with thanos v0.11.0 and higher.",
         "summary": "Define configuration for connecting to thanos query instances.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecQueryConfig",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecQueryConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30751,8 +30751,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecResources": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecResources": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30761,7 +30761,7 @@ Object {
         "remarks": "If not provided, no requests/limits will be set",
         "summary": "Resources defines the resource requirements for single Pods.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecResources",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30821,8 +30821,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30831,7 +30831,7 @@ Object {
         "remarks": "If unspecified, only the same namespace as the ThanosRuler object is in is used.",
         "summary": "Namespaces to be selected for Rules discovery.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30858,7 +30858,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -30891,8 +30891,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30900,7 +30900,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleNamespaceSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -30972,8 +30972,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -30981,7 +30981,7 @@ Object {
         },
         "summary": "A label selector to select which PrometheusRules to mount for alerting and recording.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31008,7 +31008,7 @@ Object {
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -31041,8 +31041,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31050,7 +31050,7 @@ Object {
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecRuleSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecRuleSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31122,8 +31122,8 @@ Object {
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContext": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContext": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31132,7 +31132,7 @@ Object {
         "remarks": "This defaults to the default PodSecurityContext.",
         "summary": "SecurityContext holds pod-level security attributes and common container settings.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContext",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContext",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31260,7 +31260,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "seLinuxOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSeLinuxOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSeLinuxOptions",
           },
         },
         Object {
@@ -31307,7 +31307,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSysctls",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSysctls",
               },
               "kind": "array",
             },
@@ -31330,13 +31330,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "windowsOptions",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextWindowsOptions",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextWindowsOptions",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSeLinuxOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSeLinuxOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31345,7 +31345,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
         "summary": "The SELinux context to be applied to all containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSeLinuxOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSeLinuxOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31431,8 +31431,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSysctls": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSysctls": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31440,7 +31440,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Sysctl defines a kernel parameter to be set.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextSysctls",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextSysctls",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31486,8 +31486,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextWindowsOptions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextWindowsOptions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31496,7 +31496,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
         "summary": "The Windows specific settings applied to all containers.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecSecurityContextWindowsOptions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecSecurityContextWindowsOptions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31565,8 +31565,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorage": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorage": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31574,7 +31574,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Storage spec to specify how storage shall be used.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorage",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorage",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31619,7 +31619,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "emptyDir",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageEmptyDir",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageEmptyDir",
           },
         },
         Object {
@@ -31638,13 +31638,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "volumeClaimTemplate",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplate",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplate",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageEmptyDir": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageEmptyDir": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31653,7 +31653,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If specified, used in place of any volumeClaimTemplate. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
         "summary": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageEmptyDir",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageEmptyDir",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31703,8 +31703,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplate": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplate": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31712,7 +31712,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "A PVC spec to be used by the Prometheus StatefulSets.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplate",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplate",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31776,7 +31776,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "metadata",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateMetadata",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateMetadata",
           },
         },
         Object {
@@ -31796,7 +31796,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "spec",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpec",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpec",
           },
         },
         Object {
@@ -31816,13 +31816,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "status",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatus",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatus",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateMetadata": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateMetadata": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31830,7 +31830,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "EmbeddedMetadata contains metadata relevant to an EmbeddedResource.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateMetadata",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateMetadata",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31910,8 +31910,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpec": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpec": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -31920,7 +31920,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "Spec defines the desired characteristics of a volume requested by a pod author.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpec",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpec",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -31969,7 +31969,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "dataSource",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource",
           },
         },
         Object {
@@ -31989,7 +31989,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "resources",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources",
           },
         },
         Object {
@@ -32008,7 +32008,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "selector",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector",
           },
         },
         Object {
@@ -32072,8 +32072,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32081,7 +32081,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecDataSource",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32147,8 +32147,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32157,7 +32157,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
         "summary": "Resources represents the minimum resources the volume should have.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecResources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32217,8 +32217,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32226,7 +32226,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "A label query over volumes to consider for binding.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelector",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32253,7 +32253,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions",
               },
               "kind": "array",
             },
@@ -32286,8 +32286,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32295,7 +32295,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateSpecSelectorMatchExpressions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32367,8 +32367,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatus": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatus": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32377,7 +32377,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "Status represents the current information/status of a persistent volume claim.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatus",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatus",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32453,7 +32453,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions",
               },
               "kind": "array",
             },
@@ -32480,8 +32480,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32489,7 +32489,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "PersistentVolumeClaimCondition contails details about state of pvc.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecStorageVolumeClaimTemplateStatusConditions",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32611,8 +32611,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTolerations": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecTolerations": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32620,7 +32620,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTolerations",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecTolerations",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32731,8 +32731,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTracingConfig": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecTracingConfig": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32741,7 +32741,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This is an experimental feature, it may change in any upcoming release in a breaking way.",
         "summary": "TracingConfig configures tracing in Thanos.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecTracingConfig",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecTracingConfig",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32809,8 +32809,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumes": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumes": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -32818,7 +32818,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumes",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumes",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -32862,7 +32862,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "awsElasticBlockStore",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAwsElasticBlockStore",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAwsElasticBlockStore",
           },
         },
         Object {
@@ -32881,7 +32881,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "azureDisk",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureDisk",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureDisk",
           },
         },
         Object {
@@ -32900,7 +32900,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "azureFile",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureFile",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureFile",
           },
         },
         Object {
@@ -32919,7 +32919,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "cephfs",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfs",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfs",
           },
         },
         Object {
@@ -32939,7 +32939,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "cinder",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinder",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinder",
           },
         },
         Object {
@@ -32958,7 +32958,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMap",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMap",
           },
         },
         Object {
@@ -32977,7 +32977,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "csi",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsi",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsi",
           },
         },
         Object {
@@ -32996,7 +32996,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "downwardAPI",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApi",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApi",
           },
         },
         Object {
@@ -33016,7 +33016,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "emptyDir",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesEmptyDir",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesEmptyDir",
           },
         },
         Object {
@@ -33035,7 +33035,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fc",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFc",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFc",
           },
         },
         Object {
@@ -33054,7 +33054,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "flexVolume",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolume",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolume",
           },
         },
         Object {
@@ -33074,7 +33074,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "flocker",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlocker",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlocker",
           },
         },
         Object {
@@ -33094,7 +33094,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "gcePersistentDisk",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGcePersistentDisk",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGcePersistentDisk",
           },
         },
         Object {
@@ -33114,7 +33114,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "gitRepo",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGitRepo",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGitRepo",
           },
         },
         Object {
@@ -33134,7 +33134,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "glusterfs",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGlusterfs",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGlusterfs",
           },
         },
         Object {
@@ -33154,7 +33154,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "hostPath",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesHostPath",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesHostPath",
           },
         },
         Object {
@@ -33174,7 +33174,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "iscsi",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsi",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsi",
           },
         },
         Object {
@@ -33193,7 +33193,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "nfs",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesNfs",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesNfs",
           },
         },
         Object {
@@ -33213,7 +33213,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "persistentVolumeClaim",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPersistentVolumeClaim",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPersistentVolumeClaim",
           },
         },
         Object {
@@ -33232,7 +33232,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "photonPersistentDisk",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPhotonPersistentDisk",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPhotonPersistentDisk",
           },
         },
         Object {
@@ -33251,7 +33251,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "portworxVolume",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPortworxVolume",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPortworxVolume",
           },
         },
         Object {
@@ -33270,7 +33270,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "projected",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjected",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjected",
           },
         },
         Object {
@@ -33289,7 +33289,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "quobyte",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesQuobyte",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesQuobyte",
           },
         },
         Object {
@@ -33309,7 +33309,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "rbd",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbd",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbd",
           },
         },
         Object {
@@ -33328,7 +33328,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "scaleIO",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIo",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIo",
           },
         },
         Object {
@@ -33348,7 +33348,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecret",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecret",
           },
         },
         Object {
@@ -33367,7 +33367,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "storageos",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageos",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageos",
           },
         },
         Object {
@@ -33386,13 +33386,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "vsphereVolume",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesVsphereVolume",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesVsphereVolume",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAwsElasticBlockStore": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAwsElasticBlockStore": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33401,7 +33401,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
         "summary": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAwsElasticBlockStore",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAwsElasticBlockStore",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33490,8 +33490,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureDisk": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureDisk": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33499,7 +33499,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureDisk",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33625,8 +33625,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureFile": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureFile": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33634,7 +33634,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesAzureFile",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesAzureFile",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33701,8 +33701,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfs": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfs": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33710,7 +33710,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfs",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33817,7 +33817,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfsSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfsSecretRef",
           },
         },
         Object {
@@ -33841,8 +33841,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfsSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfsSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33851,7 +33851,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
         "summary": "Optional: SecretRef is reference to the authentication secret for User, default is empty.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCephfsSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCephfsSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33881,8 +33881,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinder": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinder": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33891,7 +33891,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
         "summary": "Cinder represents a cinder volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinder",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinder",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -33975,13 +33975,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinderSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinderSecretRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinderSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinderSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -33989,7 +33989,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCinderSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCinderSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34019,8 +34019,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMap": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMap": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34028,7 +34028,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "ConfigMap represents a configMap that should populate this volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMap",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34076,7 +34076,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMapItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMapItems",
               },
               "kind": "array",
             },
@@ -34123,8 +34123,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMapItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMapItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34132,7 +34132,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesConfigMapItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesConfigMapItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34199,8 +34199,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsi": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsi": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34208,7 +34208,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsi",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34272,7 +34272,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "nodePublishSecretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsiNodePublishSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsiNodePublishSecretRef",
           },
         },
         Object {
@@ -34323,8 +34323,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsiNodePublishSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsiNodePublishSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34333,7 +34333,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
         "summary": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesCsiNodePublishSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesCsiNodePublishSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34363,8 +34363,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApi": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApi": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34372,7 +34372,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPI represents downward API about the pod that should populate this volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApi",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34419,7 +34419,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItems",
               },
               "kind": "array",
             },
@@ -34427,8 +34427,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34436,7 +34436,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPIVolumeFile represents information to create the file containing the pod field.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34479,7 +34479,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsFieldRef",
           },
         },
         Object {
@@ -34518,13 +34518,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34532,7 +34532,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34579,8 +34579,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34588,7 +34588,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesDownwardApiItemsResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34654,8 +34654,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesEmptyDir": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesEmptyDir": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34664,7 +34664,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
         "summary": "EmptyDir represents a temporary directory that shares a pod's lifetime.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesEmptyDir",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesEmptyDir",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34714,8 +34714,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFc": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFc": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34723,7 +34723,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFc",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFc",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34841,8 +34841,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolume": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolume": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34850,7 +34850,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolume",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -34958,13 +34958,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolumeSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolumeSecretRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolumeSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolumeSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -34973,7 +34973,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
         "summary": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlexVolumeSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlexVolumeSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35003,8 +35003,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlocker": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlocker": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35013,7 +35013,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This depends on the Flocker control service being running",
         "summary": "Flocker represents a Flocker volume attached to a kubelet's host machine.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesFlocker",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesFlocker",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35062,8 +35062,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGcePersistentDisk": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGcePersistentDisk": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35072,7 +35072,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
         "summary": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGcePersistentDisk",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGcePersistentDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35162,8 +35162,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGitRepo": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGitRepo": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35172,7 +35172,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "summary": "GitRepo represents a git repository at a particular revision.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGitRepo",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGitRepo",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35239,8 +35239,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGlusterfs": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGlusterfs": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35249,7 +35249,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/glusterfs/README.md",
         "summary": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesGlusterfs",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesGlusterfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35318,8 +35318,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesHostPath": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesHostPath": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35328,7 +35328,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
         "summary": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesHostPath",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesHostPath",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35377,8 +35377,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsi": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsi": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35387,7 +35387,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/iscsi/README.md",
         "summary": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsi",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35611,13 +35611,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsiSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsiSecretRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsiSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsiSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35625,7 +35625,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "CHAP Secret for iSCSI target and initiator authentication.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesIscsiSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesIscsiSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35655,8 +35655,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesNfs": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesNfs": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35664,7 +35664,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesNfs",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesNfs",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35733,8 +35733,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPersistentVolumeClaim": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPersistentVolumeClaim": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35743,7 +35743,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
         "summary": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPersistentVolumeClaim",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPersistentVolumeClaim",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35792,8 +35792,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPhotonPersistentDisk": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPhotonPersistentDisk": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35801,7 +35801,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPhotonPersistentDisk",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPhotonPersistentDisk",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35849,8 +35849,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPortworxVolume": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPortworxVolume": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35858,7 +35858,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesPortworxVolume",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesPortworxVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35927,8 +35927,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjected": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjected": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35936,7 +35936,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Items for all in one resources secrets, configmaps, and downward API.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjected",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjected",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -35961,7 +35961,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSources",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSources",
               },
               "kind": "array",
             },
@@ -35989,8 +35989,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSources": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSources": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -35998,7 +35998,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Projection that may be projected along with other supported volume types.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSources",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSources",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36022,7 +36022,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "configMap",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMap",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMap",
           },
         },
         Object {
@@ -36041,7 +36041,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "downwardAPI",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApi",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApi",
           },
         },
         Object {
@@ -36060,7 +36060,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secret",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecret",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecret",
           },
         },
         Object {
@@ -36079,13 +36079,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "serviceAccountToken",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMap": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMap": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36093,7 +36093,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the configMap data to project.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMap",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMap",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36120,7 +36120,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems",
               },
               "kind": "array",
             },
@@ -36167,8 +36167,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36176,7 +36176,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesConfigMapItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36243,8 +36243,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApi": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApi": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36252,7 +36252,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the downwardAPI data to project.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApi",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApi",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36278,7 +36278,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems",
               },
               "kind": "array",
             },
@@ -36286,8 +36286,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36295,7 +36295,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "DownwardAPIVolumeFile represents information to create the file containing the pod field.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36338,7 +36338,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "fieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef",
           },
         },
         Object {
@@ -36377,13 +36377,13 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "resourceFieldRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
           },
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36391,7 +36391,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36438,8 +36438,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36447,7 +36447,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36513,8 +36513,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecret": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecret": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36522,7 +36522,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the secret data to project.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecret",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36549,7 +36549,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecretItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecretItems",
               },
               "kind": "array",
             },
@@ -36596,8 +36596,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecretItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecretItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36605,7 +36605,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesSecretItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesSecretItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36672,8 +36672,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36681,7 +36681,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "information about the serviceAccountToken data to project.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesProjectedSourcesServiceAccountToken",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36750,8 +36750,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesQuobyte": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesQuobyte": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36759,7 +36759,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesQuobyte",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesQuobyte",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -36885,8 +36885,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbd": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbd": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -36895,7 +36895,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://examples.k8s.io/volumes/rbd/README.md",
         "summary": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbd",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbd",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37047,7 +37047,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbdSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbdSecretRef",
           },
         },
         Object {
@@ -37073,8 +37073,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbdSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbdSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37084,7 +37084,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
         "summary": "SecretRef is name of the authentication secret for RBDUser.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesRbdSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesRbdSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37114,8 +37114,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIo": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIo": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37123,7 +37123,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIo",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIo",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37165,7 +37165,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           },
           "name": "secretRef",
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIoSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIoSecretRef",
           },
         },
         Object {
@@ -37327,8 +37327,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIoSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIoSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37337,7 +37337,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If this is not provided, Login operation will fail.",
         "summary": "SecretRef references to the secret for ScaleIO user and other sensitive information.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesScaleIoSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesScaleIoSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37367,8 +37367,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecret": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecret": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37377,7 +37377,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
         "summary": "Secret represents a secret that should populate this volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecret",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecret",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37425,7 +37425,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "type": Object {
             "collection": Object {
               "elementtype": Object {
-                "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecretItems",
+                "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecretItems",
               },
               "kind": "array",
             },
@@ -37472,8 +37472,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecretItems": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecretItems": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37481,7 +37481,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "Maps a string key to a path within a volume.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesSecretItems",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesSecretItems",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37548,8 +37548,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageos": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageos": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37557,7 +37557,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageos",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageos",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37623,7 +37623,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
           "name": "secretRef",
           "optional": true,
           "type": Object {
-            "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageosSecretRef",
+            "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageosSecretRef",
           },
         },
         Object {
@@ -37668,8 +37668,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageosSecretRef": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageosSecretRef": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37678,7 +37678,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         "remarks": "If not specified, default values will be attempted.",
         "summary": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesStorageosSecretRef",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesStorageosSecretRef",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",
@@ -37708,8 +37708,8 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
       ],
     },
-    "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesVsphereVolume": Object {
-      "assembly": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc",
+    "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesVsphereVolume": Object {
+      "assembly": "monitoringcoreoscomthanosruler",
       "datatype": true,
       "docs": Object {
         "custom": Object {
@@ -37717,7 +37717,7 @@ If unset, the Kubelet will not modify the ownership and permissions of any volum
         },
         "summary": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.",
       },
-      "fqn": "3cfc3ca2e4387e1a395840106ab16abf718f4ac9da72588f5a762f45dc08d8cc.ThanosRulerSpecVolumesVsphereVolume",
+      "fqn": "monitoringcoreoscomthanosruler.ThanosRulerSpecVolumesVsphereVolume",
       "kind": "interface",
       "locationInModule": Object {
         "filename": "monitoring.coreos.com/thanosruler.ts",

--- a/test/test-imports/python/expected-from-cli/mattermost/com/clusterinstallation/__init__.py
+++ b/test/test-imports/python/expected-from-cli/mattermost/com/clusterinstallation/__init__.py
@@ -17,7 +17,7 @@ import constructs
 class ClusterInstallation(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallation",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallation",
 ):
     """ClusterInstallation is the Schema for the clusterinstallations API.
 
@@ -46,7 +46,7 @@ class ClusterInstallation(
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationOptions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -102,7 +102,7 @@ class ClusterInstallationOptions:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpec",
     jsii_struct_bases=[],
     name_mapping={
         "ingress_name": "ingressName",
@@ -447,7 +447,7 @@ class ClusterInstallationSpec:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "node_affinity": "nodeAffinity",
@@ -540,7 +540,7 @@ class ClusterInstallationSpecAffinity:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -627,7 +627,7 @@ class ClusterInstallationSpecAffinityNodeAffinity:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"preference": "preference", "weight": "weight"},
 )
@@ -689,7 +689,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -769,7 +769,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -842,7 +842,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -915,7 +915,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"node_selector_terms": "nodeSelectorTerms"},
 )
@@ -969,7 +969,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1051,7 +1051,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1124,7 +1124,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1197,7 +1197,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1284,7 +1284,7 @@ class ClusterInstallationSpecAffinityPodAffinity:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1348,7 +1348,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1438,7 +1438,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1512,7 +1512,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1585,7 +1585,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1673,7 +1673,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1747,7 +1747,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1820,7 +1820,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1907,7 +1907,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinity:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1971,7 +1971,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2061,7 +2061,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2135,7 +2135,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2208,7 +2208,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2296,7 +2296,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2370,7 +2370,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2443,7 +2443,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecBlueGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreen",
     jsii_struct_bases=[],
     name_mapping={
         "blue": "blue",
@@ -2534,7 +2534,7 @@ class ClusterInstallationSpecBlueGreen:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecBlueGreenBlue",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenBlue",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2627,7 +2627,7 @@ class ClusterInstallationSpecBlueGreenBlue:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecBlueGreenGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenGreen",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2720,7 +2720,7 @@ class ClusterInstallationSpecBlueGreenGreen:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecCanary",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanary",
     jsii_struct_bases=[],
     name_mapping={"deployment": "deployment", "enable": "enable"},
 )
@@ -2778,7 +2778,7 @@ class ClusterInstallationSpecCanary:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecCanaryDeployment",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanaryDeployment",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2871,7 +2871,7 @@ class ClusterInstallationSpecCanaryDeployment:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecDatabase",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabase",
     jsii_struct_bases=[],
     name_mapping={
         "backup_remote_delete_policy": "backupRemoteDeletePolicy",
@@ -3067,7 +3067,7 @@ class ClusterInstallationSpecDatabase:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecDatabaseResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabaseResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -3127,7 +3127,7 @@ class ClusterInstallationSpecDatabaseResources:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecElasticSearch",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecElasticSearch",
     jsii_struct_bases=[],
     name_mapping={"host": "host", "password": "password", "username": "username"},
 )
@@ -3193,7 +3193,7 @@ class ClusterInstallationSpecElasticSearch:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -3374,7 +3374,7 @@ class ClusterInstallationSpecLivenessProbe:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -3417,7 +3417,7 @@ class ClusterInstallationSpecLivenessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -3535,7 +3535,7 @@ class ClusterInstallationSpecLivenessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -3586,7 +3586,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecLivenessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -3618,7 +3618,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -3679,7 +3679,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocket:
 
 class ClusterInstallationSpecLivenessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecLivenessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -3711,7 +3711,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnv",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnv",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value", "value_from": "valueFrom"},
 )
@@ -3795,7 +3795,7 @@ class ClusterInstallationSpecMattermostEnv:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnvValueFrom",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFrom",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_key_ref": "configMapKeyRef",
@@ -3920,7 +3920,7 @@ class ClusterInstallationSpecMattermostEnvValueFrom:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -3992,7 +3992,7 @@ class ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -4045,7 +4045,7 @@ class ClusterInstallationSpecMattermostEnvValueFromFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -4119,7 +4119,7 @@ class ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -4193,7 +4193,7 @@ class ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMinio",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinio",
     jsii_struct_bases=[],
     name_mapping={
         "external_bucket": "externalBucket",
@@ -4318,7 +4318,7 @@ class ClusterInstallationSpecMinio:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecMinioResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinioResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -4378,7 +4378,7 @@ class ClusterInstallationSpecMinioResources:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -4561,7 +4561,7 @@ class ClusterInstallationSpecReadinessProbe:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -4604,7 +4604,7 @@ class ClusterInstallationSpecReadinessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -4722,7 +4722,7 @@ class ClusterInstallationSpecReadinessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -4774,7 +4774,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecReadinessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -4806,7 +4806,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -4867,7 +4867,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocket:
 
 class ClusterInstallationSpecReadinessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecReadinessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -4899,7 +4899,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f.ClusterInstallationSpecResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )

--- a/test/test-imports/python/expected-from-cli/mattermost/com/clusterinstallation/_jsii/__init__.py
+++ b/test/test-imports/python/expected-from-cli/mattermost/com/clusterinstallation/_jsii/__init__.py
@@ -12,10 +12,10 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f",
+    "mattermostcomclusterinstallation",
     "0.0.0",
     __name__[0:-6],
-    "404987be5d9cf583074bb3bc6e46a777f73452d5f704cd061aca9ae49f3aa37f@0.0.0.jsii.tgz",
+    "mattermostcomclusterinstallation@0.0.0.jsii.tgz",
 )
 
 __all__ = [

--- a/test/test-imports/python/expected-from-config/jenkins/io/jenkins/__init__.py
+++ b/test/test-imports/python/expected-from-config/jenkins/io/jenkins/__init__.py
@@ -15,9 +15,7 @@ import constructs
 
 
 class Jenkins(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.Jenkins",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="jenkinsiojenkins.Jenkins"
 ):
     """Jenkins is the Schema for the jenkins API.
 
@@ -46,7 +44,7 @@ class Jenkins(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsOptions",
+    jsii_type="jenkinsiojenkins.JenkinsOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -103,7 +101,7 @@ class JenkinsOptions:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpec",
+    jsii_type="jenkinsiojenkins.JenkinsSpec",
     jsii_struct_bases=[],
     name_mapping={
         "jenkins_api_settings": "jenkinsAPISettings",
@@ -331,7 +329,7 @@ class JenkinsSpec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackup",
+    jsii_type="jenkinsiojenkins.JenkinsSpecBackup",
     jsii_struct_bases=[],
     name_mapping={
         "action": "action",
@@ -420,7 +418,7 @@ class JenkinsSpecBackup:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupAction",
+    jsii_type="jenkinsiojenkins.JenkinsSpecBackupAction",
     jsii_struct_bases=[],
     name_mapping={"exec": "exec"},
 )
@@ -463,7 +461,7 @@ class JenkinsSpecBackupAction:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecBackupActionExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecBackupActionExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -504,7 +502,7 @@ class JenkinsSpecBackupActionExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCode",
+    jsii_type="jenkinsiojenkins.JenkinsSpecConfigurationAsCode",
     jsii_struct_bases=[],
     name_mapping={"configurations": "configurations", "secret": "secret"},
 )
@@ -562,7 +560,7 @@ class JenkinsSpecConfigurationAsCode:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeConfigurations",
+    jsii_type="jenkinsiojenkins.JenkinsSpecConfigurationAsCodeConfigurations",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -600,7 +598,7 @@ class JenkinsSpecConfigurationAsCodeConfigurations:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecConfigurationAsCodeSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecConfigurationAsCodeSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -638,7 +636,7 @@ class JenkinsSpecConfigurationAsCodeSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScripts",
+    jsii_type="jenkinsiojenkins.JenkinsSpecGroovyScripts",
     jsii_struct_bases=[],
     name_mapping={"configurations": "configurations", "secret": "secret"},
 )
@@ -694,7 +692,7 @@ class JenkinsSpecGroovyScripts:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsConfigurations",
+    jsii_type="jenkinsiojenkins.JenkinsSpecGroovyScriptsConfigurations",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -732,7 +730,7 @@ class JenkinsSpecGroovyScriptsConfigurations:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecGroovyScriptsSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecGroovyScriptsSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -770,7 +768,7 @@ class JenkinsSpecGroovyScriptsSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecJenkinsApiSettings",
+    jsii_type="jenkinsiojenkins.JenkinsSpecJenkinsApiSettings",
     jsii_struct_bases=[],
     name_mapping={"authorization_strategy": "authorizationStrategy"},
 )
@@ -809,7 +807,7 @@ class JenkinsSpecJenkinsApiSettings:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMaster",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMaster",
     jsii_struct_bases=[],
     name_mapping={
         "disable_csrf_protection": "disableCSRFProtection",
@@ -1049,7 +1047,7 @@ class JenkinsSpecMaster:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterBasePlugins",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterBasePlugins",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "version": "version"},
 )
@@ -1099,7 +1097,7 @@ class JenkinsSpecMasterBasePlugins:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainers",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainers",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -1398,7 +1396,7 @@ class JenkinsSpecMasterContainers:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnv",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnv",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value", "value_from": "valueFrom"},
 )
@@ -1478,7 +1476,7 @@ class JenkinsSpecMasterContainersEnv:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFrom",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvFrom",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_ref": "configMapRef",
@@ -1567,7 +1565,7 @@ class JenkinsSpecMasterContainersEnvFrom:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromConfigMapRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromConfigMapRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "optional": "optional"},
 )
@@ -1625,7 +1623,7 @@ class JenkinsSpecMasterContainersEnvFromConfigMapRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvFromSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvFromSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "optional": "optional"},
 )
@@ -1683,7 +1681,7 @@ class JenkinsSpecMasterContainersEnvFromSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFrom",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFrom",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_key_ref": "configMapKeyRef",
@@ -1802,7 +1800,7 @@ class JenkinsSpecMasterContainersEnvValueFrom:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -1873,7 +1871,7 @@ class JenkinsSpecMasterContainersEnvValueFromConfigMapKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -1926,7 +1924,7 @@ class JenkinsSpecMasterContainersEnvValueFromFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -2000,7 +1998,7 @@ class JenkinsSpecMasterContainersEnvValueFromResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersEnvValueFromSecretKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -2073,7 +2071,7 @@ class JenkinsSpecMasterContainersEnvValueFromSecretKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecycle",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecycle",
     jsii_struct_bases=[],
     name_mapping={"post_start": "postStart", "pre_stop": "preStop"},
 )
@@ -2143,7 +2141,7 @@ class JenkinsSpecMasterContainersLifecycle:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStart",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStart",
     jsii_struct_bases=[],
     name_mapping={"exec": "exec", "http_get": "httpGet", "tcp_socket": "tcpSocket"},
 )
@@ -2238,7 +2236,7 @@ class JenkinsSpecMasterContainersLifecyclePostStart:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -2281,7 +2279,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -2401,7 +2399,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -2453,7 +2451,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartHttpGetHttpHeaders:
 
 class JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -2485,7 +2483,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -2546,7 +2544,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartTcpSocket:
 
 class JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -2578,7 +2576,7 @@ class JenkinsSpecMasterContainersLifecyclePostStartTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStop",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStop",
     jsii_struct_bases=[],
     name_mapping={"exec": "exec", "http_get": "httpGet", "tcp_socket": "tcpSocket"},
 )
@@ -2671,7 +2669,7 @@ class JenkinsSpecMasterContainersLifecyclePreStop:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -2714,7 +2712,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -2832,7 +2830,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -2884,7 +2882,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopHttpGetHttpHeaders:
 
 class JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -2916,7 +2914,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -2977,7 +2975,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopTcpSocket:
 
 class JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -3009,7 +3007,7 @@ class JenkinsSpecMasterContainersLifecyclePreStopTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbe",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -3194,7 +3192,7 @@ class JenkinsSpecMasterContainersLivenessProbe:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -3237,7 +3235,7 @@ class JenkinsSpecMasterContainersLivenessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGet",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -3355,7 +3353,7 @@ class JenkinsSpecMasterContainersLivenessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -3407,7 +3405,7 @@ class JenkinsSpecMasterContainersLivenessProbeHttpGetHttpHeaders:
 
 class JenkinsSpecMasterContainersLivenessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -3439,7 +3437,7 @@ class JenkinsSpecMasterContainersLivenessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -3500,7 +3498,7 @@ class JenkinsSpecMasterContainersLivenessProbeTcpSocket:
 
 class JenkinsSpecMasterContainersLivenessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersLivenessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -3532,7 +3530,7 @@ class JenkinsSpecMasterContainersLivenessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersPorts",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersPorts",
     jsii_struct_bases=[],
     name_mapping={
         "container_port": "containerPort",
@@ -3644,7 +3642,7 @@ class JenkinsSpecMasterContainersPorts:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbe",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -3831,7 +3829,7 @@ class JenkinsSpecMasterContainersReadinessProbe:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -3874,7 +3872,7 @@ class JenkinsSpecMasterContainersReadinessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGet",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -3992,7 +3990,7 @@ class JenkinsSpecMasterContainersReadinessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -4044,7 +4042,7 @@ class JenkinsSpecMasterContainersReadinessProbeHttpGetHttpHeaders:
 
 class JenkinsSpecMasterContainersReadinessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -4076,7 +4074,7 @@ class JenkinsSpecMasterContainersReadinessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -4137,7 +4135,7 @@ class JenkinsSpecMasterContainersReadinessProbeTcpSocket:
 
 class JenkinsSpecMasterContainersReadinessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersReadinessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -4169,7 +4167,7 @@ class JenkinsSpecMasterContainersReadinessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersResources",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -4231,7 +4229,7 @@ class JenkinsSpecMasterContainersResources:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContext",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContext",
     jsii_struct_bases=[],
     name_mapping={
         "allow_privilege_escalation": "allowPrivilegeEscalation",
@@ -4460,7 +4458,7 @@ class JenkinsSpecMasterContainersSecurityContext:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextCapabilities",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextCapabilities",
     jsii_struct_bases=[],
     name_mapping={"add": "add", "drop": "drop"},
 )
@@ -4521,7 +4519,7 @@ class JenkinsSpecMasterContainersSecurityContextCapabilities:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextSeLinuxOptions",
     jsii_struct_bases=[],
     name_mapping={"level": "level", "role": "role", "type": "type", "user": "user"},
 )
@@ -4606,7 +4604,7 @@ class JenkinsSpecMasterContainersSecurityContextSeLinuxOptions:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersSecurityContextWindowsOptions",
     jsii_struct_bases=[],
     name_mapping={
         "gmsa_credential_spec": "gmsaCredentialSpec",
@@ -4689,7 +4687,7 @@ class JenkinsSpecMasterContainersSecurityContextWindowsOptions:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterContainersVolumeMounts",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterContainersVolumeMounts",
     jsii_struct_bases=[],
     name_mapping={
         "mount_path": "mountPath",
@@ -4822,7 +4820,7 @@ class JenkinsSpecMasterContainersVolumeMounts:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterImagePullSecrets",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterImagePullSecrets",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -4863,7 +4861,7 @@ class JenkinsSpecMasterImagePullSecrets:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterPlugins",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterPlugins",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "version": "version"},
 )
@@ -4913,7 +4911,7 @@ class JenkinsSpecMasterPlugins:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContext",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterSecurityContext",
     jsii_struct_bases=[],
     name_mapping={
         "fs_group": "fsGroup",
@@ -5103,7 +5101,7 @@ class JenkinsSpecMasterSecurityContext:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSeLinuxOptions",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterSecurityContextSeLinuxOptions",
     jsii_struct_bases=[],
     name_mapping={"level": "level", "role": "role", "type": "type", "user": "user"},
 )
@@ -5187,7 +5185,7 @@ class JenkinsSpecMasterSecurityContextSeLinuxOptions:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextSysctls",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterSecurityContextSysctls",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -5237,7 +5235,7 @@ class JenkinsSpecMasterSecurityContextSysctls:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterSecurityContextWindowsOptions",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterSecurityContextWindowsOptions",
     jsii_struct_bases=[],
     name_mapping={
         "gmsa_credential_spec": "gmsaCredentialSpec",
@@ -5319,7 +5317,7 @@ class JenkinsSpecMasterSecurityContextWindowsOptions:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterTolerations",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterTolerations",
     jsii_struct_bases=[],
     name_mapping={
         "effect": "effect",
@@ -5433,7 +5431,7 @@ class JenkinsSpecMasterTolerations:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumes",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumes",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -5982,7 +5980,7 @@ class JenkinsSpecMasterVolumes:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAwsElasticBlockStore",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesAwsElasticBlockStore",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -6079,7 +6077,7 @@ class JenkinsSpecMasterVolumesAwsElasticBlockStore:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureDisk",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesAzureDisk",
     jsii_struct_bases=[],
     name_mapping={
         "disk_name": "diskName",
@@ -6202,7 +6200,7 @@ class JenkinsSpecMasterVolumesAzureDisk:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesAzureFile",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesAzureFile",
     jsii_struct_bases=[],
     name_mapping={
         "secret_name": "secretName",
@@ -6279,7 +6277,7 @@ class JenkinsSpecMasterVolumesAzureFile:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfs",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCephfs",
     jsii_struct_bases=[],
     name_mapping={
         "monitors": "monitors",
@@ -6403,7 +6401,7 @@ class JenkinsSpecMasterVolumesCephfs:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCephfsSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCephfsSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -6446,7 +6444,7 @@ class JenkinsSpecMasterVolumesCephfsSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinder",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCinder",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -6546,7 +6544,7 @@ class JenkinsSpecMasterVolumesCinder:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCinderSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCinderSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -6587,7 +6585,7 @@ class JenkinsSpecMasterVolumesCinderSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMap",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMap",
     jsii_struct_bases=[],
     name_mapping={
         "default_mode": "defaultMode",
@@ -6687,7 +6685,7 @@ class JenkinsSpecMasterVolumesConfigMap:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesConfigMapItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesConfigMapItems",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "path": "path", "mode": "mode"},
 )
@@ -6755,7 +6753,7 @@ class JenkinsSpecMasterVolumesConfigMapItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsi",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCsi",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -6877,7 +6875,7 @@ class JenkinsSpecMasterVolumesCsi:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesCsiNodePublishSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -6920,7 +6918,7 @@ class JenkinsSpecMasterVolumesCsiNodePublishSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApi",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApi",
     jsii_struct_bases=[],
     name_mapping={"default_mode": "defaultMode", "items": "items"},
 )
@@ -6985,7 +6983,7 @@ class JenkinsSpecMasterVolumesDownwardApi:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItems",
     jsii_struct_bases=[],
     name_mapping={
         "path": "path",
@@ -7090,7 +7088,7 @@ class JenkinsSpecMasterVolumesDownwardApiItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -7143,7 +7141,7 @@ class JenkinsSpecMasterVolumesDownwardApiItemsFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -7217,7 +7215,7 @@ class JenkinsSpecMasterVolumesDownwardApiItemsResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesEmptyDir",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesEmptyDir",
     jsii_struct_bases=[],
     name_mapping={"medium": "medium", "size_limit": "sizeLimit"},
 )
@@ -7279,7 +7277,7 @@ class JenkinsSpecMasterVolumesEmptyDir:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFc",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesFc",
     jsii_struct_bases=[],
     name_mapping={
         "fs_type": "fsType",
@@ -7387,7 +7385,7 @@ class JenkinsSpecMasterVolumesFc:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolume",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolume",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -7503,7 +7501,7 @@ class JenkinsSpecMasterVolumesFlexVolume:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesFlexVolumeSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -7546,7 +7544,7 @@ class JenkinsSpecMasterVolumesFlexVolumeSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesFlocker",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesFlocker",
     jsii_struct_bases=[],
     name_mapping={"dataset_name": "datasetName", "dataset_uuid": "datasetUUID"},
 )
@@ -7606,7 +7604,7 @@ class JenkinsSpecMasterVolumesFlocker:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGcePersistentDisk",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesGcePersistentDisk",
     jsii_struct_bases=[],
     name_mapping={
         "pd_name": "pdName",
@@ -7706,7 +7704,7 @@ class JenkinsSpecMasterVolumesGcePersistentDisk:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGitRepo",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesGitRepo",
     jsii_struct_bases=[],
     name_mapping={
         "repository": "repository",
@@ -7783,7 +7781,7 @@ class JenkinsSpecMasterVolumesGitRepo:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesGlusterfs",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesGlusterfs",
     jsii_struct_bases=[],
     name_mapping={"endpoints": "endpoints", "path": "path", "read_only": "readOnly"},
 )
@@ -7858,7 +7856,7 @@ class JenkinsSpecMasterVolumesGlusterfs:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesHostPath",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesHostPath",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "type": "type"},
 )
@@ -7916,7 +7914,7 @@ class JenkinsSpecMasterVolumesHostPath:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsi",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesIscsi",
     jsii_struct_bases=[],
     name_mapping={
         "iqn": "iqn",
@@ -8121,7 +8119,7 @@ class JenkinsSpecMasterVolumesIscsi:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesIscsiSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesIscsiSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -8162,7 +8160,7 @@ class JenkinsSpecMasterVolumesIscsiSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesNfs",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesNfs",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "server": "server", "read_only": "readOnly"},
 )
@@ -8235,7 +8233,7 @@ class JenkinsSpecMasterVolumesNfs:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPersistentVolumeClaim",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesPersistentVolumeClaim",
     jsii_struct_bases=[],
     name_mapping={"claim_name": "claimName", "read_only": "readOnly"},
 )
@@ -8294,7 +8292,7 @@ class JenkinsSpecMasterVolumesPersistentVolumeClaim:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPhotonPersistentDisk",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesPhotonPersistentDisk",
     jsii_struct_bases=[],
     name_mapping={"pd_id": "pdID", "fs_type": "fsType"},
 )
@@ -8347,7 +8345,7 @@ class JenkinsSpecMasterVolumesPhotonPersistentDisk:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesPortworxVolume",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesPortworxVolume",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -8427,7 +8425,7 @@ class JenkinsSpecMasterVolumesPortworxVolume:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjected",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjected",
     jsii_struct_bases=[],
     name_mapping={"sources": "sources", "default_mode": "defaultMode"},
 )
@@ -8485,7 +8483,7 @@ class JenkinsSpecMasterVolumesProjected:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSources",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSources",
     jsii_struct_bases=[],
     name_mapping={
         "config_map": "configMap",
@@ -8600,7 +8598,7 @@ class JenkinsSpecMasterVolumesProjectedSources:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMap",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "name": "name", "optional": "optional"},
 )
@@ -8679,7 +8677,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesConfigMap:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "path": "path", "mode": "mode"},
 )
@@ -8747,7 +8745,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesConfigMapItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApi",
     jsii_struct_bases=[],
     name_mapping={"items": "items"},
 )
@@ -8796,7 +8794,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesDownwardApi:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems",
     jsii_struct_bases=[],
     name_mapping={
         "path": "path",
@@ -8908,7 +8906,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -8962,7 +8960,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -9036,7 +9034,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesDownwardApiItemsResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecret",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "name": "name", "optional": "optional"},
 )
@@ -9115,7 +9113,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesSecretItems",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "path": "path", "mode": "mode"},
 )
@@ -9183,7 +9181,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesSecretItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken",
     jsii_struct_bases=[],
     name_mapping={
         "path": "path",
@@ -9264,7 +9262,7 @@ class JenkinsSpecMasterVolumesProjectedSourcesServiceAccountToken:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesQuobyte",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesQuobyte",
     jsii_struct_bases=[],
     name_mapping={
         "registry": "registry",
@@ -9389,7 +9387,7 @@ class JenkinsSpecMasterVolumesQuobyte:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbd",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesRbd",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -9566,7 +9564,7 @@ class JenkinsSpecMasterVolumesRbd:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesRbdSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesRbdSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -9612,7 +9610,7 @@ class JenkinsSpecMasterVolumesRbdSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIo",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIo",
     jsii_struct_bases=[],
     name_mapping={
         "gateway": "gateway",
@@ -9800,7 +9798,7 @@ class JenkinsSpecMasterVolumesScaleIo:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesScaleIoSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesScaleIoSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -9843,7 +9841,7 @@ class JenkinsSpecMasterVolumesScaleIoSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesSecret",
     jsii_struct_bases=[],
     name_mapping={
         "default_mode": "defaultMode",
@@ -9945,7 +9943,7 @@ class JenkinsSpecMasterVolumesSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesSecretItems",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesSecretItems",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "path": "path", "mode": "mode"},
 )
@@ -10013,7 +10011,7 @@ class JenkinsSpecMasterVolumesSecretItems:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageos",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesStorageos",
     jsii_struct_bases=[],
     name_mapping={
         "fs_type": "fsType",
@@ -10133,7 +10131,7 @@ class JenkinsSpecMasterVolumesStorageos:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesStorageosSecretRef",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesStorageosSecretRef",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -10176,7 +10174,7 @@ class JenkinsSpecMasterVolumesStorageosSecretRef:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecMasterVolumesVsphereVolume",
+    jsii_type="jenkinsiojenkins.JenkinsSpecMasterVolumesVsphereVolume",
     jsii_struct_bases=[],
     name_mapping={
         "volume_path": "volumePath",
@@ -10265,7 +10263,7 @@ class JenkinsSpecMasterVolumesVsphereVolume:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotifications",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotifications",
     jsii_struct_bases=[],
     name_mapping={
         "level": "level",
@@ -10398,7 +10396,7 @@ class JenkinsSpecNotifications:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgun",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsMailgun",
     jsii_struct_bases=[],
     name_mapping={
         "api_key_secret_key_selector": "apiKeySecretKeySelector",
@@ -10485,7 +10483,7 @@ class JenkinsSpecNotificationsMailgun:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "secret": "secret"},
 )
@@ -10546,7 +10544,7 @@ class JenkinsSpecNotificationsMailgunApiKeySecretKeySelector:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -10588,7 +10586,7 @@ class JenkinsSpecNotificationsMailgunApiKeySecretKeySelectorSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlack",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSlack",
     jsii_struct_bases=[],
     name_mapping={"web_hook_url_secret_key_selector": "webHookURLSecretKeySelector"},
 )
@@ -10637,7 +10635,7 @@ class JenkinsSpecNotificationsSlack:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "secret": "secret"},
 )
@@ -10701,7 +10699,7 @@ class JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelector:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -10743,7 +10741,7 @@ class JenkinsSpecNotificationsSlackWebHookUrlSecretKeySelectorSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtp",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSmtp",
     jsii_struct_bases=[],
     name_mapping={
         "from_": "from",
@@ -10874,7 +10872,7 @@ class JenkinsSpecNotificationsSmtp:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "secret": "secret"},
 )
@@ -10935,7 +10933,7 @@ class JenkinsSpecNotificationsSmtpPasswordSecretKeySelector:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -10977,7 +10975,7 @@ class JenkinsSpecNotificationsSmtpPasswordSecretKeySelectorSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "secret": "secret"},
 )
@@ -11038,7 +11036,7 @@ class JenkinsSpecNotificationsSmtpUsernameSecretKeySelector:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -11080,7 +11078,7 @@ class JenkinsSpecNotificationsSmtpUsernameSecretKeySelectorSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeams",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsTeams",
     jsii_struct_bases=[],
     name_mapping={"web_hook_url_secret_key_selector": "webHookURLSecretKeySelector"},
 )
@@ -11129,7 +11127,7 @@ class JenkinsSpecNotificationsTeams:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "secret": "secret"},
 )
@@ -11193,7 +11191,7 @@ class JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelector:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
+    jsii_type="jenkinsiojenkins.JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -11235,7 +11233,7 @@ class JenkinsSpecNotificationsTeamsWebHookUrlSecretKeySelectorSecret:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestore",
+    jsii_type="jenkinsiojenkins.JenkinsSpecRestore",
     jsii_struct_bases=[],
     name_mapping={
         "action": "action",
@@ -11309,7 +11307,7 @@ class JenkinsSpecRestore:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreAction",
+    jsii_type="jenkinsiojenkins.JenkinsSpecRestoreAction",
     jsii_struct_bases=[],
     name_mapping={"exec": "exec"},
 )
@@ -11352,7 +11350,7 @@ class JenkinsSpecRestoreAction:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRestoreActionExec",
+    jsii_type="jenkinsiojenkins.JenkinsSpecRestoreActionExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -11393,7 +11391,7 @@ class JenkinsSpecRestoreActionExec:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecRoles",
+    jsii_type="jenkinsiojenkins.JenkinsSpecRoles",
     jsii_struct_bases=[],
     name_mapping={"api_group": "apiGroup", "kind": "kind", "name": "name"},
 )
@@ -11454,7 +11452,7 @@ class JenkinsSpecRoles:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSeedJobs",
+    jsii_type="jenkinsiojenkins.JenkinsSpecSeedJobs",
     jsii_struct_bases=[],
     name_mapping={
         "additional_classpath": "additionalClasspath",
@@ -11697,7 +11695,7 @@ class JenkinsSpecSeedJobs:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecService",
+    jsii_type="jenkinsiojenkins.JenkinsSpecService",
     jsii_struct_bases=[],
     name_mapping={
         "annotations": "annotations",
@@ -11849,7 +11847,7 @@ class JenkinsSpecService:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecServiceAccount",
+    jsii_type="jenkinsiojenkins.JenkinsSpecServiceAccount",
     jsii_struct_bases=[],
     name_mapping={"annotations": "annotations"},
 )
@@ -11892,7 +11890,7 @@ class JenkinsSpecServiceAccount:
 
 
 @jsii.data_type(
-    jsii_type="de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645.JenkinsSpecSlaveService",
+    jsii_type="jenkinsiojenkins.JenkinsSpecSlaveService",
     jsii_struct_bases=[],
     name_mapping={
         "annotations": "annotations",

--- a/test/test-imports/python/expected-from-config/jenkins/io/jenkins/_jsii/__init__.py
+++ b/test/test-imports/python/expected-from-config/jenkins/io/jenkins/_jsii/__init__.py
@@ -12,10 +12,7 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645",
-    "0.0.0",
-    __name__[0:-6],
-    "de6f67853a60f88a5e105a28a47f88bd9fe5b3eeb297e175be18cafbaf0bd645@0.0.0.jsii.tgz",
+    "jenkinsiojenkins", "0.0.0", __name__[0:-6], "jenkinsiojenkins@0.0.0.jsii.tgz"
 )
 
 __all__ = [

--- a/test/test-imports/python/expected-from-config/k8s/__init__.py
+++ b/test/test-imports/python/expected-from-config/k8s/__init__.py
@@ -15,7 +15,7 @@ import constructs
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Affinity",
+    jsii_type="k8s.Affinity",
     jsii_struct_bases=[],
     name_mapping={
         "node_affinity": "nodeAffinity",
@@ -94,7 +94,7 @@ class Affinity:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AggregationRule",
+    jsii_type="k8s.AggregationRule",
     jsii_struct_bases=[],
     name_mapping={"cluster_role_selectors": "clusterRoleSelectors"},
 )
@@ -139,7 +139,7 @@ class AggregationRule:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AllowedCsiDriver",
+    jsii_type="k8s.AllowedCsiDriver",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -178,7 +178,7 @@ class AllowedCsiDriver:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AllowedFlexVolume",
+    jsii_type="k8s.AllowedFlexVolume",
     jsii_struct_bases=[],
     name_mapping={"driver": "driver"},
 )
@@ -217,7 +217,7 @@ class AllowedFlexVolume:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AllowedHostPath",
+    jsii_type="k8s.AllowedHostPath",
     jsii_struct_bases=[],
     name_mapping={"path_prefix": "pathPrefix", "read_only": "readOnly"},
 )
@@ -278,11 +278,7 @@ class AllowedHostPath:
         )
 
 
-class ApiService(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ApiService",
-):
+class ApiService(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ApiService"):
     """APIService represents a server for a particular GroupVersion.
 
     Name must be "version.group".
@@ -312,9 +308,7 @@ class ApiService(
 
 
 class ApiServiceList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ApiServiceList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ApiServiceList"
 ):
     """APIServiceList is a list of APIService objects.
 
@@ -343,7 +337,7 @@ class ApiServiceList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ApiServiceListOptions",
+    jsii_type="k8s.ApiServiceListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -399,7 +393,7 @@ class ApiServiceListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ApiServiceOptions",
+    jsii_type="k8s.ApiServiceOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -460,7 +454,7 @@ class ApiServiceOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ApiServiceSpec",
+    jsii_type="k8s.ApiServiceSpec",
     jsii_struct_bases=[],
     name_mapping={
         "group_priority_minimum": "groupPriorityMinimum",
@@ -602,11 +596,7 @@ class ApiServiceSpec:
         )
 
 
-class AuditSink(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AuditSink",
-):
+class AuditSink(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.AuditSink"):
     """AuditSink represents a cluster level audit sink.
 
     schema:
@@ -634,9 +624,7 @@ class AuditSink(
 
 
 class AuditSinkList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AuditSinkList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.AuditSinkList"
 ):
     """AuditSinkList is a list of AuditSink items.
 
@@ -665,7 +653,7 @@ class AuditSinkList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AuditSinkListOptions",
+    jsii_type="k8s.AuditSinkListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -722,7 +710,7 @@ class AuditSinkListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AuditSinkOptions",
+    jsii_type="k8s.AuditSinkOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -781,7 +769,7 @@ class AuditSinkOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AuditSinkSpec",
+    jsii_type="k8s.AuditSinkSpec",
     jsii_struct_bases=[],
     name_mapping={"policy": "policy", "webhook": "webhook"},
 )
@@ -835,7 +823,7 @@ class AuditSinkSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AwsElasticBlockStoreVolumeSource",
+    jsii_type="k8s.AwsElasticBlockStoreVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -932,7 +920,7 @@ class AwsElasticBlockStoreVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AzureDiskVolumeSource",
+    jsii_type="k8s.AzureDiskVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "disk_name": "diskName",
@@ -1055,7 +1043,7 @@ class AzureDiskVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AzureFilePersistentVolumeSource",
+    jsii_type="k8s.AzureFilePersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "secret_name": "secretName",
@@ -1146,7 +1134,7 @@ class AzureFilePersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.AzureFileVolumeSource",
+    jsii_type="k8s.AzureFileVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "secret_name": "secretName",
@@ -1222,11 +1210,7 @@ class AzureFileVolumeSource:
         )
 
 
-class Binding(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Binding",
-):
+class Binding(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Binding"):
     """Binding ties one object to another;
 
     for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
@@ -1256,7 +1240,7 @@ class Binding(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.BindingOptions",
+    jsii_type="k8s.BindingOptions",
     jsii_struct_bases=[],
     name_mapping={"target": "target", "metadata": "metadata"},
 )
@@ -1320,7 +1304,7 @@ class BindingOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.BoundObjectReference",
+    jsii_type="k8s.BoundObjectReference",
     jsii_struct_bases=[],
     name_mapping={
         "api_version": "apiVersion",
@@ -1409,7 +1393,7 @@ class BoundObjectReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Capabilities",
+    jsii_type="k8s.Capabilities",
     jsii_struct_bases=[],
     name_mapping={"add": "add", "drop": "drop"},
 )
@@ -1465,7 +1449,7 @@ class Capabilities:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CephFsPersistentVolumeSource",
+    jsii_type="k8s.CephFsPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "monitors": "monitors",
@@ -1589,7 +1573,7 @@ class CephFsPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CephFsVolumeSource",
+    jsii_type="k8s.CephFsVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "monitors": "monitors",
@@ -1713,9 +1697,7 @@ class CephFsVolumeSource:
 
 
 class CertificateSigningRequest(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CertificateSigningRequest",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CertificateSigningRequest"
 ):
     """Describes a certificate signing request.
 
@@ -1746,7 +1728,7 @@ class CertificateSigningRequest(
 class CertificateSigningRequestList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CertificateSigningRequestList",
+    jsii_type="k8s.CertificateSigningRequestList",
 ):
     """
     schema:
@@ -1774,7 +1756,7 @@ class CertificateSigningRequestList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CertificateSigningRequestListOptions",
+    jsii_type="k8s.CertificateSigningRequestListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -1829,7 +1811,7 @@ class CertificateSigningRequestListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CertificateSigningRequestOptions",
+    jsii_type="k8s.CertificateSigningRequestOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -1888,7 +1870,7 @@ class CertificateSigningRequestOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CertificateSigningRequestSpec",
+    jsii_type="k8s.CertificateSigningRequestSpec",
     jsii_struct_bases=[],
     name_mapping={
         "request": "request",
@@ -2016,7 +1998,7 @@ class CertificateSigningRequestSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CinderPersistentVolumeSource",
+    jsii_type="k8s.CinderPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -2116,7 +2098,7 @@ class CinderPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CinderVolumeSource",
+    jsii_type="k8s.CinderVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -2216,7 +2198,7 @@ class CinderVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClientIpConfig",
+    jsii_type="k8s.ClientIpConfig",
     jsii_struct_bases=[],
     name_mapping={"timeout_seconds": "timeoutSeconds"},
 )
@@ -2257,9 +2239,7 @@ class ClientIpConfig:
 
 
 class ClusterRole(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRole",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ClusterRole"
 ):
     """ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 
@@ -2292,9 +2272,7 @@ class ClusterRole(
 
 
 class ClusterRoleBinding(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleBinding",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ClusterRoleBinding"
 ):
     """ClusterRoleBinding references a ClusterRole, but not contain it.
 
@@ -2329,9 +2307,7 @@ class ClusterRoleBinding(
 
 
 class ClusterRoleBindingList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleBindingList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ClusterRoleBindingList"
 ):
     """ClusterRoleBindingList is a collection of ClusterRoleBindings.
 
@@ -2360,7 +2336,7 @@ class ClusterRoleBindingList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleBindingListOptions",
+    jsii_type="k8s.ClusterRoleBindingListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -2418,7 +2394,7 @@ class ClusterRoleBindingListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleBindingOptions",
+    jsii_type="k8s.ClusterRoleBindingOptions",
     jsii_struct_bases=[],
     name_mapping={
         "role_ref": "roleRef",
@@ -2499,9 +2475,7 @@ class ClusterRoleBindingOptions:
 
 
 class ClusterRoleList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ClusterRoleList"
 ):
     """ClusterRoleList is a collection of ClusterRoles.
 
@@ -2530,7 +2504,7 @@ class ClusterRoleList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleListOptions",
+    jsii_type="k8s.ClusterRoleListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -2588,7 +2562,7 @@ class ClusterRoleListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ClusterRoleOptions",
+    jsii_type="k8s.ClusterRoleOptions",
     jsii_struct_bases=[],
     name_mapping={
         "aggregation_rule": "aggregationRule",
@@ -2667,7 +2641,7 @@ class ClusterRoleOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ComponentCondition",
+    jsii_type="k8s.ComponentCondition",
     jsii_struct_bases=[],
     name_mapping={
         "status": "status",
@@ -2761,9 +2735,7 @@ class ComponentCondition:
 
 
 class ComponentStatus(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ComponentStatus",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ComponentStatus"
 ):
     """ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 
@@ -2792,9 +2764,7 @@ class ComponentStatus(
 
 
 class ComponentStatusList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ComponentStatusList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ComponentStatusList"
 ):
     """Status of all the conditions for the component as a list of ComponentStatus objects.
 
@@ -2823,7 +2793,7 @@ class ComponentStatusList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ComponentStatusListOptions",
+    jsii_type="k8s.ComponentStatusListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -2883,7 +2853,7 @@ class ComponentStatusListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ComponentStatusOptions",
+    jsii_type="k8s.ComponentStatusOptions",
     jsii_struct_bases=[],
     name_mapping={"conditions": "conditions", "metadata": "metadata"},
 )
@@ -2942,11 +2912,7 @@ class ComponentStatusOptions:
         )
 
 
-class ConfigMap(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMap",
-):
+class ConfigMap(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ConfigMap"):
     """ConfigMap holds configuration data for pods to consume.
 
     schema:
@@ -2978,7 +2944,7 @@ class ConfigMap(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapEnvSource",
+    jsii_type="k8s.ConfigMapEnvSource",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "optional": "optional"},
 )
@@ -3038,7 +3004,7 @@ class ConfigMapEnvSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapKeySelector",
+    jsii_type="k8s.ConfigMapKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -3109,9 +3075,7 @@ class ConfigMapKeySelector:
 
 
 class ConfigMapList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ConfigMapList"
 ):
     """ConfigMapList is a resource containing a list of ConfigMap objects.
 
@@ -3140,7 +3104,7 @@ class ConfigMapList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapListOptions",
+    jsii_type="k8s.ConfigMapListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -3198,7 +3162,7 @@ class ConfigMapListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapNodeConfigSource",
+    jsii_type="k8s.ConfigMapNodeConfigSource",
     jsii_struct_bases=[],
     name_mapping={
         "kubelet_config_key": "kubeletConfigKey",
@@ -3297,7 +3261,7 @@ class ConfigMapNodeConfigSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapOptions",
+    jsii_type="k8s.ConfigMapOptions",
     jsii_struct_bases=[],
     name_mapping={"binary_data": "binaryData", "data": "data", "metadata": "metadata"},
 )
@@ -3374,7 +3338,7 @@ class ConfigMapOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapProjection",
+    jsii_type="k8s.ConfigMapProjection",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "name": "name", "optional": "optional"},
 )
@@ -3449,7 +3413,7 @@ class ConfigMapProjection:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ConfigMapVolumeSource",
+    jsii_type="k8s.ConfigMapVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "default_mode": "defaultMode",
@@ -3547,7 +3511,7 @@ class ConfigMapVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Container",
+    jsii_type="k8s.Container",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -3960,7 +3924,7 @@ class Container:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ContainerPort",
+    jsii_type="k8s.ContainerPort",
     jsii_struct_bases=[],
     name_mapping={
         "container_port": "containerPort",
@@ -4072,9 +4036,7 @@ class ContainerPort:
 
 
 class ControllerRevision(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ControllerRevision",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ControllerRevision"
 ):
     """ControllerRevision implements an immutable snapshot of state data.
 
@@ -4109,9 +4071,7 @@ class ControllerRevision(
 
 
 class ControllerRevisionList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ControllerRevisionList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ControllerRevisionList"
 ):
     """ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 
@@ -4140,7 +4100,7 @@ class ControllerRevisionList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ControllerRevisionListOptions",
+    jsii_type="k8s.ControllerRevisionListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -4198,7 +4158,7 @@ class ControllerRevisionListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ControllerRevisionOptions",
+    jsii_type="k8s.ControllerRevisionOptions",
     jsii_struct_bases=[],
     name_mapping={"revision": "revision", "data": "data", "metadata": "metadata"},
 )
@@ -4272,11 +4232,7 @@ class ControllerRevisionOptions:
         )
 
 
-class CronJob(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CronJob",
-):
+class CronJob(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CronJob"):
     """CronJob represents the configuration of a single cron job.
 
     schema:
@@ -4304,9 +4260,7 @@ class CronJob(
 
 
 class CronJobList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CronJobList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CronJobList"
 ):
     """CronJobList is a collection of cron jobs.
 
@@ -4335,7 +4289,7 @@ class CronJobList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CronJobListOptions",
+    jsii_type="k8s.CronJobListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -4395,7 +4349,7 @@ class CronJobListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CronJobOptions",
+    jsii_type="k8s.CronJobOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -4459,7 +4413,7 @@ class CronJobOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CronJobSpec",
+    jsii_type="k8s.CronJobSpec",
     jsii_struct_bases=[],
     name_mapping={
         "job_template": "jobTemplate",
@@ -4610,7 +4564,7 @@ class CronJobSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CrossVersionObjectReference",
+    jsii_type="k8s.CrossVersionObjectReference",
     jsii_struct_bases=[],
     name_mapping={"kind": "kind", "name": "name", "api_version": "apiVersion"},
 )
@@ -4677,11 +4631,7 @@ class CrossVersionObjectReference:
         )
 
 
-class CsiDriver(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiDriver",
-):
+class CsiDriver(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CsiDriver"):
     """CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster.
 
     CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
@@ -4711,9 +4661,7 @@ class CsiDriver(
 
 
 class CsiDriverList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiDriverList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CsiDriverList"
 ):
     """CSIDriverList is a collection of CSIDriver objects.
 
@@ -4742,7 +4690,7 @@ class CsiDriverList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiDriverListOptions",
+    jsii_type="k8s.CsiDriverListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -4800,7 +4748,7 @@ class CsiDriverListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiDriverOptions",
+    jsii_type="k8s.CsiDriverOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -4861,7 +4809,7 @@ class CsiDriverOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiDriverSpec",
+    jsii_type="k8s.CsiDriverSpec",
     jsii_struct_bases=[],
     name_mapping={
         "attach_required": "attachRequired",
@@ -4942,11 +4890,7 @@ class CsiDriverSpec:
         )
 
 
-class CsiNode(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNode",
-):
+class CsiNode(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CsiNode"):
     """CSINode holds information about all CSI drivers installed on a node.
 
     CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
@@ -4976,7 +4920,7 @@ class CsiNode(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNodeDriver",
+    jsii_type="k8s.CsiNodeDriver",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -5072,9 +5016,7 @@ class CsiNodeDriver:
 
 
 class CsiNodeList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNodeList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CsiNodeList"
 ):
     """CSINodeList is a collection of CSINode objects.
 
@@ -5103,7 +5045,7 @@ class CsiNodeList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNodeListOptions",
+    jsii_type="k8s.CsiNodeListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -5161,7 +5103,7 @@ class CsiNodeListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNodeOptions",
+    jsii_type="k8s.CsiNodeOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -5220,7 +5162,7 @@ class CsiNodeOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiNodeSpec",
+    jsii_type="k8s.CsiNodeSpec",
     jsii_struct_bases=[],
     name_mapping={"drivers": "drivers"},
 )
@@ -5261,7 +5203,7 @@ class CsiNodeSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiPersistentVolumeSource",
+    jsii_type="k8s.CsiPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -5450,7 +5392,7 @@ class CsiPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CsiVolumeSource",
+    jsii_type="k8s.CsiVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -5566,7 +5508,7 @@ class CsiVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceColumnDefinition",
+    jsii_type="k8s.CustomResourceColumnDefinition",
     jsii_struct_bases=[],
     name_mapping={
         "json_path": "jsonPath",
@@ -5685,7 +5627,7 @@ class CustomResourceColumnDefinition:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceConversion",
+    jsii_type="k8s.CustomResourceConversion",
     jsii_struct_bases=[],
     name_mapping={"strategy": "strategy", "webhook": "webhook"},
 )
@@ -5745,9 +5687,7 @@ class CustomResourceConversion:
 
 
 class CustomResourceDefinition(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinition",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.CustomResourceDefinition"
 ):
     """CustomResourceDefinition represents a resource that should be exposed on the API server.
 
@@ -5780,7 +5720,7 @@ class CustomResourceDefinition(
 class CustomResourceDefinitionList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionList",
+    jsii_type="k8s.CustomResourceDefinitionList",
 ):
     """CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
 
@@ -5809,7 +5749,7 @@ class CustomResourceDefinitionList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionListOptions",
+    jsii_type="k8s.CustomResourceDefinitionListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -5866,7 +5806,7 @@ class CustomResourceDefinitionListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionNames",
+    jsii_type="k8s.CustomResourceDefinitionNames",
     jsii_struct_bases=[],
     name_mapping={
         "kind": "kind",
@@ -5996,7 +5936,7 @@ class CustomResourceDefinitionNames:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionOptions",
+    jsii_type="k8s.CustomResourceDefinitionOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -6057,7 +5997,7 @@ class CustomResourceDefinitionOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionSpec",
+    jsii_type="k8s.CustomResourceDefinitionSpec",
     jsii_struct_bases=[],
     name_mapping={
         "group": "group",
@@ -6181,7 +6121,7 @@ class CustomResourceDefinitionSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceDefinitionVersion",
+    jsii_type="k8s.CustomResourceDefinitionVersion",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -6306,7 +6246,7 @@ class CustomResourceDefinitionVersion:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceSubresourceScale",
+    jsii_type="k8s.CustomResourceSubresourceScale",
     jsii_struct_bases=[],
     name_mapping={
         "spec_replicas_path": "specReplicasPath",
@@ -6378,7 +6318,7 @@ class CustomResourceSubresourceScale:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceSubresources",
+    jsii_type="k8s.CustomResourceSubresources",
     jsii_struct_bases=[],
     name_mapping={"scale": "scale", "status": "status"},
 )
@@ -6438,7 +6378,7 @@ class CustomResourceSubresources:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.CustomResourceValidation",
+    jsii_type="k8s.CustomResourceValidation",
     jsii_struct_bases=[],
     name_mapping={"open_apiv3_schema": "openAPIV3Schema"},
 )
@@ -6480,11 +6420,7 @@ class CustomResourceValidation:
         )
 
 
-class DaemonSet(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSet",
-):
+class DaemonSet(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.DaemonSet"):
     """DaemonSet represents the configuration of a daemon set.
 
     schema:
@@ -6512,9 +6448,7 @@ class DaemonSet(
 
 
 class DaemonSetList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSetList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.DaemonSetList"
 ):
     """DaemonSetList is a collection of daemon sets.
 
@@ -6543,7 +6477,7 @@ class DaemonSetList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSetListOptions",
+    jsii_type="k8s.DaemonSetListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -6603,7 +6537,7 @@ class DaemonSetListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSetOptions",
+    jsii_type="k8s.DaemonSetOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -6667,7 +6601,7 @@ class DaemonSetOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSetSpec",
+    jsii_type="k8s.DaemonSetSpec",
     jsii_struct_bases=[],
     name_mapping={
         "selector": "selector",
@@ -6787,7 +6721,7 @@ class DaemonSetSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DaemonSetUpdateStrategy",
+    jsii_type="k8s.DaemonSetUpdateStrategy",
     jsii_struct_bases=[],
     name_mapping={"rolling_update": "rollingUpdate", "type": "type"},
 )
@@ -6852,7 +6786,7 @@ class DaemonSetUpdateStrategy:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeleteOptions",
+    jsii_type="k8s.DeleteOptions",
     jsii_struct_bases=[],
     name_mapping={
         "api_version": "apiVersion",
@@ -6999,11 +6933,7 @@ class DeleteOptions:
         )
 
 
-class Deployment(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Deployment",
-):
+class Deployment(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Deployment"):
     """Deployment enables declarative updates for Pods and ReplicaSets.
 
     schema:
@@ -7031,9 +6961,7 @@ class Deployment(
 
 
 class DeploymentList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeploymentList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.DeploymentList"
 ):
     """DeploymentList is a list of Deployments.
 
@@ -7062,7 +6990,7 @@ class DeploymentList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeploymentListOptions",
+    jsii_type="k8s.DeploymentListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -7120,7 +7048,7 @@ class DeploymentListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeploymentOptions",
+    jsii_type="k8s.DeploymentOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -7180,7 +7108,7 @@ class DeploymentOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeploymentSpec",
+    jsii_type="k8s.DeploymentSpec",
     jsii_struct_bases=[],
     name_mapping={
         "selector": "selector",
@@ -7350,7 +7278,7 @@ class DeploymentSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DeploymentStrategy",
+    jsii_type="k8s.DeploymentStrategy",
     jsii_struct_bases=[],
     name_mapping={"rolling_update": "rollingUpdate", "type": "type"},
 )
@@ -7415,7 +7343,7 @@ class DeploymentStrategy:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DownwardApiProjection",
+    jsii_type="k8s.DownwardApiProjection",
     jsii_struct_bases=[],
     name_mapping={"items": "items"},
 )
@@ -7458,7 +7386,7 @@ class DownwardApiProjection:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DownwardApiVolumeFile",
+    jsii_type="k8s.DownwardApiVolumeFile",
     jsii_struct_bases=[],
     name_mapping={
         "path": "path",
@@ -7553,7 +7481,7 @@ class DownwardApiVolumeFile:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.DownwardApiVolumeSource",
+    jsii_type="k8s.DownwardApiVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"default_mode": "defaultMode", "items": "items"},
 )
@@ -7616,7 +7544,7 @@ class DownwardApiVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EmptyDirVolumeSource",
+    jsii_type="k8s.EmptyDirVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"medium": "medium", "size_limit": "sizeLimit"},
 )
@@ -7678,7 +7606,7 @@ class EmptyDirVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Endpoint",
+    jsii_type="k8s.Endpoint",
     jsii_struct_bases=[],
     name_mapping={
         "addresses": "addresses",
@@ -7795,7 +7723,7 @@ class Endpoint:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointAddress",
+    jsii_type="k8s.EndpointAddress",
     jsii_struct_bases=[],
     name_mapping={
         "ip": "ip",
@@ -7888,7 +7816,7 @@ class EndpointAddress:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointConditions",
+    jsii_type="k8s.EndpointConditions",
     jsii_struct_bases=[],
     name_mapping={"ready": "ready"},
 )
@@ -7929,7 +7857,7 @@ class EndpointConditions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointPort",
+    jsii_type="k8s.EndpointPort",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "name": "name", "protocol": "protocol"},
 )
@@ -8005,9 +7933,7 @@ class EndpointPort:
 
 
 class EndpointSlice(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointSlice",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.EndpointSlice"
 ):
     """EndpointSlice represents a subset of the endpoints that implement a service.
 
@@ -8047,9 +7973,7 @@ class EndpointSlice(
 
 
 class EndpointSliceList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointSliceList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.EndpointSliceList"
 ):
     """EndpointSliceList represents a list of endpoint slices.
 
@@ -8078,7 +8002,7 @@ class EndpointSliceList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointSliceListOptions",
+    jsii_type="k8s.EndpointSliceListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -8136,7 +8060,7 @@ class EndpointSliceListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointSliceOptions",
+    jsii_type="k8s.EndpointSliceOptions",
     jsii_struct_bases=[],
     name_mapping={
         "address_type": "addressType",
@@ -8232,7 +8156,7 @@ class EndpointSliceOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointSubset",
+    jsii_type="k8s.EndpointSubset",
     jsii_struct_bases=[],
     name_mapping={
         "addresses": "addresses",
@@ -8315,11 +8239,7 @@ class EndpointSubset:
         )
 
 
-class Endpoints(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Endpoints",
-):
+class Endpoints(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Endpoints"):
     """Endpoints is a collection of endpoints that implement the actual service.
 
     Example:
@@ -8360,9 +8280,7 @@ class Endpoints(
 
 
 class EndpointsList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointsList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.EndpointsList"
 ):
     """EndpointsList is a list of endpoints.
 
@@ -8391,7 +8309,7 @@ class EndpointsList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointsListOptions",
+    jsii_type="k8s.EndpointsListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -8451,7 +8369,7 @@ class EndpointsListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EndpointsOptions",
+    jsii_type="k8s.EndpointsOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "subsets": "subsets"},
 )
@@ -8526,7 +8444,7 @@ class EndpointsOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EnvFromSource",
+    jsii_type="k8s.EnvFromSource",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_ref": "configMapRef",
@@ -8605,7 +8523,7 @@ class EnvFromSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EnvVar",
+    jsii_type="k8s.EnvVar",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value", "value_from": "valueFrom"},
 )
@@ -8685,7 +8603,7 @@ class EnvVar:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EnvVarSource",
+    jsii_type="k8s.EnvVarSource",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_key_ref": "configMapKeyRef",
@@ -8780,7 +8698,7 @@ class EnvVarSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EphemeralContainer",
+    jsii_type="k8s.EphemeralContainer",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -9198,11 +9116,7 @@ class EphemeralContainer:
         )
 
 
-class Event(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Event",
-):
+class Event(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Event"):
     """Event is a report of an event somewhere in the cluster.
 
     schema:
@@ -9271,11 +9185,7 @@ class Event(
         jsii.create(Event, self, [scope, name, options])
 
 
-class EventList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EventList",
-):
+class EventList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.EventList"):
     """EventList is a list of events.
 
     schema:
@@ -9303,7 +9213,7 @@ class EventList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EventListOptions",
+    jsii_type="k8s.EventListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -9363,7 +9273,7 @@ class EventListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EventOptions",
+    jsii_type="k8s.EventOptions",
     jsii_struct_bases=[],
     name_mapping={
         "involved_object": "involvedObject",
@@ -9619,7 +9529,7 @@ class EventOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EventSeries",
+    jsii_type="k8s.EventSeries",
     jsii_struct_bases=[],
     name_mapping={
         "count": "count",
@@ -9694,7 +9604,7 @@ class EventSeries:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EventSource",
+    jsii_type="k8s.EventSource",
     jsii_struct_bases=[],
     name_mapping={"component": "component", "host": "host"},
 )
@@ -9749,11 +9659,7 @@ class EventSource:
         )
 
 
-class Eviction(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Eviction",
-):
+class Eviction(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Eviction"):
     """Eviction evicts a pod from its node subject to certain policies and safety constraints.
 
     This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods//evictions.
@@ -9783,7 +9689,7 @@ class Eviction(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.EvictionOptions",
+    jsii_type="k8s.EvictionOptions",
     jsii_struct_bases=[],
     name_mapping={"delete_options": "deleteOptions", "metadata": "metadata"},
 )
@@ -9845,7 +9751,7 @@ class EvictionOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ExecAction",
+    jsii_type="k8s.ExecAction",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -9886,7 +9792,7 @@ class ExecAction:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ExternalDocumentation",
+    jsii_type="k8s.ExternalDocumentation",
     jsii_struct_bases=[],
     name_mapping={"description": "description", "url": "url"},
 )
@@ -9940,7 +9846,7 @@ class ExternalDocumentation:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FcVolumeSource",
+    jsii_type="k8s.FcVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "fs_type": "fsType",
@@ -10050,7 +9956,7 @@ class FcVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlexPersistentVolumeSource",
+    jsii_type="k8s.FlexPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -10162,7 +10068,7 @@ class FlexPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlexVolumeSource",
+    jsii_type="k8s.FlexVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "driver": "driver",
@@ -10274,7 +10180,7 @@ class FlexVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlockerVolumeSource",
+    jsii_type="k8s.FlockerVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"dataset_name": "datasetName", "dataset_uuid": "datasetUUID"},
 )
@@ -10334,7 +10240,7 @@ class FlockerVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowDistinguisherMethod",
+    jsii_type="k8s.FlowDistinguisherMethod",
     jsii_struct_bases=[],
     name_mapping={"type": "type"},
 )
@@ -10374,11 +10280,7 @@ class FlowDistinguisherMethod:
         )
 
 
-class FlowSchema(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowSchema",
-):
+class FlowSchema(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.FlowSchema"):
     """FlowSchema defines the schema of a group of flows.
 
     Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -10408,9 +10310,7 @@ class FlowSchema(
 
 
 class FlowSchemaList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowSchemaList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.FlowSchemaList"
 ):
     """FlowSchemaList is a list of FlowSchema objects.
 
@@ -10439,7 +10339,7 @@ class FlowSchemaList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowSchemaListOptions",
+    jsii_type="k8s.FlowSchemaListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -10499,7 +10399,7 @@ class FlowSchemaListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowSchemaOptions",
+    jsii_type="k8s.FlowSchemaOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -10565,7 +10465,7 @@ class FlowSchemaOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FlowSchemaSpec",
+    jsii_type="k8s.FlowSchemaSpec",
     jsii_struct_bases=[],
     name_mapping={
         "priority_level_configuration": "priorityLevelConfiguration",
@@ -10666,7 +10566,7 @@ class FlowSchemaSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.FsGroupStrategyOptions",
+    jsii_type="k8s.FsGroupStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={"ranges": "ranges", "rule": "rule"},
 )
@@ -10724,7 +10624,7 @@ class FsGroupStrategyOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.GcePersistentDiskVolumeSource",
+    jsii_type="k8s.GcePersistentDiskVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "pd_name": "pdName",
@@ -10824,7 +10724,7 @@ class GcePersistentDiskVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.GitRepoVolumeSource",
+    jsii_type="k8s.GitRepoVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "repository": "repository",
@@ -10903,7 +10803,7 @@ class GitRepoVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.GlusterfsPersistentVolumeSource",
+    jsii_type="k8s.GlusterfsPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "endpoints": "endpoints",
@@ -11002,7 +10902,7 @@ class GlusterfsPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.GlusterfsVolumeSource",
+    jsii_type="k8s.GlusterfsVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"endpoints": "endpoints", "path": "path", "read_only": "readOnly"},
 )
@@ -11077,7 +10977,7 @@ class GlusterfsVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Handler",
+    jsii_type="k8s.Handler",
     jsii_struct_bases=[],
     name_mapping={"exec": "exec", "http_get": "httpGet", "tcp_socket": "tcpSocket"},
 )
@@ -11156,9 +11056,7 @@ class Handler:
 
 
 class HorizontalPodAutoscaler(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HorizontalPodAutoscaler",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.HorizontalPodAutoscaler"
 ):
     """configuration of a horizontal pod autoscaler.
 
@@ -11189,7 +11087,7 @@ class HorizontalPodAutoscaler(
 class HorizontalPodAutoscalerList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HorizontalPodAutoscalerList",
+    jsii_type="k8s.HorizontalPodAutoscalerList",
 ):
     """list of horizontal pod autoscaler objects.
 
@@ -11218,7 +11116,7 @@ class HorizontalPodAutoscalerList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HorizontalPodAutoscalerListOptions",
+    jsii_type="k8s.HorizontalPodAutoscalerListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -11276,7 +11174,7 @@ class HorizontalPodAutoscalerListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HorizontalPodAutoscalerOptions",
+    jsii_type="k8s.HorizontalPodAutoscalerOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -11340,7 +11238,7 @@ class HorizontalPodAutoscalerOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HorizontalPodAutoscalerSpec",
+    jsii_type="k8s.HorizontalPodAutoscalerSpec",
     jsii_struct_bases=[],
     name_mapping={
         "max_replicas": "maxReplicas",
@@ -11438,7 +11336,7 @@ class HorizontalPodAutoscalerSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HostAlias",
+    jsii_type="k8s.HostAlias",
     jsii_struct_bases=[],
     name_mapping={"hostnames": "hostnames", "ip": "ip"},
 )
@@ -11494,7 +11392,7 @@ class HostAlias:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HostPathVolumeSource",
+    jsii_type="k8s.HostPathVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "type": "type"},
 )
@@ -11552,7 +11450,7 @@ class HostPathVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HostPortRange",
+    jsii_type="k8s.HostPortRange",
     jsii_struct_bases=[],
     name_mapping={"max": "max", "min": "min"},
 )
@@ -11604,7 +11502,7 @@ class HostPortRange:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HttpGetAction",
+    jsii_type="k8s.HttpGetAction",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -11716,7 +11614,7 @@ class HttpGetAction:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HttpHeader",
+    jsii_type="k8s.HttpHeader",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -11766,7 +11664,7 @@ class HttpHeader:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HttpIngressPath",
+    jsii_type="k8s.HttpIngressPath",
     jsii_struct_bases=[],
     name_mapping={"backend": "backend", "path": "path"},
 )
@@ -11823,7 +11721,7 @@ class HttpIngressPath:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.HttpIngressRuleValue",
+    jsii_type="k8s.HttpIngressRuleValue",
     jsii_struct_bases=[],
     name_mapping={"paths": "paths"},
 )
@@ -11864,7 +11762,7 @@ class HttpIngressRuleValue:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IdRange",
+    jsii_type="k8s.IdRange",
     jsii_struct_bases=[],
     name_mapping={"max": "max", "min": "min"},
 )
@@ -11913,11 +11811,7 @@ class IdRange:
         )
 
 
-class Ingress(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Ingress",
-):
+class Ingress(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Ingress"):
     """Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
     An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
@@ -11947,7 +11841,7 @@ class Ingress(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressBackend",
+    jsii_type="k8s.IngressBackend",
     jsii_struct_bases=[],
     name_mapping={"service_name": "serviceName", "service_port": "servicePort"},
 )
@@ -11997,9 +11891,7 @@ class IngressBackend:
 
 
 class IngressList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.IngressList"
 ):
     """IngressList is a collection of Ingress.
 
@@ -12028,7 +11920,7 @@ class IngressList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressListOptions",
+    jsii_type="k8s.IngressListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -12088,7 +11980,7 @@ class IngressListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressOptions",
+    jsii_type="k8s.IngressOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -12154,7 +12046,7 @@ class IngressOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressRule",
+    jsii_type="k8s.IngressRule",
     jsii_struct_bases=[],
     name_mapping={"host": "host", "http": "http"},
 )
@@ -12220,7 +12112,7 @@ class IngressRule:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressSpec",
+    jsii_type="k8s.IngressSpec",
     jsii_struct_bases=[],
     name_mapping={"backend": "backend", "rules": "rules", "tls": "tls"},
 )
@@ -12297,7 +12189,7 @@ class IngressSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IngressTls",
+    jsii_type="k8s.IngressTls",
     jsii_struct_bases=[],
     name_mapping={"hosts": "hosts", "secret_name": "secretName"},
 )
@@ -12359,10 +12251,7 @@ class IngressTls:
         )
 
 
-class IntOrString(
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IntOrString",
-):
+class IntOrString(metaclass=jsii.JSIIMeta, jsii_type="k8s.IntOrString"):
     """
     schema:
     :schema:: io.k8s.apimachinery.pkg.util.intstr.IntOrString
@@ -12385,9 +12274,7 @@ class IntOrString(
         return jsii.sinvoke(cls, "fromString", [value])
 
 
-@jsii.enum(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind"
-)
+@jsii.enum(jsii_type="k8s.IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind")
 class IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind(enum.Enum):
     """Kind is a string value representing the REST resource this object represents.
 
@@ -12402,7 +12289,7 @@ class IoK8SApimachineryPkgApisMetaV1DeleteOptionsKind(enum.Enum):
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IpBlock",
+    jsii_type="k8s.IpBlock",
     jsii_struct_bases=[],
     name_mapping={"cidr": "cidr", "except_": "except"},
 )
@@ -12457,7 +12344,7 @@ class IpBlock:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IscsiPersistentVolumeSource",
+    jsii_type="k8s.IscsiPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "iqn": "iqn",
@@ -12662,7 +12549,7 @@ class IscsiPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.IscsiVolumeSource",
+    jsii_type="k8s.IscsiVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "iqn": "iqn",
@@ -12866,11 +12753,7 @@ class IscsiVolumeSource:
         )
 
 
-class Job(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Job",
-):
+class Job(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Job"):
     """Job represents the configuration of a single job.
 
     schema:
@@ -12897,11 +12780,7 @@ class Job(
         jsii.create(Job, self, [scope, name, options])
 
 
-class JobList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JobList",
-):
+class JobList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.JobList"):
     """JobList is a collection of jobs.
 
     schema:
@@ -12929,7 +12808,7 @@ class JobList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JobListOptions",
+    jsii_type="k8s.JobListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -12986,7 +12865,7 @@ class JobListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JobOptions",
+    jsii_type="k8s.JobOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -13050,7 +12929,7 @@ class JobOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JobSpec",
+    jsii_type="k8s.JobSpec",
     jsii_struct_bases=[],
     name_mapping={
         "template": "template",
@@ -13216,7 +13095,7 @@ class JobSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JobTemplateSpec",
+    jsii_type="k8s.JobTemplateSpec",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -13280,7 +13159,7 @@ class JobTemplateSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.JsonSchemaProps",
+    jsii_type="k8s.JsonSchemaProps",
     jsii_struct_bases=[],
     name_mapping={
         "additional_items": "additionalItems",
@@ -13806,7 +13685,7 @@ class JsonSchemaProps:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.KeyToPath",
+    jsii_type="k8s.KeyToPath",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "path": "path", "mode": "mode"},
 )
@@ -13874,7 +13753,7 @@ class KeyToPath:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LabelSelector",
+    jsii_type="k8s.LabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -13943,7 +13822,7 @@ class LabelSelector:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LabelSelectorRequirement",
+    jsii_type="k8s.LabelSelectorRequirement",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -14014,11 +13893,7 @@ class LabelSelectorRequirement:
         )
 
 
-class Lease(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Lease",
-):
+class Lease(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Lease"):
     """Lease defines a lease concept.
 
     schema:
@@ -14045,11 +13920,7 @@ class Lease(
         jsii.create(Lease, self, [scope, name, options])
 
 
-class LeaseList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LeaseList",
-):
+class LeaseList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.LeaseList"):
     """LeaseList is a list of Lease objects.
 
     schema:
@@ -14077,7 +13948,7 @@ class LeaseList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LeaseListOptions",
+    jsii_type="k8s.LeaseListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -14137,7 +14008,7 @@ class LeaseListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LeaseOptions",
+    jsii_type="k8s.LeaseOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -14199,7 +14070,7 @@ class LeaseOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LeaseSpec",
+    jsii_type="k8s.LeaseSpec",
     jsii_struct_bases=[],
     name_mapping={
         "acquire_time": "acquireTime",
@@ -14302,7 +14173,7 @@ class LeaseSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Lifecycle",
+    jsii_type="k8s.Lifecycle",
     jsii_struct_bases=[],
     name_mapping={"post_start": "postStart", "pre_stop": "preStop"},
 )
@@ -14367,11 +14238,7 @@ class Lifecycle:
         )
 
 
-class LimitRange(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRange",
-):
+class LimitRange(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.LimitRange"):
     """LimitRange sets resource usage limits for each kind of resource in a Namespace.
 
     schema:
@@ -14399,7 +14266,7 @@ class LimitRange(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRangeItem",
+    jsii_type="k8s.LimitRangeItem",
     jsii_struct_bases=[],
     name_mapping={
         "default": "default",
@@ -14520,9 +14387,7 @@ class LimitRangeItem:
 
 
 class LimitRangeList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRangeList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.LimitRangeList"
 ):
     """LimitRangeList is a list of LimitRange items.
 
@@ -14551,7 +14416,7 @@ class LimitRangeList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRangeListOptions",
+    jsii_type="k8s.LimitRangeListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -14613,7 +14478,7 @@ class LimitRangeListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRangeOptions",
+    jsii_type="k8s.LimitRangeOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -14677,7 +14542,7 @@ class LimitRangeOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitRangeSpec",
+    jsii_type="k8s.LimitRangeSpec",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits"},
 )
@@ -14716,7 +14581,7 @@ class LimitRangeSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitResponse",
+    jsii_type="k8s.LimitResponse",
     jsii_struct_bases=[],
     name_mapping={"type": "type", "queuing": "queuing"},
 )
@@ -14775,7 +14640,7 @@ class LimitResponse:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LimitedPriorityLevelConfiguration",
+    jsii_type="k8s.LimitedPriorityLevelConfiguration",
     jsii_struct_bases=[],
     name_mapping={
         "assured_concurrency_shares": "assuredConcurrencyShares",
@@ -14846,7 +14711,7 @@ class LimitedPriorityLevelConfiguration:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ListMeta",
+    jsii_type="k8s.ListMeta",
     jsii_struct_bases=[],
     name_mapping={
         "continue_": "continue",
@@ -14943,7 +14808,7 @@ class ListMeta:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LocalObjectReference",
+    jsii_type="k8s.LocalObjectReference",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -14984,9 +14849,7 @@ class LocalObjectReference:
 
 
 class LocalSubjectAccessReview(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LocalSubjectAccessReview",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.LocalSubjectAccessReview"
 ):
     """LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 
@@ -15017,7 +14880,7 @@ class LocalSubjectAccessReview(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LocalSubjectAccessReviewOptions",
+    jsii_type="k8s.LocalSubjectAccessReviewOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -15080,7 +14943,7 @@ class LocalSubjectAccessReviewOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.LocalVolumeSource",
+    jsii_type="k8s.LocalVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "fs_type": "fsType"},
 )
@@ -15135,7 +14998,7 @@ class LocalVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ManagedFieldsEntry",
+    jsii_type="k8s.ManagedFieldsEntry",
     jsii_struct_bases=[],
     name_mapping={
         "api_version": "apiVersion",
@@ -15258,7 +15121,7 @@ class ManagedFieldsEntry:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.MutatingWebhook",
+    jsii_type="k8s.MutatingWebhook",
     jsii_struct_bases=[],
     name_mapping={
         "admission_review_versions": "admissionReviewVersions",
@@ -15527,7 +15390,7 @@ class MutatingWebhook:
 class MutatingWebhookConfiguration(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.MutatingWebhookConfiguration",
+    jsii_type="k8s.MutatingWebhookConfiguration",
 ):
     """MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
 
@@ -15560,7 +15423,7 @@ class MutatingWebhookConfiguration(
 class MutatingWebhookConfigurationList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.MutatingWebhookConfigurationList",
+    jsii_type="k8s.MutatingWebhookConfigurationList",
 ):
     """MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
 
@@ -15591,7 +15454,7 @@ class MutatingWebhookConfigurationList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.MutatingWebhookConfigurationListOptions",
+    jsii_type="k8s.MutatingWebhookConfigurationListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -15651,7 +15514,7 @@ class MutatingWebhookConfigurationListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.MutatingWebhookConfigurationOptions",
+    jsii_type="k8s.MutatingWebhookConfigurationOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "webhooks": "webhooks"},
 )
@@ -15710,11 +15573,7 @@ class MutatingWebhookConfigurationOptions:
         )
 
 
-class Namespace(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Namespace",
-):
+class Namespace(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Namespace"):
     """Namespace provides a scope for Names.
 
     Use of multiple namespaces is optional.
@@ -15744,9 +15603,7 @@ class Namespace(
 
 
 class NamespaceList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NamespaceList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.NamespaceList"
 ):
     """NamespaceList is a list of Namespaces.
 
@@ -15775,7 +15632,7 @@ class NamespaceList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NamespaceListOptions",
+    jsii_type="k8s.NamespaceListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -15837,7 +15694,7 @@ class NamespaceListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NamespaceOptions",
+    jsii_type="k8s.NamespaceOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -15903,7 +15760,7 @@ class NamespaceOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NamespaceSpec",
+    jsii_type="k8s.NamespaceSpec",
     jsii_struct_bases=[],
     name_mapping={"finalizers": "finalizers"},
 )
@@ -15944,9 +15801,7 @@ class NamespaceSpec:
 
 
 class NetworkPolicy(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicy",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.NetworkPolicy"
 ):
     """NetworkPolicy describes what network traffic is allowed for a set of Pods.
 
@@ -15975,7 +15830,7 @@ class NetworkPolicy(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyEgressRule",
+    jsii_type="k8s.NetworkPolicyEgressRule",
     jsii_struct_bases=[],
     name_mapping={"ports": "ports", "to": "to"},
 )
@@ -16037,7 +15892,7 @@ class NetworkPolicyEgressRule:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyIngressRule",
+    jsii_type="k8s.NetworkPolicyIngressRule",
     jsii_struct_bases=[],
     name_mapping={"from_": "from", "ports": "ports"},
 )
@@ -16099,9 +15954,7 @@ class NetworkPolicyIngressRule:
 
 
 class NetworkPolicyList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.NetworkPolicyList"
 ):
     """NetworkPolicyList is a list of NetworkPolicy objects.
 
@@ -16130,7 +15983,7 @@ class NetworkPolicyList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyListOptions",
+    jsii_type="k8s.NetworkPolicyListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -16190,7 +16043,7 @@ class NetworkPolicyListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyOptions",
+    jsii_type="k8s.NetworkPolicyOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -16252,7 +16105,7 @@ class NetworkPolicyOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyPeer",
+    jsii_type="k8s.NetworkPolicyPeer",
     jsii_struct_bases=[],
     name_mapping={
         "ip_block": "ipBlock",
@@ -16343,7 +16196,7 @@ class NetworkPolicyPeer:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicyPort",
+    jsii_type="k8s.NetworkPolicyPort",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "protocol": "protocol"},
 )
@@ -16403,7 +16256,7 @@ class NetworkPolicyPort:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NetworkPolicySpec",
+    jsii_type="k8s.NetworkPolicySpec",
     jsii_struct_bases=[],
     name_mapping={
         "pod_selector": "podSelector",
@@ -16500,7 +16353,7 @@ class NetworkPolicySpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NfsVolumeSource",
+    jsii_type="k8s.NfsVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "server": "server", "read_only": "readOnly"},
 )
@@ -16574,11 +16427,7 @@ class NfsVolumeSource:
         )
 
 
-class Node(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Node",
-):
+class Node(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Node"):
     """Node is a worker node in Kubernetes.
 
     Each node will have a unique identifier in the cache (i.e. in etcd).
@@ -16608,7 +16457,7 @@ class Node(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeAffinity",
+    jsii_type="k8s.NodeAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -16687,7 +16536,7 @@ class NodeAffinity:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeConfigSource",
+    jsii_type="k8s.NodeConfigSource",
     jsii_struct_bases=[],
     name_mapping={"config_map": "configMap"},
 )
@@ -16731,11 +16580,7 @@ class NodeConfigSource:
         )
 
 
-class NodeList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeList",
-):
+class NodeList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.NodeList"):
     """NodeList is the whole list of all Nodes which have been registered with master.
 
     schema:
@@ -16763,7 +16608,7 @@ class NodeList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeListOptions",
+    jsii_type="k8s.NodeListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -16823,7 +16668,7 @@ class NodeListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeOptions",
+    jsii_type="k8s.NodeOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -16889,7 +16734,7 @@ class NodeOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeSelector",
+    jsii_type="k8s.NodeSelector",
     jsii_struct_bases=[],
     name_mapping={"node_selector_terms": "nodeSelectorTerms"},
 )
@@ -16932,7 +16777,7 @@ class NodeSelector:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeSelectorRequirement",
+    jsii_type="k8s.NodeSelectorRequirement",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -17004,7 +16849,7 @@ class NodeSelectorRequirement:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeSelectorTerm",
+    jsii_type="k8s.NodeSelectorTerm",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -17069,7 +16914,7 @@ class NodeSelectorTerm:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NodeSpec",
+    jsii_type="k8s.NodeSpec",
     jsii_struct_bases=[],
     name_mapping={
         "config_source": "configSource",
@@ -17206,7 +17051,7 @@ class NodeSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NonResourceAttributes",
+    jsii_type="k8s.NonResourceAttributes",
     jsii_struct_bases=[],
     name_mapping={"path": "path", "verb": "verb"},
 )
@@ -17259,7 +17104,7 @@ class NonResourceAttributes:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.NonResourcePolicyRule",
+    jsii_type="k8s.NonResourcePolicyRule",
     jsii_struct_bases=[],
     name_mapping={"non_resource_ur_ls": "nonResourceURLs", "verbs": "verbs"},
 )
@@ -17324,7 +17169,7 @@ class NonResourcePolicyRule:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ObjectFieldSelector",
+    jsii_type="k8s.ObjectFieldSelector",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -17377,7 +17222,7 @@ class ObjectFieldSelector:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ObjectMeta",
+    jsii_type="k8s.ObjectMeta",
     jsii_struct_bases=[],
     name_mapping={
         "annotations": "annotations",
@@ -17680,7 +17525,7 @@ class ObjectMeta:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ObjectReference",
+    jsii_type="k8s.ObjectReference",
     jsii_struct_bases=[],
     name_mapping={
         "api_version": "apiVersion",
@@ -17819,7 +17664,7 @@ class ObjectReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Overhead",
+    jsii_type="k8s.Overhead",
     jsii_struct_bases=[],
     name_mapping={"pod_fixed": "podFixed"},
 )
@@ -17860,7 +17705,7 @@ class Overhead:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.OwnerReference",
+    jsii_type="k8s.OwnerReference",
     jsii_struct_bases=[],
     name_mapping={
         "api_version": "apiVersion",
@@ -17985,9 +17830,7 @@ class OwnerReference:
 
 
 class PersistentVolume(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolume",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PersistentVolume"
 ):
     """PersistentVolume (PV) is a storage resource provisioned by an administrator.
 
@@ -18018,9 +17861,7 @@ class PersistentVolume(
 
 
 class PersistentVolumeClaim(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaim",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PersistentVolumeClaim"
 ):
     """PersistentVolumeClaim is a user's request for and claim to a persistent volume.
 
@@ -18049,9 +17890,7 @@ class PersistentVolumeClaim(
 
 
 class PersistentVolumeClaimList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaimList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PersistentVolumeClaimList"
 ):
     """PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
 
@@ -18080,7 +17919,7 @@ class PersistentVolumeClaimList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaimListOptions",
+    jsii_type="k8s.PersistentVolumeClaimListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -18142,7 +17981,7 @@ class PersistentVolumeClaimListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaimOptions",
+    jsii_type="k8s.PersistentVolumeClaimOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -18206,7 +18045,7 @@ class PersistentVolumeClaimOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaimSpec",
+    jsii_type="k8s.PersistentVolumeClaimSpec",
     jsii_struct_bases=[],
     name_mapping={
         "access_modes": "accessModes",
@@ -18351,7 +18190,7 @@ class PersistentVolumeClaimSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeClaimVolumeSource",
+    jsii_type="k8s.PersistentVolumeClaimVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"claim_name": "claimName", "read_only": "readOnly"},
 )
@@ -18410,9 +18249,7 @@ class PersistentVolumeClaimVolumeSource:
 
 
 class PersistentVolumeList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PersistentVolumeList"
 ):
     """PersistentVolumeList is a list of PersistentVolume items.
 
@@ -18441,7 +18278,7 @@ class PersistentVolumeList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeListOptions",
+    jsii_type="k8s.PersistentVolumeListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -18503,7 +18340,7 @@ class PersistentVolumeListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeOptions",
+    jsii_type="k8s.PersistentVolumeOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -18569,7 +18406,7 @@ class PersistentVolumeOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PersistentVolumeSpec",
+    jsii_type="k8s.PersistentVolumeSpec",
     jsii_struct_bases=[],
     name_mapping={
         "access_modes": "accessModes",
@@ -19114,7 +18951,7 @@ class PersistentVolumeSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PhotonPersistentDiskVolumeSource",
+    jsii_type="k8s.PhotonPersistentDiskVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"pd_id": "pdID", "fs_type": "fsType"},
 )
@@ -19166,11 +19003,7 @@ class PhotonPersistentDiskVolumeSource:
         )
 
 
-class Pod(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Pod",
-):
+class Pod(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Pod"):
     """Pod is a collection of containers that can run on a host.
 
     This resource is created by clients and scheduled onto hosts.
@@ -19200,7 +19033,7 @@ class Pod(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodAffinity",
+    jsii_type="k8s.PodAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -19275,7 +19108,7 @@ class PodAffinity:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodAffinityTerm",
+    jsii_type="k8s.PodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -19354,7 +19187,7 @@ class PodAffinityTerm:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodAntiAffinity",
+    jsii_type="k8s.PodAntiAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -19429,9 +19262,7 @@ class PodAntiAffinity:
 
 
 class PodDisruptionBudget(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDisruptionBudget",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodDisruptionBudget"
 ):
     """PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods.
 
@@ -19460,9 +19291,7 @@ class PodDisruptionBudget(
 
 
 class PodDisruptionBudgetList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDisruptionBudgetList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodDisruptionBudgetList"
 ):
     """PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
 
@@ -19491,7 +19320,7 @@ class PodDisruptionBudgetList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDisruptionBudgetListOptions",
+    jsii_type="k8s.PodDisruptionBudgetListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -19547,7 +19376,7 @@ class PodDisruptionBudgetListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDisruptionBudgetOptions",
+    jsii_type="k8s.PodDisruptionBudgetOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -19606,7 +19435,7 @@ class PodDisruptionBudgetOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDisruptionBudgetSpec",
+    jsii_type="k8s.PodDisruptionBudgetSpec",
     jsii_struct_bases=[],
     name_mapping={
         "max_unavailable": "maxUnavailable",
@@ -19681,7 +19510,7 @@ class PodDisruptionBudgetSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDnsConfig",
+    jsii_type="k8s.PodDnsConfig",
     jsii_struct_bases=[],
     name_mapping={
         "nameservers": "nameservers",
@@ -19760,7 +19589,7 @@ class PodDnsConfig:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodDnsConfigOption",
+    jsii_type="k8s.PodDnsConfigOption",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -19811,11 +19640,7 @@ class PodDnsConfigOption:
         )
 
 
-class PodList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodList",
-):
+class PodList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodList"):
     """PodList is a list of Pods.
 
     schema:
@@ -19843,7 +19668,7 @@ class PodList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodListOptions",
+    jsii_type="k8s.PodListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -19902,7 +19727,7 @@ class PodListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodOptions",
+    jsii_type="k8s.PodOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -19967,11 +19792,7 @@ class PodOptions:
         )
 
 
-class PodPreset(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodPreset",
-):
+class PodPreset(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodPreset"):
     """PodPreset is a policy resource that defines additional runtime requirements for a Pod.
 
     schema:
@@ -19999,9 +19820,7 @@ class PodPreset(
 
 
 class PodPresetList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodPresetList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodPresetList"
 ):
     """PodPresetList is a list of PodPreset objects.
 
@@ -20030,7 +19849,7 @@ class PodPresetList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodPresetListOptions",
+    jsii_type="k8s.PodPresetListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -20090,7 +19909,7 @@ class PodPresetListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodPresetOptions",
+    jsii_type="k8s.PodPresetOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -20148,7 +19967,7 @@ class PodPresetOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodPresetSpec",
+    jsii_type="k8s.PodPresetSpec",
     jsii_struct_bases=[],
     name_mapping={
         "env": "env",
@@ -20253,7 +20072,7 @@ class PodPresetSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodReadinessGate",
+    jsii_type="k8s.PodReadinessGate",
     jsii_struct_bases=[],
     name_mapping={"condition_type": "conditionType"},
 )
@@ -20292,7 +20111,7 @@ class PodReadinessGate:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityContext",
+    jsii_type="k8s.PodSecurityContext",
     jsii_struct_bases=[],
     name_mapping={
         "fs_group": "fsGroup",
@@ -20464,9 +20283,7 @@ class PodSecurityContext:
 
 
 class PodSecurityPolicy(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityPolicy",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodSecurityPolicy"
 ):
     """PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
 
@@ -20495,9 +20312,7 @@ class PodSecurityPolicy(
 
 
 class PodSecurityPolicyList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityPolicyList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodSecurityPolicyList"
 ):
     """PodSecurityPolicyList is a list of PodSecurityPolicy objects.
 
@@ -20526,7 +20341,7 @@ class PodSecurityPolicyList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityPolicyListOptions",
+    jsii_type="k8s.PodSecurityPolicyListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -20586,7 +20401,7 @@ class PodSecurityPolicyListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityPolicyOptions",
+    jsii_type="k8s.PodSecurityPolicyOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -20648,7 +20463,7 @@ class PodSecurityPolicyOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSecurityPolicySpec",
+    jsii_type="k8s.PodSecurityPolicySpec",
     jsii_struct_bases=[],
     name_mapping={
         "fs_group": "fsGroup",
@@ -21060,7 +20875,7 @@ class PodSecurityPolicySpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodSpec",
+    jsii_type="k8s.PodSpec",
     jsii_struct_bases=[],
     name_mapping={
         "containers": "containers",
@@ -21671,9 +21486,7 @@ class PodSpec:
 
 
 class PodTemplate(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodTemplate",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodTemplate"
 ):
     """PodTemplate describes a template for creating copies of a predefined pod.
 
@@ -21702,9 +21515,7 @@ class PodTemplate(
 
 
 class PodTemplateList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodTemplateList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PodTemplateList"
 ):
     """PodTemplateList is a list of PodTemplates.
 
@@ -21733,7 +21544,7 @@ class PodTemplateList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodTemplateListOptions",
+    jsii_type="k8s.PodTemplateListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -21793,7 +21604,7 @@ class PodTemplateListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodTemplateOptions",
+    jsii_type="k8s.PodTemplateOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "template": "template"},
 )
@@ -21857,7 +21668,7 @@ class PodTemplateOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PodTemplateSpec",
+    jsii_type="k8s.PodTemplateSpec",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -21921,7 +21732,7 @@ class PodTemplateSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Policy",
+    jsii_type="k8s.Policy",
     jsii_struct_bases=[],
     name_mapping={"level": "level", "stages": "stages"},
 )
@@ -21976,7 +21787,7 @@ class Policy:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PolicyRule",
+    jsii_type="k8s.PolicyRule",
     jsii_struct_bases=[],
     name_mapping={
         "verbs": "verbs",
@@ -22087,7 +21898,7 @@ class PolicyRule:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PolicyRulesWithSubjects",
+    jsii_type="k8s.PolicyRulesWithSubjects",
     jsii_struct_bases=[],
     name_mapping={
         "subjects": "subjects",
@@ -22170,7 +21981,7 @@ class PolicyRulesWithSubjects:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PortworxVolumeSource",
+    jsii_type="k8s.PortworxVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "volume_id": "volumeID",
@@ -22250,7 +22061,7 @@ class PortworxVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Preconditions",
+    jsii_type="k8s.Preconditions",
     jsii_struct_bases=[],
     name_mapping={"resource_version": "resourceVersion", "uid": "uid"},
 )
@@ -22306,7 +22117,7 @@ class Preconditions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PreferredSchedulingTerm",
+    jsii_type="k8s.PreferredSchedulingTerm",
     jsii_struct_bases=[],
     name_mapping={"preference": "preference", "weight": "weight"},
 )
@@ -22358,9 +22169,7 @@ class PreferredSchedulingTerm:
 
 
 class PriorityClass(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityClass",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PriorityClass"
 ):
     """PriorityClass defines mapping from a priority class name to the priority integer value.
 
@@ -22403,9 +22212,7 @@ class PriorityClass(
 
 
 class PriorityClassList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityClassList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PriorityClassList"
 ):
     """PriorityClassList is a collection of priority classes.
 
@@ -22434,7 +22241,7 @@ class PriorityClassList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityClassListOptions",
+    jsii_type="k8s.PriorityClassListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -22492,7 +22299,7 @@ class PriorityClassListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityClassOptions",
+    jsii_type="k8s.PriorityClassOptions",
     jsii_struct_bases=[],
     name_mapping={
         "value": "value",
@@ -22608,9 +22415,7 @@ class PriorityClassOptions:
 
 
 class PriorityLevelConfiguration(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfiguration",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.PriorityLevelConfiguration"
 ):
     """PriorityLevelConfiguration represents the configuration of a priority level.
 
@@ -22641,7 +22446,7 @@ class PriorityLevelConfiguration(
 class PriorityLevelConfigurationList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfigurationList",
+    jsii_type="k8s.PriorityLevelConfigurationList",
 ):
     """PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
 
@@ -22670,7 +22475,7 @@ class PriorityLevelConfigurationList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfigurationListOptions",
+    jsii_type="k8s.PriorityLevelConfigurationListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -22730,7 +22535,7 @@ class PriorityLevelConfigurationListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfigurationOptions",
+    jsii_type="k8s.PriorityLevelConfigurationOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -22794,7 +22599,7 @@ class PriorityLevelConfigurationOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfigurationReference",
+    jsii_type="k8s.PriorityLevelConfigurationReference",
     jsii_struct_bases=[],
     name_mapping={"name": "name"},
 )
@@ -22833,7 +22638,7 @@ class PriorityLevelConfigurationReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.PriorityLevelConfigurationSpec",
+    jsii_type="k8s.PriorityLevelConfigurationSpec",
     jsii_struct_bases=[],
     name_mapping={"type": "type", "limited": "limited"},
 )
@@ -22895,7 +22700,7 @@ class PriorityLevelConfigurationSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Probe",
+    jsii_type="k8s.Probe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -23070,7 +22875,7 @@ class Probe:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ProjectedVolumeSource",
+    jsii_type="k8s.ProjectedVolumeSource",
     jsii_struct_bases=[],
     name_mapping={"sources": "sources", "default_mode": "defaultMode"},
 )
@@ -23127,10 +22932,7 @@ class ProjectedVolumeSource:
         )
 
 
-class Quantity(
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Quantity",
-):
+class Quantity(metaclass=jsii.JSIIMeta, jsii_type="k8s.Quantity"):
     """
     schema:
     :schema:: io.k8s.apimachinery.pkg.api.resource.Quantity
@@ -23154,7 +22956,7 @@ class Quantity(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.QueuingConfiguration",
+    jsii_type="k8s.QueuingConfiguration",
     jsii_struct_bases=[],
     name_mapping={
         "hand_size": "handSize",
@@ -23233,7 +23035,7 @@ class QueuingConfiguration:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.QuobyteVolumeSource",
+    jsii_type="k8s.QuobyteVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "registry": "registry",
@@ -23360,7 +23162,7 @@ class QuobyteVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RbdPersistentVolumeSource",
+    jsii_type="k8s.RbdPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -23537,7 +23339,7 @@ class RbdPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RbdVolumeSource",
+    jsii_type="k8s.RbdVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -23713,11 +23515,7 @@ class RbdVolumeSource:
         )
 
 
-class ReplicaSet(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicaSet",
-):
+class ReplicaSet(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ReplicaSet"):
     """ReplicaSet ensures that a specified number of pod replicas are running at any given time.
 
     schema:
@@ -23745,9 +23543,7 @@ class ReplicaSet(
 
 
 class ReplicaSetList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicaSetList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ReplicaSetList"
 ):
     """ReplicaSetList is a collection of ReplicaSets.
 
@@ -23776,7 +23572,7 @@ class ReplicaSetList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicaSetListOptions",
+    jsii_type="k8s.ReplicaSetListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -23838,7 +23634,7 @@ class ReplicaSetListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicaSetOptions",
+    jsii_type="k8s.ReplicaSetOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -23902,7 +23698,7 @@ class ReplicaSetOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicaSetSpec",
+    jsii_type="k8s.ReplicaSetSpec",
     jsii_struct_bases=[],
     name_mapping={
         "selector": "selector",
@@ -24007,9 +23803,7 @@ class ReplicaSetSpec:
 
 
 class ReplicationController(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicationController",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ReplicationController"
 ):
     """ReplicationController represents the configuration of a replication controller.
 
@@ -24038,9 +23832,7 @@ class ReplicationController(
 
 
 class ReplicationControllerList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicationControllerList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ReplicationControllerList"
 ):
     """ReplicationControllerList is a collection of replication controllers.
 
@@ -24069,7 +23861,7 @@ class ReplicationControllerList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicationControllerListOptions",
+    jsii_type="k8s.ReplicationControllerListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -24131,7 +23923,7 @@ class ReplicationControllerListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicationControllerOptions",
+    jsii_type="k8s.ReplicationControllerOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -24195,7 +23987,7 @@ class ReplicationControllerOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ReplicationControllerSpec",
+    jsii_type="k8s.ReplicationControllerSpec",
     jsii_struct_bases=[],
     name_mapping={
         "min_ready_seconds": "minReadySeconds",
@@ -24298,7 +24090,7 @@ class ReplicationControllerSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceAttributes",
+    jsii_type="k8s.ResourceAttributes",
     jsii_struct_bases=[],
     name_mapping={
         "group": "group",
@@ -24441,7 +24233,7 @@ class ResourceAttributes:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceFieldSelector",
+    jsii_type="k8s.ResourceFieldSelector",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -24514,7 +24306,7 @@ class ResourceFieldSelector:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourcePolicyRule",
+    jsii_type="k8s.ResourcePolicyRule",
     jsii_struct_bases=[],
     name_mapping={
         "api_groups": "apiGroups",
@@ -24623,9 +24415,7 @@ class ResourcePolicyRule:
 
 
 class ResourceQuota(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceQuota",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ResourceQuota"
 ):
     """ResourceQuota sets aggregate quota restrictions enforced per namespace.
 
@@ -24654,9 +24444,7 @@ class ResourceQuota(
 
 
 class ResourceQuotaList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceQuotaList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ResourceQuotaList"
 ):
     """ResourceQuotaList is a list of ResourceQuota items.
 
@@ -24685,7 +24473,7 @@ class ResourceQuotaList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceQuotaListOptions",
+    jsii_type="k8s.ResourceQuotaListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -24747,7 +24535,7 @@ class ResourceQuotaListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceQuotaOptions",
+    jsii_type="k8s.ResourceQuotaOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -24811,7 +24599,7 @@ class ResourceQuotaOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceQuotaSpec",
+    jsii_type="k8s.ResourceQuotaSpec",
     jsii_struct_bases=[],
     name_mapping={
         "hard": "hard",
@@ -24892,7 +24680,7 @@ class ResourceQuotaSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ResourceRequirements",
+    jsii_type="k8s.ResourceRequirements",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -24951,11 +24739,7 @@ class ResourceRequirements:
         )
 
 
-class Role(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Role",
-):
+class Role(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Role"):
     """Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 
     schema:
@@ -24983,9 +24767,7 @@ class Role(
 
 
 class RoleBinding(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleBinding",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.RoleBinding"
 ):
     """RoleBinding references a role, but does not contain it.
 
@@ -25020,9 +24802,7 @@ class RoleBinding(
 
 
 class RoleBindingList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleBindingList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.RoleBindingList"
 ):
     """RoleBindingList is a collection of RoleBindings.
 
@@ -25051,7 +24831,7 @@ class RoleBindingList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleBindingListOptions",
+    jsii_type="k8s.RoleBindingListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -25109,7 +24889,7 @@ class RoleBindingListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleBindingOptions",
+    jsii_type="k8s.RoleBindingOptions",
     jsii_struct_bases=[],
     name_mapping={
         "role_ref": "roleRef",
@@ -25189,11 +24969,7 @@ class RoleBindingOptions:
         )
 
 
-class RoleList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleList",
-):
+class RoleList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.RoleList"):
     """RoleList is a collection of Roles.
 
     schema:
@@ -25221,7 +24997,7 @@ class RoleList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleListOptions",
+    jsii_type="k8s.RoleListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -25279,7 +25055,7 @@ class RoleListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleOptions",
+    jsii_type="k8s.RoleOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "rules": "rules"},
 )
@@ -25337,7 +25113,7 @@ class RoleOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RoleRef",
+    jsii_type="k8s.RoleRef",
     jsii_struct_bases=[],
     name_mapping={"api_group": "apiGroup", "kind": "kind", "name": "name"},
 )
@@ -25398,7 +25174,7 @@ class RoleRef:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RollingUpdateDaemonSet",
+    jsii_type="k8s.RollingUpdateDaemonSet",
     jsii_struct_bases=[],
     name_mapping={"max_unavailable": "maxUnavailable"},
 )
@@ -25441,7 +25217,7 @@ class RollingUpdateDaemonSet:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RollingUpdateDeployment",
+    jsii_type="k8s.RollingUpdateDeployment",
     jsii_struct_bases=[],
     name_mapping={"max_surge": "maxSurge", "max_unavailable": "maxUnavailable"},
 )
@@ -25507,7 +25283,7 @@ class RollingUpdateDeployment:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RollingUpdateStatefulSetStrategy",
+    jsii_type="k8s.RollingUpdateStatefulSetStrategy",
     jsii_struct_bases=[],
     name_mapping={"partition": "partition"},
 )
@@ -25548,7 +25324,7 @@ class RollingUpdateStatefulSetStrategy:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuleWithOperations",
+    jsii_type="k8s.RuleWithOperations",
     jsii_struct_bases=[],
     name_mapping={
         "api_groups": "apiGroups",
@@ -25668,7 +25444,7 @@ class RuleWithOperations:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RunAsGroupStrategyOptions",
+    jsii_type="k8s.RunAsGroupStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={"rule": "rule", "ranges": "ranges"},
 )
@@ -25723,7 +25499,7 @@ class RunAsGroupStrategyOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RunAsUserStrategyOptions",
+    jsii_type="k8s.RunAsUserStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={"rule": "rule", "ranges": "ranges"},
 )
@@ -25778,9 +25554,7 @@ class RunAsUserStrategyOptions:
 
 
 class RuntimeClass(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuntimeClass",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.RuntimeClass"
 ):
     """RuntimeClass defines a class of container runtime supported in the cluster.
 
@@ -25817,9 +25591,7 @@ class RuntimeClass(
 
 
 class RuntimeClassList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuntimeClassList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.RuntimeClassList"
 ):
     """RuntimeClassList is a list of RuntimeClass objects.
 
@@ -25848,7 +25620,7 @@ class RuntimeClassList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuntimeClassListOptions",
+    jsii_type="k8s.RuntimeClassListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -25908,7 +25680,7 @@ class RuntimeClassListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuntimeClassOptions",
+    jsii_type="k8s.RuntimeClassOptions",
     jsii_struct_bases=[],
     name_mapping={
         "handler": "handler",
@@ -26009,7 +25781,7 @@ class RuntimeClassOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.RuntimeClassStrategyOptions",
+    jsii_type="k8s.RuntimeClassStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={
         "allowed_runtime_class_names": "allowedRuntimeClassNames",
@@ -26071,11 +25843,7 @@ class RuntimeClassStrategyOptions:
         )
 
 
-class Scale(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Scale",
-):
+class Scale(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Scale"):
     """Scale represents a scaling request for a resource.
 
     schema:
@@ -26103,7 +25871,7 @@ class Scale(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScaleIoPersistentVolumeSource",
+    jsii_type="k8s.ScaleIoPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "gateway": "gateway",
@@ -26291,7 +26059,7 @@ class ScaleIoPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScaleIoVolumeSource",
+    jsii_type="k8s.ScaleIoVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "gateway": "gateway",
@@ -26479,7 +26247,7 @@ class ScaleIoVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScaleOptions",
+    jsii_type="k8s.ScaleOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -26543,7 +26311,7 @@ class ScaleOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScaleSpec",
+    jsii_type="k8s.ScaleSpec",
     jsii_struct_bases=[],
     name_mapping={"replicas": "replicas"},
 )
@@ -26582,7 +26350,7 @@ class ScaleSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Scheduling",
+    jsii_type="k8s.Scheduling",
     jsii_struct_bases=[],
     name_mapping={"node_selector": "nodeSelector", "tolerations": "tolerations"},
 )
@@ -26640,7 +26408,7 @@ class Scheduling:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScopeSelector",
+    jsii_type="k8s.ScopeSelector",
     jsii_struct_bases=[],
     name_mapping={"match_expressions": "matchExpressions"},
 )
@@ -26687,7 +26455,7 @@ class ScopeSelector:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ScopedResourceSelectorRequirement",
+    jsii_type="k8s.ScopedResourceSelectorRequirement",
     jsii_struct_bases=[],
     name_mapping={
         "operator": "operator",
@@ -26763,7 +26531,7 @@ class ScopedResourceSelectorRequirement:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SeLinuxOptions",
+    jsii_type="k8s.SeLinuxOptions",
     jsii_struct_bases=[],
     name_mapping={"level": "level", "role": "role", "type": "type", "user": "user"},
 )
@@ -26845,7 +26613,7 @@ class SeLinuxOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SeLinuxStrategyOptions",
+    jsii_type="k8s.SeLinuxStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={"rule": "rule", "se_linux_options": "seLinuxOptions"},
 )
@@ -26901,11 +26669,7 @@ class SeLinuxStrategyOptions:
         )
 
 
-class Secret(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Secret",
-):
+class Secret(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Secret"):
     """Secret holds secret data of a certain type.
 
     The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
@@ -26941,7 +26705,7 @@ class Secret(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretEnvSource",
+    jsii_type="k8s.SecretEnvSource",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "optional": "optional"},
 )
@@ -27001,7 +26765,7 @@ class SecretEnvSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretKeySelector",
+    jsii_type="k8s.SecretKeySelector",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -27073,11 +26837,7 @@ class SecretKeySelector:
         )
 
 
-class SecretList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretList",
-):
+class SecretList(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.SecretList"):
     """SecretList is a list of Secret.
 
     schema:
@@ -27105,7 +26865,7 @@ class SecretList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretListOptions",
+    jsii_type="k8s.SecretListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -27167,7 +26927,7 @@ class SecretListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretOptions",
+    jsii_type="k8s.SecretOptions",
     jsii_struct_bases=[],
     name_mapping={
         "data": "data",
@@ -27264,7 +27024,7 @@ class SecretOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretProjection",
+    jsii_type="k8s.SecretProjection",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "name": "name", "optional": "optional"},
 )
@@ -27339,7 +27099,7 @@ class SecretProjection:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretReference",
+    jsii_type="k8s.SecretReference",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "namespace": "namespace"},
 )
@@ -27397,7 +27157,7 @@ class SecretReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecretVolumeSource",
+    jsii_type="k8s.SecretVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "default_mode": "defaultMode",
@@ -27495,7 +27255,7 @@ class SecretVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SecurityContext",
+    jsii_type="k8s.SecurityContext",
     jsii_struct_bases=[],
     name_mapping={
         "allow_privilege_escalation": "allowPrivilegeEscalation",
@@ -27706,9 +27466,7 @@ class SecurityContext:
 
 
 class SelfSubjectAccessReview(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectAccessReview",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.SelfSubjectAccessReview"
 ):
     """SelfSubjectAccessReview checks whether or the current user can perform an action.
 
@@ -27739,7 +27497,7 @@ class SelfSubjectAccessReview(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectAccessReviewOptions",
+    jsii_type="k8s.SelfSubjectAccessReviewOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -27802,7 +27560,7 @@ class SelfSubjectAccessReviewOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectAccessReviewSpec",
+    jsii_type="k8s.SelfSubjectAccessReviewSpec",
     jsii_struct_bases=[],
     name_mapping={
         "non_resource_attributes": "nonResourceAttributes",
@@ -27867,9 +27625,7 @@ class SelfSubjectAccessReviewSpec:
 
 
 class SelfSubjectRulesReview(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectRulesReview",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.SelfSubjectRulesReview"
 ):
     """SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace.
 
@@ -27900,7 +27656,7 @@ class SelfSubjectRulesReview(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectRulesReviewOptions",
+    jsii_type="k8s.SelfSubjectRulesReviewOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -27961,7 +27717,7 @@ class SelfSubjectRulesReviewOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SelfSubjectRulesReviewSpec",
+    jsii_type="k8s.SelfSubjectRulesReviewSpec",
     jsii_struct_bases=[],
     name_mapping={"namespace": "namespace"},
 )
@@ -28000,11 +27756,7 @@ class SelfSubjectRulesReviewSpec:
         )
 
 
-class Service(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Service",
-):
+class Service(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Service"):
     """Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
 
     schema:
@@ -28032,9 +27784,7 @@ class Service(
 
 
 class ServiceAccount(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceAccount",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ServiceAccount"
 ):
     """ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets.
 
@@ -28072,9 +27822,7 @@ class ServiceAccount(
 
 
 class ServiceAccountList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceAccountList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ServiceAccountList"
 ):
     """ServiceAccountList is a list of ServiceAccount objects.
 
@@ -28103,7 +27851,7 @@ class ServiceAccountList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceAccountListOptions",
+    jsii_type="k8s.ServiceAccountListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -28165,7 +27913,7 @@ class ServiceAccountListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceAccountOptions",
+    jsii_type="k8s.ServiceAccountOptions",
     jsii_struct_bases=[],
     name_mapping={
         "automount_service_account_token": "automountServiceAccountToken",
@@ -28266,7 +28014,7 @@ class ServiceAccountOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceAccountTokenProjection",
+    jsii_type="k8s.ServiceAccountTokenProjection",
     jsii_struct_bases=[],
     name_mapping={
         "path": "path",
@@ -28348,9 +28096,7 @@ class ServiceAccountTokenProjection:
 
 
 class ServiceList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.ServiceList"
 ):
     """ServiceList holds a list of services.
 
@@ -28379,7 +28125,7 @@ class ServiceList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceListOptions",
+    jsii_type="k8s.ServiceListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -28439,7 +28185,7 @@ class ServiceListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceOptions",
+    jsii_type="k8s.ServiceOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -28503,7 +28249,7 @@ class ServiceOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServicePort",
+    jsii_type="k8s.ServicePort",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -28618,7 +28364,7 @@ class ServicePort:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceReference",
+    jsii_type="k8s.ServiceReference",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -28713,7 +28459,7 @@ class ServiceReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ServiceSpec",
+    jsii_type="k8s.ServiceSpec",
     jsii_struct_bases=[],
     name_mapping={
         "cluster_ip": "clusterIP",
@@ -28988,7 +28734,7 @@ class ServiceSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SessionAffinityConfig",
+    jsii_type="k8s.SessionAffinityConfig",
     jsii_struct_bases=[],
     name_mapping={"client_ip": "clientIP"},
 )
@@ -29029,9 +28775,7 @@ class SessionAffinityConfig:
 
 
 class StatefulSet(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSet",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.StatefulSet"
 ):
     """StatefulSet represents a set of pods with consistent identities.
 
@@ -29066,9 +28810,7 @@ class StatefulSet(
 
 
 class StatefulSetList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSetList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.StatefulSetList"
 ):
     """StatefulSetList is a collection of StatefulSets.
 
@@ -29097,7 +28839,7 @@ class StatefulSetList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSetListOptions",
+    jsii_type="k8s.StatefulSetListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -29153,7 +28895,7 @@ class StatefulSetListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSetOptions",
+    jsii_type="k8s.StatefulSetOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "spec": "spec"},
 )
@@ -29218,7 +28960,7 @@ class StatefulSetOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSetSpec",
+    jsii_type="k8s.StatefulSetSpec",
     jsii_struct_bases=[],
     name_mapping={
         "selector": "selector",
@@ -29383,7 +29125,7 @@ class StatefulSetSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatefulSetUpdateStrategy",
+    jsii_type="k8s.StatefulSetUpdateStrategy",
     jsii_struct_bases=[],
     name_mapping={"rolling_update": "rollingUpdate", "type": "type"},
 )
@@ -29447,11 +29189,7 @@ class StatefulSetUpdateStrategy:
         )
 
 
-class Status(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Status",
-):
+class Status(cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.Status"):
     """Status is a return value for calls that don't return other objects.
 
     schema:
@@ -29491,7 +29229,7 @@ class Status(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatusCause",
+    jsii_type="k8s.StatusCause",
     jsii_struct_bases=[],
     name_mapping={"field": "field", "message": "message", "reason": "reason"},
 )
@@ -29570,7 +29308,7 @@ class StatusCause:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatusDetails",
+    jsii_type="k8s.StatusDetails",
     jsii_struct_bases=[],
     name_mapping={
         "causes": "causes",
@@ -29695,7 +29433,7 @@ class StatusDetails:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StatusOptions",
+    jsii_type="k8s.StatusOptions",
     jsii_struct_bases=[],
     name_mapping={
         "code": "code",
@@ -29806,9 +29544,7 @@ class StatusOptions:
 
 
 class StorageClass(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageClass",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.StorageClass"
 ):
     """StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
 
@@ -29860,9 +29596,7 @@ class StorageClass(
 
 
 class StorageClassList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageClassList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.StorageClassList"
 ):
     """StorageClassList is a collection of storage classes.
 
@@ -29891,7 +29625,7 @@ class StorageClassList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageClassListOptions",
+    jsii_type="k8s.StorageClassListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -29949,7 +29683,7 @@ class StorageClassListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageClassOptions",
+    jsii_type="k8s.StorageClassOptions",
     jsii_struct_bases=[],
     name_mapping={
         "provisioner": "provisioner",
@@ -30109,7 +29843,7 @@ class StorageClassOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageOsPersistentVolumeSource",
+    jsii_type="k8s.StorageOsPersistentVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "fs_type": "fsType",
@@ -30225,7 +29959,7 @@ class StorageOsPersistentVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.StorageOsVolumeSource",
+    jsii_type="k8s.StorageOsVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "fs_type": "fsType",
@@ -30341,7 +30075,7 @@ class StorageOsVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Subject",
+    jsii_type="k8s.Subject",
     jsii_struct_bases=[],
     name_mapping={
         "kind": "kind",
@@ -30438,9 +30172,7 @@ class Subject:
 
 
 class SubjectAccessReview(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SubjectAccessReview",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.SubjectAccessReview"
 ):
     """SubjectAccessReview checks whether or not a user or group can perform an action.
 
@@ -30469,7 +30201,7 @@ class SubjectAccessReview(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SubjectAccessReviewOptions",
+    jsii_type="k8s.SubjectAccessReviewOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -30528,7 +30260,7 @@ class SubjectAccessReviewOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SubjectAccessReviewSpec",
+    jsii_type="k8s.SubjectAccessReviewSpec",
     jsii_struct_bases=[],
     name_mapping={
         "extra": "extra",
@@ -30651,7 +30383,7 @@ class SubjectAccessReviewSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.SupplementalGroupsStrategyOptions",
+    jsii_type="k8s.SupplementalGroupsStrategyOptions",
     jsii_struct_bases=[],
     name_mapping={"ranges": "ranges", "rule": "rule"},
 )
@@ -30709,7 +30441,7 @@ class SupplementalGroupsStrategyOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Sysctl",
+    jsii_type="k8s.Sysctl",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -30759,7 +30491,7 @@ class Sysctl:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Taint",
+    jsii_type="k8s.Taint",
     jsii_struct_bases=[],
     name_mapping={
         "effect": "effect",
@@ -30853,7 +30585,7 @@ class Taint:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TcpSocketAction",
+    jsii_type="k8s.TcpSocketAction",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -30908,9 +30640,7 @@ class TcpSocketAction:
 
 
 class TokenRequest(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenRequest",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.TokenRequest"
 ):
     """TokenRequest requests a token for a given service account.
 
@@ -30939,7 +30669,7 @@ class TokenRequest(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenRequestOptions",
+    jsii_type="k8s.TokenRequestOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -30997,7 +30727,7 @@ class TokenRequestOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenRequestSpec",
+    jsii_type="k8s.TokenRequestSpec",
     jsii_struct_bases=[],
     name_mapping={
         "audiences": "audiences",
@@ -31078,9 +30808,7 @@ class TokenRequestSpec:
 
 
 class TokenReview(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenReview",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.TokenReview"
 ):
     """TokenReview attempts to authenticate a token to a known user.
 
@@ -31111,7 +30839,7 @@ class TokenReview(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenReviewOptions",
+    jsii_type="k8s.TokenReviewOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -31169,7 +30897,7 @@ class TokenReviewOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TokenReviewSpec",
+    jsii_type="k8s.TokenReviewSpec",
     jsii_struct_bases=[],
     name_mapping={"audiences": "audiences", "token": "token"},
 )
@@ -31227,7 +30955,7 @@ class TokenReviewSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Toleration",
+    jsii_type="k8s.Toleration",
     jsii_struct_bases=[],
     name_mapping={
         "effect": "effect",
@@ -31341,7 +31069,7 @@ class Toleration:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TopologySelectorLabelRequirement",
+    jsii_type="k8s.TopologySelectorLabelRequirement",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "values": "values"},
 )
@@ -31395,7 +31123,7 @@ class TopologySelectorLabelRequirement:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TopologySelectorTerm",
+    jsii_type="k8s.TopologySelectorTerm",
     jsii_struct_bases=[],
     name_mapping={"match_label_expressions": "matchLabelExpressions"},
 )
@@ -31444,7 +31172,7 @@ class TopologySelectorTerm:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TopologySpreadConstraint",
+    jsii_type="k8s.TopologySpreadConstraint",
     jsii_struct_bases=[],
     name_mapping={
         "max_skew": "maxSkew",
@@ -31539,7 +31267,7 @@ class TopologySpreadConstraint:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.TypedLocalObjectReference",
+    jsii_type="k8s.TypedLocalObjectReference",
     jsii_struct_bases=[],
     name_mapping={"kind": "kind", "name": "name", "api_group": "apiGroup"},
 )
@@ -31605,7 +31333,7 @@ class TypedLocalObjectReference:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ValidatingWebhook",
+    jsii_type="k8s.ValidatingWebhook",
     jsii_struct_bases=[],
     name_mapping={
         "admission_review_versions": "admissionReviewVersions",
@@ -31849,7 +31577,7 @@ class ValidatingWebhook:
 class ValidatingWebhookConfiguration(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ValidatingWebhookConfiguration",
+    jsii_type="k8s.ValidatingWebhookConfiguration",
 ):
     """ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
 
@@ -31882,7 +31610,7 @@ class ValidatingWebhookConfiguration(
 class ValidatingWebhookConfigurationList(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ValidatingWebhookConfigurationList",
+    jsii_type="k8s.ValidatingWebhookConfigurationList",
 ):
     """ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
 
@@ -31913,7 +31641,7 @@ class ValidatingWebhookConfigurationList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ValidatingWebhookConfigurationListOptions",
+    jsii_type="k8s.ValidatingWebhookConfigurationListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -31973,7 +31701,7 @@ class ValidatingWebhookConfigurationListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.ValidatingWebhookConfigurationOptions",
+    jsii_type="k8s.ValidatingWebhookConfigurationOptions",
     jsii_struct_bases=[],
     name_mapping={"metadata": "metadata", "webhooks": "webhooks"},
 )
@@ -32033,7 +31761,7 @@ class ValidatingWebhookConfigurationOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Volume",
+    jsii_type="k8s.Volume",
     jsii_struct_bases=[],
     name_mapping={
         "name": "name",
@@ -32570,9 +32298,7 @@ class Volume:
 
 
 class VolumeAttachment(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachment",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.VolumeAttachment"
 ):
     """VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
 
@@ -32603,9 +32329,7 @@ class VolumeAttachment(
 
 
 class VolumeAttachmentList(
-    cdk8s.ApiObject,
-    metaclass=jsii.JSIIMeta,
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachmentList",
+    cdk8s.ApiObject, metaclass=jsii.JSIIMeta, jsii_type="k8s.VolumeAttachmentList"
 ):
     """VolumeAttachmentList is a collection of VolumeAttachment objects.
 
@@ -32634,7 +32358,7 @@ class VolumeAttachmentList(
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachmentListOptions",
+    jsii_type="k8s.VolumeAttachmentListOptions",
     jsii_struct_bases=[],
     name_mapping={"items": "items", "metadata": "metadata"},
 )
@@ -32692,7 +32416,7 @@ class VolumeAttachmentListOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachmentOptions",
+    jsii_type="k8s.VolumeAttachmentOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -32758,7 +32482,7 @@ class VolumeAttachmentOptions:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachmentSource",
+    jsii_type="k8s.VolumeAttachmentSource",
     jsii_struct_bases=[],
     name_mapping={
         "inline_volume_spec": "inlineVolumeSpec",
@@ -32823,7 +32547,7 @@ class VolumeAttachmentSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeAttachmentSpec",
+    jsii_type="k8s.VolumeAttachmentSpec",
     jsii_struct_bases=[],
     name_mapping={"attacher": "attacher", "node_name": "nodeName", "source": "source"},
 )
@@ -32890,7 +32614,7 @@ class VolumeAttachmentSpec:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeDevice",
+    jsii_type="k8s.VolumeDevice",
     jsii_struct_bases=[],
     name_mapping={"device_path": "devicePath", "name": "name"},
 )
@@ -32940,7 +32664,7 @@ class VolumeDevice:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeMount",
+    jsii_type="k8s.VolumeMount",
     jsii_struct_bases=[],
     name_mapping={
         "mount_path": "mountPath",
@@ -33073,7 +32797,7 @@ class VolumeMount:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeNodeAffinity",
+    jsii_type="k8s.VolumeNodeAffinity",
     jsii_struct_bases=[],
     name_mapping={"required": "required"},
 )
@@ -33114,7 +32838,7 @@ class VolumeNodeAffinity:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeNodeResources",
+    jsii_type="k8s.VolumeNodeResources",
     jsii_struct_bases=[],
     name_mapping={"count": "count"},
 )
@@ -33155,7 +32879,7 @@ class VolumeNodeResources:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VolumeProjection",
+    jsii_type="k8s.VolumeProjection",
     jsii_struct_bases=[],
     name_mapping={
         "config_map": "configMap",
@@ -33252,7 +32976,7 @@ class VolumeProjection:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.VsphereVirtualDiskVolumeSource",
+    jsii_type="k8s.VsphereVirtualDiskVolumeSource",
     jsii_struct_bases=[],
     name_mapping={
         "volume_path": "volumePath",
@@ -33341,7 +33065,7 @@ class VsphereVirtualDiskVolumeSource:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.Webhook",
+    jsii_type="k8s.Webhook",
     jsii_struct_bases=[],
     name_mapping={"client_config": "clientConfig", "throttle": "throttle"},
 )
@@ -33401,7 +33125,7 @@ class Webhook:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.WebhookClientConfig",
+    jsii_type="k8s.WebhookClientConfig",
     jsii_struct_bases=[],
     name_mapping={"ca_bundle": "caBundle", "service": "service", "url": "url"},
 )
@@ -33488,7 +33212,7 @@ class WebhookClientConfig:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.WebhookConversion",
+    jsii_type="k8s.WebhookConversion",
     jsii_struct_bases=[],
     name_mapping={
         "conversion_review_versions": "conversionReviewVersions",
@@ -33551,7 +33275,7 @@ class WebhookConversion:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.WebhookThrottleConfig",
+    jsii_type="k8s.WebhookThrottleConfig",
     jsii_struct_bases=[],
     name_mapping={"burst": "burst", "qps": "qps"},
 )
@@ -33607,7 +33331,7 @@ class WebhookThrottleConfig:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.WeightedPodAffinityTerm",
+    jsii_type="k8s.WeightedPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -33663,7 +33387,7 @@ class WeightedPodAffinityTerm:
 
 
 @jsii.data_type(
-    jsii_type="17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1.WindowsSecurityContextOptions",
+    jsii_type="k8s.WindowsSecurityContextOptions",
     jsii_struct_bases=[],
     name_mapping={
         "gmsa_credential_spec": "gmsaCredentialSpec",

--- a/test/test-imports/python/expected-from-config/k8s/_jsii/__init__.py
+++ b/test/test-imports/python/expected-from-config/k8s/_jsii/__init__.py
@@ -12,10 +12,7 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1",
-    "0.0.0",
-    __name__[0:-6],
-    "17c132990e8e8523ccd403287b6ae761c1cd57f764df278bce7ed310bbddd7f1@0.0.0.jsii.tgz",
+    "k8s", "0.0.0", __name__[0:-6], "k8s@0.0.0.jsii.tgz"
 )
 
 __all__ = [

--- a/test/test-imports/python/expected-from-config/mattermost/mattermost/com/clusterinstallation/__init__.py
+++ b/test/test-imports/python/expected-from-config/mattermost/mattermost/com/clusterinstallation/__init__.py
@@ -17,7 +17,7 @@ import constructs
 class ClusterInstallation(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallation",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallation",
 ):
     """ClusterInstallation is the Schema for the clusterinstallations API.
 
@@ -46,7 +46,7 @@ class ClusterInstallation(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationOptions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -102,7 +102,7 @@ class ClusterInstallationOptions:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpec",
     jsii_struct_bases=[],
     name_mapping={
         "ingress_name": "ingressName",
@@ -447,7 +447,7 @@ class ClusterInstallationSpec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "node_affinity": "nodeAffinity",
@@ -540,7 +540,7 @@ class ClusterInstallationSpecAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -627,7 +627,7 @@ class ClusterInstallationSpecAffinityNodeAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"preference": "preference", "weight": "weight"},
 )
@@ -689,7 +689,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -769,7 +769,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -842,7 +842,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -915,7 +915,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"node_selector_terms": "nodeSelectorTerms"},
 )
@@ -969,7 +969,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1051,7 +1051,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1124,7 +1124,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1197,7 +1197,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1284,7 +1284,7 @@ class ClusterInstallationSpecAffinityPodAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1348,7 +1348,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1438,7 +1438,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1512,7 +1512,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1585,7 +1585,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1673,7 +1673,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1747,7 +1747,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1820,7 +1820,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1907,7 +1907,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1971,7 +1971,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2061,7 +2061,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2135,7 +2135,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2208,7 +2208,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2296,7 +2296,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2370,7 +2370,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2443,7 +2443,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreen",
     jsii_struct_bases=[],
     name_mapping={
         "blue": "blue",
@@ -2534,7 +2534,7 @@ class ClusterInstallationSpecBlueGreen:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreenBlue",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenBlue",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2627,7 +2627,7 @@ class ClusterInstallationSpecBlueGreenBlue:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreenGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenGreen",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2720,7 +2720,7 @@ class ClusterInstallationSpecBlueGreenGreen:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecCanary",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanary",
     jsii_struct_bases=[],
     name_mapping={"deployment": "deployment", "enable": "enable"},
 )
@@ -2778,7 +2778,7 @@ class ClusterInstallationSpecCanary:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecCanaryDeployment",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanaryDeployment",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2871,7 +2871,7 @@ class ClusterInstallationSpecCanaryDeployment:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecDatabase",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabase",
     jsii_struct_bases=[],
     name_mapping={
         "backup_remote_delete_policy": "backupRemoteDeletePolicy",
@@ -3067,7 +3067,7 @@ class ClusterInstallationSpecDatabase:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecDatabaseResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabaseResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -3127,7 +3127,7 @@ class ClusterInstallationSpecDatabaseResources:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecElasticSearch",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecElasticSearch",
     jsii_struct_bases=[],
     name_mapping={"host": "host", "password": "password", "username": "username"},
 )
@@ -3193,7 +3193,7 @@ class ClusterInstallationSpecElasticSearch:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -3374,7 +3374,7 @@ class ClusterInstallationSpecLivenessProbe:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -3417,7 +3417,7 @@ class ClusterInstallationSpecLivenessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -3535,7 +3535,7 @@ class ClusterInstallationSpecLivenessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -3586,7 +3586,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecLivenessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -3618,7 +3618,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -3679,7 +3679,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocket:
 
 class ClusterInstallationSpecLivenessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -3711,7 +3711,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnv",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnv",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value", "value_from": "valueFrom"},
 )
@@ -3795,7 +3795,7 @@ class ClusterInstallationSpecMattermostEnv:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFrom",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFrom",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_key_ref": "configMapKeyRef",
@@ -3920,7 +3920,7 @@ class ClusterInstallationSpecMattermostEnvValueFrom:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -3992,7 +3992,7 @@ class ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -4045,7 +4045,7 @@ class ClusterInstallationSpecMattermostEnvValueFromFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -4119,7 +4119,7 @@ class ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -4193,7 +4193,7 @@ class ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMinio",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinio",
     jsii_struct_bases=[],
     name_mapping={
         "external_bucket": "externalBucket",
@@ -4318,7 +4318,7 @@ class ClusterInstallationSpecMinio:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMinioResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinioResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -4378,7 +4378,7 @@ class ClusterInstallationSpecMinioResources:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -4561,7 +4561,7 @@ class ClusterInstallationSpecReadinessProbe:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -4604,7 +4604,7 @@ class ClusterInstallationSpecReadinessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -4722,7 +4722,7 @@ class ClusterInstallationSpecReadinessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -4774,7 +4774,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecReadinessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -4806,7 +4806,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -4867,7 +4867,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocket:
 
 class ClusterInstallationSpecReadinessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -4899,7 +4899,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )

--- a/test/test-imports/python/expected-from-config/mattermost/mattermost/com/clusterinstallation/_jsii/__init__.py
+++ b/test/test-imports/python/expected-from-config/mattermost/mattermost/com/clusterinstallation/_jsii/__init__.py
@@ -12,10 +12,10 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885",
+    "mattermostcomclusterinstallation",
     "0.0.0",
     __name__[0:-6],
-    "970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885@0.0.0.jsii.tgz",
+    "mattermostcomclusterinstallation@0.0.0.jsii.tgz",
 )
 
 __all__ = [

--- a/test/test-imports/python/expected-from-config/stable/example/com/crontab/__init__.py
+++ b/test/test-imports/python/expected-from-config/stable/example/com/crontab/__init__.py
@@ -17,7 +17,7 @@ import constructs
 class CronTab(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTab",
+    jsii_type="stableexamplecomcrontab.CronTab",
 ):
     """
     schema:
@@ -43,7 +43,7 @@ class CronTab(
 
 
 @jsii.data_type(
-    jsii_type="58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabOptions",
+    jsii_type="stableexamplecomcrontab.CronTabOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec"},
 )
@@ -82,7 +82,7 @@ class CronTabOptions:
 
 
 @jsii.data_type(
-    jsii_type="58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720.CronTabSpec",
+    jsii_type="stableexamplecomcrontab.CronTabSpec",
     jsii_struct_bases=[],
     name_mapping={"cron_spec": "cronSpec", "image": "image", "replicas": "replicas"},
 )

--- a/test/test-imports/python/expected-from-config/stable/example/com/crontab/_jsii/__init__.py
+++ b/test/test-imports/python/expected-from-config/stable/example/com/crontab/_jsii/__init__.py
@@ -12,10 +12,10 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720",
+    "stableexamplecomcrontab",
     "0.0.0",
     __name__[0:-6],
-    "58aaa869a6720b158943dddef60e516061aeb4379d33c3ec001c5bcbfe7fa720@0.0.0.jsii.tgz",
+    "stableexamplecomcrontab@0.0.0.jsii.tgz",
 )
 
 __all__ = [

--- a/test/test-imports/python/expected-named-from-cli/mattermost/mattermost/com/clusterinstallation/__init__.py
+++ b/test/test-imports/python/expected-named-from-cli/mattermost/mattermost/com/clusterinstallation/__init__.py
@@ -17,7 +17,7 @@ import constructs
 class ClusterInstallation(
     cdk8s.ApiObject,
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallation",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallation",
 ):
     """ClusterInstallation is the Schema for the clusterinstallations API.
 
@@ -46,7 +46,7 @@ class ClusterInstallation(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationOptions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationOptions",
     jsii_struct_bases=[],
     name_mapping={"spec": "spec", "metadata": "metadata"},
 )
@@ -102,7 +102,7 @@ class ClusterInstallationOptions:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpec",
     jsii_struct_bases=[],
     name_mapping={
         "ingress_name": "ingressName",
@@ -447,7 +447,7 @@ class ClusterInstallationSpec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "node_affinity": "nodeAffinity",
@@ -540,7 +540,7 @@ class ClusterInstallationSpecAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -627,7 +627,7 @@ class ClusterInstallationSpecAffinityNodeAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"preference": "preference", "weight": "weight"},
 )
@@ -689,7 +689,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -769,7 +769,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -842,7 +842,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -915,7 +915,7 @@ class ClusterInstallationSpecAffinityNodeAffinityPreferredDuringSchedulingIgnore
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"node_selector_terms": "nodeSelectorTerms"},
 )
@@ -969,7 +969,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1051,7 +1051,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1124,7 +1124,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1197,7 +1197,7 @@ class ClusterInstallationSpecAffinityNodeAffinityRequiredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1284,7 +1284,7 @@ class ClusterInstallationSpecAffinityPodAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1348,7 +1348,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1438,7 +1438,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1512,7 +1512,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1585,7 +1585,7 @@ class ClusterInstallationSpecAffinityPodAffinityPreferredDuringSchedulingIgnored
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -1673,7 +1673,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -1747,7 +1747,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -1820,7 +1820,7 @@ class ClusterInstallationSpecAffinityPodAffinityRequiredDuringSchedulingIgnoredD
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinity",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinity",
     jsii_struct_bases=[],
     name_mapping={
         "preferred_during_scheduling_ignored_during_execution": "preferredDuringSchedulingIgnoredDuringExecution",
@@ -1907,7 +1907,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinity:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={"pod_affinity_term": "podAffinityTerm", "weight": "weight"},
 )
@@ -1971,7 +1971,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2061,7 +2061,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2135,7 +2135,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2208,7 +2208,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityPreferredDuringSchedulingIgn
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
     jsii_struct_bases=[],
     name_mapping={
         "topology_key": "topologyKey",
@@ -2296,7 +2296,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
     jsii_struct_bases=[],
     name_mapping={
         "match_expressions": "matchExpressions",
@@ -2370,7 +2370,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "operator": "operator", "values": "values"},
 )
@@ -2443,7 +2443,7 @@ class ClusterInstallationSpecAffinityPodAntiAffinityRequiredDuringSchedulingIgno
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreen",
     jsii_struct_bases=[],
     name_mapping={
         "blue": "blue",
@@ -2534,7 +2534,7 @@ class ClusterInstallationSpecBlueGreen:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreenBlue",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenBlue",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2627,7 +2627,7 @@ class ClusterInstallationSpecBlueGreenBlue:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecBlueGreenGreen",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecBlueGreenGreen",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2720,7 +2720,7 @@ class ClusterInstallationSpecBlueGreenGreen:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecCanary",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanary",
     jsii_struct_bases=[],
     name_mapping={"deployment": "deployment", "enable": "enable"},
 )
@@ -2778,7 +2778,7 @@ class ClusterInstallationSpecCanary:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecCanaryDeployment",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecCanaryDeployment",
     jsii_struct_bases=[],
     name_mapping={
         "image": "image",
@@ -2871,7 +2871,7 @@ class ClusterInstallationSpecCanaryDeployment:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecDatabase",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabase",
     jsii_struct_bases=[],
     name_mapping={
         "backup_remote_delete_policy": "backupRemoteDeletePolicy",
@@ -3067,7 +3067,7 @@ class ClusterInstallationSpecDatabase:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecDatabaseResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecDatabaseResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -3127,7 +3127,7 @@ class ClusterInstallationSpecDatabaseResources:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecElasticSearch",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecElasticSearch",
     jsii_struct_bases=[],
     name_mapping={"host": "host", "password": "password", "username": "username"},
 )
@@ -3193,7 +3193,7 @@ class ClusterInstallationSpecElasticSearch:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -3374,7 +3374,7 @@ class ClusterInstallationSpecLivenessProbe:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -3417,7 +3417,7 @@ class ClusterInstallationSpecLivenessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -3535,7 +3535,7 @@ class ClusterInstallationSpecLivenessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -3586,7 +3586,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecLivenessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -3618,7 +3618,7 @@ class ClusterInstallationSpecLivenessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -3679,7 +3679,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocket:
 
 class ClusterInstallationSpecLivenessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecLivenessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecLivenessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -3711,7 +3711,7 @@ class ClusterInstallationSpecLivenessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnv",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnv",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value", "value_from": "valueFrom"},
 )
@@ -3795,7 +3795,7 @@ class ClusterInstallationSpecMattermostEnv:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFrom",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFrom",
     jsii_struct_bases=[],
     name_mapping={
         "config_map_key_ref": "configMapKeyRef",
@@ -3920,7 +3920,7 @@ class ClusterInstallationSpecMattermostEnvValueFrom:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -3992,7 +3992,7 @@ class ClusterInstallationSpecMattermostEnvValueFromConfigMapKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromFieldRef",
     jsii_struct_bases=[],
     name_mapping={"field_path": "fieldPath", "api_version": "apiVersion"},
 )
@@ -4045,7 +4045,7 @@ class ClusterInstallationSpecMattermostEnvValueFromFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef",
     jsii_struct_bases=[],
     name_mapping={
         "resource": "resource",
@@ -4119,7 +4119,7 @@ class ClusterInstallationSpecMattermostEnvValueFromResourceFieldRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef",
     jsii_struct_bases=[],
     name_mapping={"key": "key", "name": "name", "optional": "optional"},
 )
@@ -4193,7 +4193,7 @@ class ClusterInstallationSpecMattermostEnvValueFromSecretKeyRef:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMinio",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinio",
     jsii_struct_bases=[],
     name_mapping={
         "external_bucket": "externalBucket",
@@ -4318,7 +4318,7 @@ class ClusterInstallationSpecMinio:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecMinioResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecMinioResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )
@@ -4378,7 +4378,7 @@ class ClusterInstallationSpecMinioResources:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbe",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbe",
     jsii_struct_bases=[],
     name_mapping={
         "exec": "exec",
@@ -4561,7 +4561,7 @@ class ClusterInstallationSpecReadinessProbe:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeExec",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeExec",
     jsii_struct_bases=[],
     name_mapping={"command": "command"},
 )
@@ -4604,7 +4604,7 @@ class ClusterInstallationSpecReadinessProbeExec:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGet",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGet",
     jsii_struct_bases=[],
     name_mapping={
         "port": "port",
@@ -4722,7 +4722,7 @@ class ClusterInstallationSpecReadinessProbeHttpGet:
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders",
     jsii_struct_bases=[],
     name_mapping={"name": "name", "value": "value"},
 )
@@ -4774,7 +4774,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetHttpHeaders:
 
 class ClusterInstallationSpecReadinessProbeHttpGetPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeHttpGetPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeHttpGetPort",
 ):
     """Name or number of the port to access on the container.
 
@@ -4806,7 +4806,7 @@ class ClusterInstallationSpecReadinessProbeHttpGetPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeTcpSocket",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocket",
     jsii_struct_bases=[],
     name_mapping={"port": "port", "host": "host"},
 )
@@ -4867,7 +4867,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocket:
 
 class ClusterInstallationSpecReadinessProbeTcpSocketPort(
     metaclass=jsii.JSIIMeta,
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecReadinessProbeTcpSocketPort",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecReadinessProbeTcpSocketPort",
 ):
     """Number or name of the port to access on the container.
 
@@ -4899,7 +4899,7 @@ class ClusterInstallationSpecReadinessProbeTcpSocketPort(
 
 
 @jsii.data_type(
-    jsii_type="970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885.ClusterInstallationSpecResources",
+    jsii_type="mattermostcomclusterinstallation.ClusterInstallationSpecResources",
     jsii_struct_bases=[],
     name_mapping={"limits": "limits", "requests": "requests"},
 )

--- a/test/test-imports/python/expected-named-from-cli/mattermost/mattermost/com/clusterinstallation/_jsii/__init__.py
+++ b/test/test-imports/python/expected-named-from-cli/mattermost/mattermost/com/clusterinstallation/_jsii/__init__.py
@@ -12,10 +12,10 @@ import cdk8s._jsii
 import constructs._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885",
+    "mattermostcomclusterinstallation",
     "0.0.0",
     __name__[0:-6],
-    "970d0d00f047327f1a86e192215f5590b2bbfe43ed26ef38426894a89f5ea885@0.0.0.jsii.tgz",
+    "mattermostcomclusterinstallation@0.0.0.jsii.tgz",
 )
 
 __all__ = [


### PR DESCRIPTION
With new changes in `jsii-srcmak`, it throws an Error when trying to use a package or moduleName with a hyphen (see commit: https://github.com/aws/jsii-srcmak/commit/766de96d655463dadf5a9578ba38d47121be447b)

This is the other side of that and fixes that issue by replacing `-` with `_`.

Tested by changing the `version.yaml` in the python CRD example to use a hyphen in the name. It successfully comes in as an underscore and is able to be imported.


Fixes https://github.com/awslabs/cdk8s/issues/274


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
