### PR TITLE
feat(plus): readiness probes

### DIFF
--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -15,6 +15,7 @@ Name|Description
 [Pod](#cdk8s-plus-pod)|Pod is a collection of containers that can run on a host.
 [PodSpec](#cdk8s-plus-podspec)|Provides read/write capabilities ontop of a `PodSpecProps`.
 [PodTemplate](#cdk8s-plus-podtemplate)|Provides read/write capabilities ontop of a `PodTemplateProps`.
+[Probe](#cdk8s-plus-probe)|Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 [Resource](#cdk8s-plus-resource)|Base class for all Kubernetes objects in stdk8s.
 [Secret](#cdk8s-plus-secret)|Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 [Service](#cdk8s-plus-service)|An abstract way to expose an application running on a set of Pods as a network service.
@@ -28,6 +29,7 @@ Name|Description
 Name|Description
 ----|-----------
 [AddDirectoryOptions](#cdk8s-plus-adddirectoryoptions)|Options for `configmap.addDirectory()`.
+[CommandProbeOptions](#cdk8s-plus-commandprobeoptions)|Options for `Probe.fromCommand()`.
 [ConfigMapProps](#cdk8s-plus-configmapprops)|Properties for initialization of `ConfigMap`.
 [ConfigMapVolumeOptions](#cdk8s-plus-configmapvolumeoptions)|Options for the ConfigMap-based volume.
 [ContainerProps](#cdk8s-plus-containerprops)|Properties for creating a container.
@@ -37,6 +39,7 @@ Name|Description
 [EnvValueFromProcessOptions](#cdk8s-plus-envvaluefromprocessoptions)|Options to specify an environment variable value from the process environment.
 [EnvValueFromSecretOptions](#cdk8s-plus-envvaluefromsecretoptions)|Options to specify an environment variable value from a Secret.
 [ExposeOptions](#cdk8s-plus-exposeoptions)|Options for exposing a deployment via a service.
+[HttpGetProbeOptions](#cdk8s-plus-httpgetprobeoptions)|Options for `Probe.fromHttpGet()`.
 [IngressProps](#cdk8s-plus-ingressprops)|Properties for `Ingress`.
 [IngressRule](#cdk8s-plus-ingressrule)|Represents the rules mapping the paths under a specified host to the related backend services.
 [JobProps](#cdk8s-plus-jobprops)|Properties for initialization of `Job`.
@@ -45,6 +48,7 @@ Name|Description
 [PodProps](#cdk8s-plus-podprops)|Properties for initialization of `Pod`.
 [PodSpecProps](#cdk8s-plus-podspecprops)|Properties of a `PodSpec`.
 [PodTemplateProps](#cdk8s-plus-podtemplateprops)|Properties of a `PodTemplate`.
+[ProbeOptions](#cdk8s-plus-probeoptions)|Probe options.
 [ResourceProps](#cdk8s-plus-resourceprops)|Initialization properties for resources.
 [SecretProps](#cdk8s-plus-secretprops)|*No description*
 [ServiceAccountProps](#cdk8s-plus-serviceaccountprops)|Properties for initialization of `ServiceAccount`.
@@ -218,6 +222,7 @@ new Container(props: ContainerProps)
   * **imagePullPolicy** (<code>[ImagePullPolicy](#cdk8s-plus-imagepullpolicy)</code>)  Image pull policy for this container. __*Default*__: ImagePullPolicy.ALWAYS
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **readiness** (<code>[Probe](#cdk8s-plus-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
 
@@ -1096,6 +1101,66 @@ Name | Type | Description
 
 
 
+## class Probe 🔹 <a id="cdk8s-plus-probe"></a>
+
+Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+
+
+### Initializer
+
+
+
+
+```ts
+new Probe()
+```
+
+
+
+### Methods
+
+
+#### *static* fromCommand(command, options?)🔹 <a id="cdk8s-plus-probe-fromcommand"></a>
+
+Defines a probe based on a command which is executed within the container.
+
+```ts
+static fromCommand(command: Array<string>, options?: ProbeOptions): Probe
+```
+
+* **command** (<code>Array<string></code>)  The command to execute.
+* **options** (<code>[ProbeOptions](#cdk8s-plus-probeoptions)</code>)  Options.
+  * **failureThreshold** (<code>number</code>)  Minimum consecutive failures for the probe to be considered failed after having succeeded. __*Default*__: 3
+  * **initialDelaySeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  Number of seconds after the container has started before liveness probes are initiated. __*Default*__: immediate
+  * **periodSeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  How often (in seconds) to perform the probe. __*Default*__: Duration.seconds(10) Minimum value is 1.
+  * **successThreshold** (<code>number</code>)  Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. __*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
+  * **timeoutSeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  Number of seconds after which the probe times out. __*Default*__: Duration.seconds(1)
+
+__Returns__:
+* <code>[Probe](#cdk8s-plus-probe)</code>
+
+#### *static* fromHttpGet(path, options?)🔹 <a id="cdk8s-plus-probe-fromhttpget"></a>
+
+Defines a probe based on an HTTP GET request to the IP address of the container.
+
+```ts
+static fromHttpGet(path: string, options?: HttpGetProbeOptions): Probe
+```
+
+* **path** (<code>string</code>)  The URL path to hit.
+* **options** (<code>[HttpGetProbeOptions](#cdk8s-plus-httpgetprobeoptions)</code>)  Options.
+  * **failureThreshold** (<code>number</code>)  Minimum consecutive failures for the probe to be considered failed after having succeeded. __*Default*__: 3
+  * **initialDelaySeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  Number of seconds after the container has started before liveness probes are initiated. __*Default*__: immediate
+  * **periodSeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  How often (in seconds) to perform the probe. __*Default*__: Duration.seconds(10) Minimum value is 1.
+  * **successThreshold** (<code>number</code>)  Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. __*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
+  * **timeoutSeconds** (<code>[Duration](#cdk8s-plus-duration)</code>)  Number of seconds after which the probe times out. __*Default*__: Duration.seconds(1)
+  * **port** (<code>number</code>)  The TCP port to use when sending the GET request. __*Default*__: defaults to `container.port`.
+
+__Returns__:
+* <code>[Probe](#cdk8s-plus-probe)</code>
+
+
+
 ## class Resource 🔹 <a id="cdk8s-plus-resource"></a>
 
 Base class for all Kubernetes objects in stdk8s.
@@ -1674,6 +1739,23 @@ Name | Type | Description
 
 
 
+## struct CommandProbeOptions 🔹 <a id="cdk8s-plus-commandprobeoptions"></a>
+
+
+Options for `Probe.fromCommand()`.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**failureThreshold**?🔹 | <code>number</code> | Minimum consecutive failures for the probe to be considered failed after having succeeded.<br/>__*Default*__: 3
+**initialDelaySeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after the container has started before liveness probes are initiated.<br/>__*Default*__: immediate
+**periodSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | How often (in seconds) to perform the probe.<br/>__*Default*__: Duration.seconds(10) Minimum value is 1.
+**successThreshold**?🔹 | <code>number</code> | Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.<br/>__*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
+**timeoutSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after which the probe times out.<br/>__*Default*__: Duration.seconds(1)
+
+
+
 ## struct ConfigMapProps 🔹 <a id="cdk8s-plus-configmapprops"></a>
 
 
@@ -1721,6 +1803,7 @@ Name | Type | Description
 **imagePullPolicy**?🔹 | <code>[ImagePullPolicy](#cdk8s-plus-imagepullpolicy)</code> | Image pull policy for this container.<br/>__*Default*__: ImagePullPolicy.ALWAYS
 **name**?🔹 | <code>string</code> | Name of the container specified as a DNS_LABEL.<br/>__*Default*__: 'main'
 **port**?🔹 | <code>number</code> | Number of port to expose on the pod's IP address.<br/>__*Default*__: No port is exposed.
+**readiness**?🔹 | <code>[Probe](#cdk8s-plus-probe)</code> | Determines when the container is ready to serve traffic.<br/>__*Default*__: no readiness probe is defined
 **volumeMounts**?🔹 | <code>Array<[VolumeMount](#cdk8s-plus-volumemount)></code> | Pod volumes to mount into the container's filesystem.<br/>__*Optional*__
 **workingDir**?🔹 | <code>string</code> | Container's working directory.<br/>__*Default*__: The container runtime's default.
 
@@ -1809,6 +1892,24 @@ Options for exposing a deployment via a service.
 Name | Type | Description 
 -----|------|-------------
 **serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
+
+
+
+## struct HttpGetProbeOptions 🔹 <a id="cdk8s-plus-httpgetprobeoptions"></a>
+
+
+Options for `Probe.fromHttpGet()`.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**failureThreshold**?🔹 | <code>number</code> | Minimum consecutive failures for the probe to be considered failed after having succeeded.<br/>__*Default*__: 3
+**initialDelaySeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after the container has started before liveness probes are initiated.<br/>__*Default*__: immediate
+**periodSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | How often (in seconds) to perform the probe.<br/>__*Default*__: Duration.seconds(10) Minimum value is 1.
+**port**?🔹 | <code>number</code> | The TCP port to use when sending the GET request.<br/>__*Default*__: defaults to `container.port`.
+**successThreshold**?🔹 | <code>number</code> | Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.<br/>__*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
+**timeoutSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after which the probe times out.<br/>__*Default*__: Duration.seconds(1)
 
 
 
@@ -2105,6 +2206,23 @@ Name | Type | Description
 **restartPolicy**?🔹 | <code>[RestartPolicy](#cdk8s-plus-restartpolicy)</code> | Restart policy for all containers within the pod.<br/>__*Default*__: RestartPolicy.ALWAYS
 **serviceAccount**?🔹 | <code>[IServiceAccount](#cdk8s-plus-iserviceaccount)</code> | A service account provides an identity for processes that run in a Pod.<br/>__*Default*__: No service account.
 **volumes**?🔹 | <code>Array<[Volume](#cdk8s-plus-volume)></code> | List of volumes that can be mounted by containers belonging to the pod.<br/>__*Default*__: No volumes.
+
+
+
+## struct ProbeOptions 🔹 <a id="cdk8s-plus-probeoptions"></a>
+
+
+Probe options.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**failureThreshold**?🔹 | <code>number</code> | Minimum consecutive failures for the probe to be considered failed after having succeeded.<br/>__*Default*__: 3
+**initialDelaySeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after the container has started before liveness probes are initiated.<br/>__*Default*__: immediate
+**periodSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | How often (in seconds) to perform the probe.<br/>__*Default*__: Duration.seconds(10) Minimum value is 1.
+**successThreshold**?🔹 | <code>number</code> | Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.<br/>__*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
+**timeoutSeconds**?🔹 | <code>[Duration](#cdk8s-plus-duration)</code> | Number of seconds after which the probe times out.<br/>__*Default*__: Duration.seconds(1)
 
 
 

--- a/packages/cdk8s-plus/README.md
+++ b/packages/cdk8s-plus/README.md
@@ -260,6 +260,29 @@ const container = new kplus.Container({
 container.mount('/path/to/mount', volume);
 ```
 
+## Probes
+
+A [Probe] is a diagnostic performed periodically by the kubelet on a Container. To
+perform a diagnostic, the kubelet calls a Handler implemented by the container.
+
+[Probe]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#probe-v1-core
+
+A `Probe` instance can be created through one of the `fromXxx` static methods:
+
+- `Probe.fromHttpGet()`
+- `Probe.fromCommand()`
+
+Readiness probes can be configured at the container-level through the `readiness` option:
+
+```ts
+new kplus.Container({
+  // ...
+  readiness: kplus.Probe.fromHttpGet('/ping')
+});
+```
+
+See the API reference for details.
+
 ### `Volume`
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.

--- a/packages/cdk8s-plus/src/container.ts
+++ b/packages/cdk8s-plus/src/container.ts
@@ -2,6 +2,7 @@ import { IConfigMap } from './config-map';
 import { ISecret } from './secret';
 import * as k8s from './imports/k8s';
 import { Volume } from './volume';
+import { Probe } from './probe';
 
 /**
  * Options to specify an envionment variable value from a ConfigMap key.
@@ -219,6 +220,13 @@ export interface ContainerProps {
    * @default ImagePullPolicy.ALWAYS
    */
   readonly imagePullPolicy?: ImagePullPolicy
+
+  /**
+   * Determines when the container is ready to serve traffic.
+   * 
+   * @default - no readiness probe is defined
+   */
+  readonly readiness?: Probe; 
 }
 
 /**
@@ -259,6 +267,7 @@ export class Container {
   private readonly _command?: readonly string[];
   private readonly _args?: readonly string[];
   private readonly _env: { [name: string]: EnvValue };
+  private readonly _readiness?: Probe;
 
   constructor(props: ContainerProps) {
     this.name = props.name ?? 'main';
@@ -267,6 +276,7 @@ export class Container {
     this._command = props.command;
     this._args = props.args;
     this._env = props.env ?? { };
+    this._readiness = props.readiness;
     this.workingDir = props.workingDir;
     this.mounts = props.volumeMounts ?? [];
     this.imagePullPolicy = props.imagePullPolicy ?? ImagePullPolicy.ALWAYS;
@@ -357,6 +367,7 @@ export class Container {
       args: this.args,
       workingDir: this.workingDir,
       env: renderEnv(this._env),
+      readinessProbe: this._readiness?._toKube(this),
     };
   }
 }

--- a/packages/cdk8s-plus/src/index.ts
+++ b/packages/cdk8s-plus/src/index.ts
@@ -11,3 +11,4 @@ export * from './service';
 export * from './volume';
 export * from './size';
 export * from './ingress';
+export * from './probe';

--- a/packages/cdk8s-plus/src/probe.ts
+++ b/packages/cdk8s-plus/src/probe.ts
@@ -1,0 +1,132 @@
+import * as k8s from './imports/k8s';
+import { Container } from './container';
+import { Duration } from './duration';
+
+/**
+ * Probe options.
+ */
+export interface ProbeOptions {
+  /**
+   * Minimum consecutive failures for the probe to be considered failed after
+   * having succeeded. 
+   *
+   * Defaults to 3. Minimum value is 1.
+   *
+   * @default 3
+   */
+  readonly failureThreshold?: number;
+
+  /**
+   * Number of seconds after the container has started before liveness probes
+   * are initiated. 
+   * 
+   * @see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+   * @default - immediate
+   */
+  readonly initialDelaySeconds?: Duration;
+
+  /**
+   * How often (in seconds) to perform the probe. 
+   *
+   * Default to 10 seconds. Minimum value is 1.
+   *
+   * @default Duration.seconds(10) Minimum value is 1.
+   */
+  readonly periodSeconds?: Duration;
+
+  /**
+   * Minimum consecutive successes for the probe to be considered successful
+   * after having failed. Defaults to 1. 
+   *
+   * Must be 1 for liveness and startup. Minimum value is 1.
+   *
+   * @default 1 Must be 1 for liveness and startup. Minimum value is 1.
+   */
+  readonly successThreshold?: number;
+
+  /**
+   * Number of seconds after which the probe times out. 
+   *
+   * Defaults to 1 second. Minimum value is 1. 
+   *
+   * @see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+   * @default Duration.seconds(1)
+   */
+  readonly timeoutSeconds?: Duration;
+}
+
+/**
+ * Options for `Probe.fromHttpGet()`.
+ */
+export interface HttpGetProbeOptions extends ProbeOptions {
+  /**
+   * The TCP port to use when sending the GET request.
+   * 
+   * @default - defaults to `container.port`.
+   */
+  readonly port?: number;
+}
+
+/**
+ * Options for `Probe.fromCommand()`.
+ */
+export interface CommandProbeOptions extends ProbeOptions {
+
+}
+
+/**
+ * Probe describes a health check to be performed against a container to
+ * determine whether it is alive or ready to receive traffic.
+ */
+export abstract class Probe {
+
+  /**
+   * Defines a probe based on an HTTP GET request to the IP address of the container.
+   * 
+   * @param path The URL path to hit
+   * @param options Options
+   */
+  public static fromHttpGet(path: string, options: HttpGetProbeOptions = { }): Probe {
+    return {
+      _toKube(container) {
+        return {
+          ...parseProbeOptions(options),
+          httpGet: {
+            path,
+            port: options.port ?? container.port ?? 80,
+          },
+        };
+      },
+    };
+  }
+
+  /**
+   * Defines a probe based on a command which is executed within the container.
+   * 
+   * @param command The command to execute
+   * @param options Options
+   */
+  public static fromCommand(command: string[], options: ProbeOptions = { }): Probe {
+    return {
+      _toKube: _ => ({
+        ...parseProbeOptions(options),
+        exec: { command },
+      }),
+    };
+  }
+
+  /**
+   * @internal
+   */
+  public abstract _toKube(container: Container): k8s.Probe;
+}
+
+function parseProbeOptions(options: ProbeOptions = {}): k8s.Probe {
+  return {
+    failureThreshold: options.failureThreshold ?? 3,
+    initialDelaySeconds: options.initialDelaySeconds ? options.initialDelaySeconds.toSeconds() : undefined,
+    periodSeconds: options.periodSeconds ? options.periodSeconds.toSeconds() : undefined,
+    successThreshold: options.successThreshold,
+    timeoutSeconds: options.timeoutSeconds ? options.timeoutSeconds.toSeconds() : undefined,
+  };
+}

--- a/packages/cdk8s-plus/test/container.test.ts
+++ b/packages/cdk8s-plus/test/container.test.ts
@@ -1,4 +1,5 @@
 import * as kplus from '../src';
+import { Duration } from '../src';
 import * as k8s from '../src/imports/k8s';
 
 describe('EnvValue', () => {
@@ -192,6 +193,26 @@ describe('Container', () => {
     };
 
     expect(container._toKube().volumeMounts).toEqual([expected]);
+  });
+
+  test('"readiness" can be used to define readiness probes', () => {
+    // GIVEN
+    const container = new kplus.Container({ 
+      image: 'foo',
+      readiness: kplus.Probe.fromHttpGet('/ping', {
+        timeoutSeconds: Duration.minutes(2),
+      }),
+    });
+
+    // THEN
+    expect(container._toKube().readinessProbe).toEqual({
+      failureThreshold: 3, 
+      httpGet: {path: '/ping', port: 80}, 
+      initialDelaySeconds: undefined, 
+      periodSeconds: undefined, 
+      successThreshold: undefined, 
+      timeoutSeconds: 120,
+    });
   });
 
 });

--- a/packages/cdk8s-plus/test/probe.test.ts
+++ b/packages/cdk8s-plus/test/probe.test.ts
@@ -1,0 +1,119 @@
+import { Container, Duration, Probe } from '../src';
+
+describe('fromHttpGet()', () => {
+  test('defaults to the container port', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromHttpGet('/hello');
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      failureThreshold: 3, 
+      httpGet: {
+        path: '/hello', 
+        port: 5555,
+      }, 
+      initialDelaySeconds: undefined, 
+      periodSeconds: undefined, 
+      successThreshold: undefined, 
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('specific port', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromHttpGet('/hello', { port: 1234 });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      failureThreshold: 3, 
+      httpGet: {
+        path: '/hello', 
+        port: 1234,
+      }, 
+      initialDelaySeconds: undefined, 
+      periodSeconds: undefined, 
+      successThreshold: undefined, 
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('options', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromHttpGet('/hello', {
+      failureThreshold: 11,
+      initialDelaySeconds: Duration.minutes(1),
+      periodSeconds: Duration.seconds(5),
+      successThreshold: 3,
+      timeoutSeconds: Duration.minutes(2),
+    });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      httpGet: {
+        path: '/hello', 
+        port: 5555,
+      },
+      failureThreshold: 11, 
+      initialDelaySeconds: 60, 
+      periodSeconds: 5, 
+      successThreshold: 3, 
+      timeoutSeconds: 120,
+    });
+  });
+
+});
+
+describe('fromCommand()', () => {
+
+  test('minimal usage', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromCommand([ 'foo', 'bar' ]);
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      exec: { command: [ 'foo', 'bar' ] },
+      failureThreshold: 3,
+      initialDelaySeconds: undefined,
+      periodSeconds: undefined,
+      successThreshold: undefined,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('options', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromCommand([ 'foo', 'bar' ], {
+      failureThreshold: 11,
+      initialDelaySeconds: Duration.minutes(1),
+      periodSeconds: Duration.seconds(5),
+      successThreshold: 3,
+      timeoutSeconds: Duration.minutes(2),
+    });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      exec: { command: [ 'foo', 'bar' ] },
+      failureThreshold: 11, 
+      initialDelaySeconds: 60, 
+      periodSeconds: 5, 
+      successThreshold: 3, 
+      timeoutSeconds: 120,
+    });
+  });
+
+});


### PR DESCRIPTION
Adds support for container-level readiness probes.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
