### PR TITLE
chore: Update java init template typo in class name

### DIFF
--- a/packages/cdk8s-cli/templates/java-app/cdk8s.yaml
+++ b/packages/cdk8s-cli/templates/java-app/cdk8s.yaml
@@ -1,4 +1,4 @@
 language: java
-app:  mvn exec:java -Dexec.mainClass="com.mycompany.app.HelloKube"
+app:  mvn exec:java -Dexec.mainClass="com.mycompany.app.Main"
 imports:
   - k8s


### PR DESCRIPTION
Noticed that the template creates the class `Main.java` but we point to `HelloKube.java` here. Fixing that.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
