### PR TITLE
feat(plus): service.addDeployment()

### DIFF
--- a/examples/typescript/cdk8s-plus-elasticsearch-query/main.ts
+++ b/examples/typescript/cdk8s-plus-elasticsearch-query/main.ts
@@ -72,7 +72,7 @@ export class MyChart extends Chart {
       }
     })
 
-    deployment.expose({port: 9000});
+    deployment.expose(9000);
 
   }
 }

--- a/examples/typescript/cdk8s-plus-ingress/main.ts
+++ b/examples/typescript/cdk8s-plus-ingress/main.ts
@@ -28,7 +28,7 @@ export class MyChart extends Chart {
       }
     });
 
-    return kplus.IngressBackend.fromService(deploy.expose({ port: 5678 }));
+    return kplus.IngressBackend.fromService(deploy.expose(5678));
   }
 }
 

--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -326,6 +326,7 @@ new Deployment(scope: Construct, id: string, props?: DeploymentProps)
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DeploymentProps](#cdk8s-plus-deploymentprops)</code>)  *No description*
   * **metadata** (<code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code>)  Metadata that all persisted resources must have, which includes all objects users must create. __*Optional*__
+  * **defaultSelector** (<code>boolean</code>)  Automatically allocates a pod selector for this deployment. __*Default*__: true
   * **spec** (<code>[DeploymentSpec](#cdk8s-plus-deploymentspec)</code>)  The spec of the deployment. __*Default*__: An empty spec will be created.
 
 
@@ -341,18 +342,18 @@ Name | Type | Description
 ### Methods
 
 
-#### expose(options)🔹 <a id="cdk8s-plus-deployment-expose"></a>
+#### expose(port, options?)🔹 <a id="cdk8s-plus-deployment-expose"></a>
 
 Expose a deployment via a service.
 
 This is equivalent to running `kubectl expose deployment <deployment-name>`.
 
 ```ts
-expose(options: ExposeOptions): Service
+expose(port: number, options?: ExposeOptions): Service
 ```
 
-* **options** (<code>[ExposeOptions](#cdk8s-plus-exposeoptions)</code>)  - Options.
-  * **port** (<code>number</code>)  The port number the service will bind to. 
+* **port** (<code>number</code>)  The port number the service will bind to.
+* **options** (<code>[ExposeOptions](#cdk8s-plus-exposeoptions)</code>)  Options.
   * **serviceType** (<code>[ServiceType](#cdk8s-plus-servicetype)</code>)  The type of the exposed service. __*Default*__: ClusterIP.
 
 __Returns__:
@@ -1288,6 +1289,24 @@ Name | Type | Description
 ### Methods
 
 
+#### addDeployment(deployment, port)🔹 <a id="cdk8s-plus-servicespecdefinition-adddeployment"></a>
+
+Exposes a deployment through this service.
+
+Requests will be routed to the port exposed by the first container in the
+deployment's pods. The label `cdk8s.deployment` will be added to pods in
+the deployment and used to select pods by this service.
+
+```ts
+addDeployment(deployment: Deployment, port: number): void
+```
+
+* **deployment** (<code>[Deployment](#cdk8s-plus-deployment)</code>)  The deployment to expose.
+* **port** (<code>number</code>)  The external port.
+
+
+
+
 #### addSelector(label, value)🔹 <a id="cdk8s-plus-servicespecdefinition-addselector"></a>
 
 Services defined using this spec will select pods according the provided label.
@@ -1668,6 +1687,7 @@ Properties for initialization of `Deployment`.
 
 Name | Type | Description 
 -----|------|-------------
+**defaultSelector**?🔹 | <code>boolean</code> | Automatically allocates a pod selector for this deployment.<br/>__*Default*__: true
 **metadata**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Metadata that all persisted resources must have, which includes all objects users must create.<br/>__*Optional*__
 **spec**?🔹 | <code>[DeploymentSpec](#cdk8s-plus-deploymentspec)</code> | The spec of the deployment.<br/>__*Default*__: An empty spec will be created.
 
@@ -1750,7 +1770,6 @@ Options for exposing a deployment via a service.
 
 Name | Type | Description 
 -----|------|-------------
-**port**🔹 | <code>number</code> | The port number the service will bind to.
 **serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
 
 

--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -748,7 +748,7 @@ addDefaultBackend(backend: IngressBackend): void
 Specify a default backend for a specific host name.
 
 This backend will be used as a catch-all for requests
-originating from the specified host name.
+targeted to this host name (the `Host` header matches this value).
 
 ```ts
 addHostDefaultBackend(host: string, backend: IngressBackend): void
@@ -762,7 +762,7 @@ addHostDefaultBackend(host: string, backend: IngressBackend): void
 
 #### addHostRule(host, path, backend)🔹 <a id="cdk8s-plus-ingress-addhostrule"></a>
 
-Adds an ingress rule applied to requests to a specific host and a specific HTTP path.
+Adds an ingress rule applied to requests to a specific host and a specific HTTP path (the `Host` header matches this value).
 
 ```ts
 addHostRule(host: string, path: string, backend: IngressBackend): void
@@ -804,6 +804,21 @@ addRules(...rules: IngressRule[]): void
 
 
 
+
+#### protected onValidate()🔹 <a id="cdk8s-plus-ingress-onvalidate"></a>
+
+Validate the current construct.
+
+This method can be implemented by derived constructs in order to perform
+validation logic. It is called on all constructs before synthesis.
+
+```ts
+protected onValidate(): Array<string>
+```
+
+
+__Returns__:
+* <code>Array<string></code>
 
 
 

--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -1182,6 +1182,27 @@ Name | Type | Description
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
 **spec**🔹 | <code>[ServiceSpecDefinition](#cdk8s-plus-servicespecdefinition)</code> | Provides access to the underlying spec.
 
+### Methods
+
+
+#### addDeployment(deployment, port)🔹 <a id="cdk8s-plus-service-adddeployment"></a>
+
+Associate a deployment to this service.
+
+Requests will be routed to the port exposed by the first container in the
+deployment's pods. The deployment's `labelSelector` will be used to select
+pods.
+
+```ts
+addDeployment(deployment: Deployment, port: number): void
+```
+
+* **deployment** (<code>[Deployment](#cdk8s-plus-deployment)</code>)  The deployment to expose.
+* **port** (<code>number</code>)  The external port.
+
+
+
+
 
 
 ## class ServiceAccount 🔹 <a id="cdk8s-plus-serviceaccount"></a>
@@ -1287,24 +1308,6 @@ Name | Type | Description
 **clusterIP**?🔹 | <code>string</code> | The IP address of the service and is usually assigned randomly by the master.<br/>__*Optional*__
 
 ### Methods
-
-
-#### addDeployment(deployment, port)🔹 <a id="cdk8s-plus-servicespecdefinition-adddeployment"></a>
-
-Exposes a deployment through this service.
-
-Requests will be routed to the port exposed by the first container in the
-deployment's pods. The label `cdk8s.deployment` will be added to pods in
-the deployment and used to select pods by this service.
-
-```ts
-addDeployment(deployment: Deployment, port: number): void
-```
-
-* **deployment** (<code>[Deployment](#cdk8s-plus-deployment)</code>)  The deployment to expose.
-* **port** (<code>number</code>)  The external port.
-
-
 
 
 #### addSelector(label, value)🔹 <a id="cdk8s-plus-servicespecdefinition-addselector"></a>

--- a/packages/cdk8s-plus/src/deployment.ts
+++ b/packages/cdk8s-plus/src/deployment.ts
@@ -115,7 +115,7 @@ export class Deployment extends Resource {
       },
     });
 
-    service.spec.addDeployment(this, port);
+    service.addDeployment(this, port);
     return service;
   }
 }

--- a/packages/cdk8s-plus/src/service.ts
+++ b/packages/cdk8s-plus/src/service.ts
@@ -1,9 +1,8 @@
 import * as k8s from './imports/k8s';
-import { Construct, Node } from 'constructs';
+import { Construct } from 'constructs';
 import { ResourceProps, Resource } from './base';
 import * as cdk8s from 'cdk8s';
 import { Deployment } from './deployment';
-import { Names } from 'cdk8s';
 
 /**
  * Properties for initialization of `Service`.
@@ -288,14 +287,10 @@ export class ServiceSpecDefinition {
       throw new Error('Cannot expose a deployment without containers');
     }
 
-    // create a label and attach it to the deployment pods
-    const selector = 'cdk8s.deployment';
-    const matcher = Names.toLabelValue(Node.of(deployment).path);
+    for (const [ k, v ] of Object.entries(deployment.spec.labelSelector)) {
+      this.addSelector(k, v);
+    }
 
-    deployment.spec.podMetadataTemplate.addLabel(selector, matcher);
-    deployment.spec.selectByLabel(selector, matcher);
-
-    this.addSelector(selector, matcher);
     this.serve(port, {
       // just a PoC, we assume the first container is the main one.
       // TODO: figure out what the correct thing to do here.

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -25,6 +25,20 @@ describe('DeploymentSpecDefinition', () => {
     expect(spec.podSpecTemplate.containers[0].image).toBe('my-image');
   });
 
+  test('A label selector is automatically allocated', () => {
+    // GIVEN
+    const chart = Testing.chart();
+
+    const d = new kplus.Deployment(chart, 'Deployment');
+    d.spec.podSpecTemplate.addContainer(new kplus.Container({ image: 'foobar' }));
+
+    const spec = d.spec._toKube();
+
+    const expectedSelector = { 'cdk8s.deployment': 'test-Deployment-9e0110cd' };
+    expect(spec.selector.matchLabels).toEqual(expectedSelector);
+    expect(spec.template.metadata?.labels).toEqual(expectedSelector);
+  });
+
   test('Can select labels', () => {
     const spec = new kplus.DeploymentSpecDefinition();
 

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -39,6 +39,25 @@ describe('DeploymentSpecDefinition', () => {
     expect(spec.template.metadata?.labels).toEqual(expectedSelector);
   });
 
+  test('No selector is generated if "defaultSelector" is false', () => {
+    // GIVEN
+    const chart = Testing.chart();
+
+    // WHEN
+    const d = new kplus.Deployment(chart, 'Deployment', { 
+      defaultSelector: false,
+      spec: {
+        podSpecTemplate: {
+          containers: [ new kplus.Container({ image: 'foobar' }) ],
+        },
+      },
+    });
+
+    const spec = d.spec._toKube();
+    expect(spec.selector.matchLabels).toEqual({});
+    expect(spec.template.metadata?.labels).toEqual(undefined);
+  });
+
   test('Can select labels', () => {
     const spec = new kplus.DeploymentSpecDefinition();
 

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -7,7 +7,7 @@ describe('DeploymentSpecDefinition', () => {
 
   test('Instantiation properties are all respected', () => {
     const chart = Testing.chart();
-    const deployment = new kplus.Deployment(chart, 'Deployment');
+    new kplus.Deployment(chart, 'Deployment');
     const spec = new kplus.DeploymentSpecDefinition({
       replicas: 3,
       podSpecTemplate: {
@@ -18,7 +18,7 @@ describe('DeploymentSpecDefinition', () => {
       },
     });
 
-    const actual: k8s.DeploymentSpec = spec._toKube(deployment);
+    const actual: k8s.DeploymentSpec = spec._toKube();
 
     expect(actual.replicas).toEqual(3);
     expect(spec.podSpecTemplate.serviceAccount?.name).toBe('my-service-account');
@@ -35,16 +35,15 @@ describe('DeploymentSpecDefinition', () => {
     );
 
     const chart = Testing.chart();
-    const deployment = new kplus.Deployment(chart, 'Deployment');
+    new kplus.Deployment(chart, 'Deployment');
 
     spec.selectByLabel('key', 'value');
 
-    const actual: k8s.LabelSelector = spec._toKube(deployment).selector;
+    const actual: k8s.LabelSelector = spec._toKube().selector;
 
     const expected: k8s.LabelSelector = {
       matchLabels: {
-        'key': 'value',
-        'cdk8s.deployment': Names.toLabelValue(Node.of(deployment).path),
+        key: 'value',
       },
     };
 
@@ -64,8 +63,7 @@ describe('Deployment', () => {
       }),
     );
 
-    const service = deployment.expose({
-      port: 9200,
+    const service = deployment.expose(9200, {
       serviceType: kplus.ServiceType.LOAD_BALANCER,
     });
 
@@ -92,9 +90,7 @@ describe('Deployment', () => {
       }),
     );
 
-    const service = deployment.expose({
-      port: 9200,
-    });
+    const service = deployment.expose(9200);
 
     const actual = service.spec._toKube();
 
@@ -112,7 +108,7 @@ describe('Deployment', () => {
 
     const deployment = new kplus.Deployment(chart, 'Deployment');
 
-    expect(() => deployment.expose({ port: 9000 })).toThrowError(
+    expect(() => deployment.expose(9000)).toThrowError(
       'Cannot expose a deployment without containers',
     );
   });


### PR DESCRIPTION
Introduce `service.addDeployment()` which associates a deployment to a service. The method `deployment.expose()` now just delegates the work to this method.

Additionally, the logic that added the selector label to the deployment was moved from `deployment._toKube()` into `service.addDeployment()` and combined with the logic that installed the selector on the service (which is much more natural).

BREAKING CHANGE: `deployment.expose()` now takes `port` as a positional argument (before: `deployment.expose({ port })`, now: `deployment.expose(port)`).

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
