### PR TITLE
chore: privacy compliance

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -23,18 +23,6 @@
 
 <head>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-166333129-1"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
-        gtag('config', '{{ .Site.GoogleAnalytics }}');
-    </script>
-
     <meta charset="utf-8">
 
     <title>cdk8s</title>
@@ -243,7 +231,9 @@
                 Made with 💙 by Amazon Web Services and distributed under the <a href="{{ .Site.Params.links.license }}" class="link">the Apache 2.0 License‍</a>
                 <br> Contributors and maintainers are governed by the <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md" class="link">CNCF Code of Conduct</a>
             </div>
-            <div class="text-block-3">© cdk8s project authors. all rights reserved</div>
+            <div class="text-block-3">
+              <a class="footer-link" href="https://aws.amazon.com/privacy/?nc1=f_pr">Privacy</a> | <a class="footer-link" href="https://aws.amazon.com/terms/?nc1=f_pr">Site Terms</a> | © 2020, Amazon Web Services, Inc. or its affiliates. © cdk8s project authors. All rights reserved.
+            </div>
         </div>
     </div>
     <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js?site=5eb123ae928e7b1c2d221701" type="text/javascript" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>


### PR DESCRIPTION
Added the same privacy links we added to the [cdkworkshop](https://cdkworkshop.com) according to this [commit](https://github.com/aws-samples/aws-cdk-intro-workshop/commit/33e139605c8ee863e03e6a8e4deef8829fee0348).

Also, removed GoogleAnalytics integration for now until we sort out cookie consent issues.

Here is how the footer looks like now:

![Screen Shot 2020-09-16 at 1 11 00 PM](https://user-images.githubusercontent.com/1428812/93324484-a4741600-f81e-11ea-8206-490289e0eca2.png)

 
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
