### PR TITLE
chore: cleanup unused LANGUAGES list in import base

### DIFF
--- a/packages/cdk8s-cli/src/import/base.ts
+++ b/packages/cdk8s-cli/src/import/base.ts
@@ -11,8 +11,6 @@ export enum Language {
   JAVA = 'java',
 }
 
-export const LANGUAGES = [ Language.TYPESCRIPT, Language.PYTHON ];
-
 export interface ImportOptions {
   readonly moduleNamePrefix?: string;
   readonly targetLanguage: Language;


### PR DESCRIPTION
Small thing... noticed it was missing `Language.JAVA`... then noticed it's altogether unneeded. Simple cleanup task.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
