### PR TITLE
chore(release): 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.29.0](https://github.com/awslabs/cdk8s/compare/v0.28.0...v0.29.0) (2020-09-27)
 
+### Features
+
+* **lib:** Upgrade constructs ([#324](https://github.com/awslabs/cdk8s/issues/324)) ([070b600](https://github.com/awslabs/cdk8s/commit/070b60093bcf626deb75e8ae0f192e24797d39d8))
+
 ## [0.28.0](https://github.com/awslabs/cdk8s/compare/v0.27.0...v0.28.0) (2020-09-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.29.0](https://github.com/awslabs/cdk8s/compare/v0.28.0...v0.29.0) (2020-09-27)
+
 ## [0.28.0](https://github.com/awslabs/cdk8s/compare/v0.27.0...v0.28.0) (2020-09-14)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.28.0"
+  "version": "0.29.0"
 }


### PR DESCRIPTION
See [CHANGELOG](https://github.com/awslabs/cdk8s/blob/bump/0.29.0/CHANGELOG.md)

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
