### PR TITLE
fix: allow tests to run without write access to os.tmpdir parent

### DIFF
--- a/packages/cdk8s/test/app.test.ts
+++ b/packages/cdk8s/test/app.test.ts
@@ -86,7 +86,7 @@ test('app with charts indirectly dependant', () => {
 test('default output directory is "dist"', () => {
   // GIVEN
   const prev = process.cwd();
-  const workdir = fs.mkdtempSync(path.join(os.tmpdir()));
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s-'));
 
   try {
     process.chdir(workdir);


### PR DESCRIPTION
The code previously created a temp directory name that was
a sibling of the os.tempdir(). This required write access to
the directory instead of simply write access to the tmpdir.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
