### PR TITLE
fix(lib): duplicate hyphens in generated resource names

### DIFF
--- a/packages/cdk8s-plus/README.md
+++ b/packages/cdk8s-plus/README.md
@@ -694,7 +694,7 @@ const ingress = new Ingress(this, 'ingress');
 ingress.addRule('/hello', kplus.IngressBackend.fromService(helloService));
 ```
 
-Yo can use `addHostRule(host, path, backend)` to define a route that will only
+You can use `addHostRule(host, path, backend)` to define a route that will only
 apply to requests with this `Host` header. This can be used to implement virtual
 hosts.
 

--- a/packages/cdk8s/src/names.ts
+++ b/packages/cdk8s/src/names.ts
@@ -61,7 +61,8 @@ export class Names {
       .split('/')
       .reverse()
       .filter(x => x)
-      .join('-');
+      .join('-')
+      .split('-').filter(x => x).join('-') // remove empty components between `-`s.
   }
 
   /**
@@ -121,6 +122,9 @@ export class Names {
       .slice(0, maxLen)
       .split('/')
       .reverse()
+      .filter(x => x)
+      .join(delim)
+      .split(delim)
       .filter(x => x)
       .join(delim);
 

--- a/packages/cdk8s/test/names.test.ts
+++ b/packages/cdk8s/test/names.test.ts
@@ -58,6 +58,12 @@ describe('toDnsLabel', () => {
     expect(toDnsName('hello/world/this/is/cool', 15)).toEqual('i-cool-a7c39f00');
     expect(toDnsName('hello/world/this/is/cool', 25)).toEqual('wor-this-is-cool-a7c39f00');
   });
+
+  test('filter empty components', () => {
+    expect(toDnsName('hello//world---this-is-cool---')).toEqual('hello-world-this-is-cool-52f679f4');
+    expect(toDnsName('hello-world-this-is-cool')).toEqual('hello-world-this-is-cool');
+    expect(toDnsName('hello/world-this//is-cool')).toEqual('hello-world-this-is-cool-b6e3e997');
+  });
 });
 
 describe('toLabel', () => {
@@ -117,5 +123,10 @@ describe('toLabel', () => {
     expect(toLabelValue('hello/world/this/is/cool', '-', 14)).toEqual('cool-a7c39f00');
     expect(toLabelValue('hello/world/this/is/cool', '-', 15)).toEqual('i-cool-a7c39f00');
     expect(toLabelValue('hello/world/this/is/cool', '-', 25)).toEqual('wor-this-is-cool-a7c39f00');
+  });
+
+  test('filter empty components', () => {
+    expect(toLabelValue('hello---this/is//cool//-')).toEqual('hello-this-is-cool-dfb4c573');
+    expect(toLabelValue('hello---this/is---//cool////-')).toEqual('hello-this-is-cool-84d02267');
   });
 });


### PR DESCRIPTION
Sometimes names generated from paths include empty components like `service/test-router-runtime---hello-pod-a611028d`. This change removes duplicate hyphens.

BREAKING CHANGE: auto-generated resource names that included duplicate hyphens will change will be replaced when applied.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
