### PR TITLE
feat(plus): expose service options in `expose()`

### DIFF
--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -38,6 +38,7 @@ Name|Description
 [EnvValueFromConfigMapOptions](#cdk8s-plus-envvaluefromconfigmapoptions)|Options to specify an envionment variable value from a ConfigMap key.
 [EnvValueFromProcessOptions](#cdk8s-plus-envvaluefromprocessoptions)|Options to specify an environment variable value from the process environment.
 [EnvValueFromSecretOptions](#cdk8s-plus-envvaluefromsecretoptions)|Options to specify an environment variable value from a Secret.
+[ExposeOptions](#cdk8s-plus-exposeoptions)|Options for exposing a deployment via a service.
 [HttpGetProbeOptions](#cdk8s-plus-httpgetprobeoptions)|Options for `Probe.fromHttpGet()`.
 [IngressProps](#cdk8s-plus-ingressprops)|Properties for `Ingress`.
 [IngressRule](#cdk8s-plus-ingressrule)|Represents the rules mapping the paths under a specified host to the related backend services.
@@ -382,23 +383,22 @@ addVolume(volume: Volume): void
 
 
 
-#### expose(port, srvOptions?, portOptions?)🔹 <a id="cdk8s-plus-deployment-expose"></a>
+#### expose(port, options?)🔹 <a id="cdk8s-plus-deployment-expose"></a>
 
 Expose a deployment via a service.
 
 This is equivalent to running `kubectl expose deployment <deployment-name>`.
 
 ```ts
-expose(port: number, srvOptions?: ServiceProps, portOptions?: ServicePortOptions): Service
+expose(port: number, options?: ExposeOptions): Service
 ```
 
 * **port** (<code>number</code>)  The port number the service will bind to.
-* **srvOptions** (<code>[ServiceProps](#cdk8s-plus-serviceprops)</code>)  Options to configure the wrapped Service.
-* **portOptions** (<code>[ServicePortOptions](#cdk8s-plus-serviceportoptions)</code>)  Optional settings for the exposed port.
-  * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
-  * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
+* **options** (<code>[ExposeOptions](#cdk8s-plus-exposeoptions)</code>)  Options to determine details of the service and port exposed.
+  * **name** (<code>string</code>)  The name of the service to expose. __*Default*__: undefined Uses the system generated name.
   * **protocol** (<code>[Protocol](#cdk8s-plus-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
-  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The value of `port` will be used.
+  * **serviceType** (<code>[ServiceType](#cdk8s-plus-servicetype)</code>)  The type of the exposed service. __*Default*__: ClusterIP.
+  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The port of the first container in the deployment (ie. containers[0].port)
 
 __Returns__:
 * <code>[Service](#cdk8s-plus-service)</code>
@@ -1335,21 +1335,21 @@ Name | Type | Description
 ### Methods
 
 
-#### addDeployment(deployment, port, portOptions?)🔹 <a id="cdk8s-plus-service-adddeployment"></a>
+#### addDeployment(deployment, port, options?)🔹 <a id="cdk8s-plus-service-adddeployment"></a>
 
 Associate a deployment to this service.
 
-Requests will be routed to the port exposed by the first container in the
-deployment's pods. The deployment's `labelSelector` will be used to select
-pods.
+If not targetPort is specific in the portOptions, then requests will be routed
+to the port exposed by the first container in the deployment's pods. 
+The deployment's `labelSelector` will be used to select pods.
 
 ```ts
-addDeployment(deployment: Deployment, port: number, portOptions?: ServicePortOptions): void
+addDeployment(deployment: Deployment, port: number, options?: ServicePortOptions): void
 ```
 
 * **deployment** (<code>[Deployment](#cdk8s-plus-deployment)</code>)  The deployment to expose.
 * **port** (<code>number</code>)  The external port.
-* **portOptions** (<code>[ServicePortOptions](#cdk8s-plus-serviceportoptions)</code>)  Optional settings for the port.
+* **options** (<code>[ServicePortOptions](#cdk8s-plus-serviceportoptions)</code>)  Optional settings for the port.
   * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
   * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
   * **protocol** (<code>[Protocol](#cdk8s-plus-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
@@ -1887,6 +1887,22 @@ Options to specify an environment variable value from a Secret.
 Name | Type | Description 
 -----|------|-------------
 **optional**?🔹 | <code>boolean</code> | Specify whether the Secret or its key must be defined.<br/>__*Default*__: false
+
+
+
+## struct ExposeOptions 🔹 <a id="cdk8s-plus-exposeoptions"></a>
+
+
+Options for exposing a deployment via a service.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**name**?🔹 | <code>string</code> | The name of the service to expose.<br/>__*Default*__: undefined Uses the system generated name.
+**protocol**?🔹 | <code>[Protocol](#cdk8s-plus-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
+**serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
+**targetPort**?🔹 | <code>number</code> | The port number the service will redirect to.<br/>__*Default*__: The port of the first container in the deployment (ie. containers[0].port)
 
 
 

--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -38,7 +38,6 @@ Name|Description
 [EnvValueFromConfigMapOptions](#cdk8s-plus-envvaluefromconfigmapoptions)|Options to specify an envionment variable value from a ConfigMap key.
 [EnvValueFromProcessOptions](#cdk8s-plus-envvaluefromprocessoptions)|Options to specify an environment variable value from the process environment.
 [EnvValueFromSecretOptions](#cdk8s-plus-envvaluefromsecretoptions)|Options to specify an environment variable value from a Secret.
-[ExposeOptions](#cdk8s-plus-exposeoptions)|Options for exposing a deployment via a service.
 [HttpGetProbeOptions](#cdk8s-plus-httpgetprobeoptions)|Options for `Probe.fromHttpGet()`.
 [IngressProps](#cdk8s-plus-ingressprops)|Properties for `Ingress`.
 [IngressRule](#cdk8s-plus-ingressrule)|Represents the rules mapping the paths under a specified host to the related backend services.
@@ -383,19 +382,23 @@ addVolume(volume: Volume): void
 
 
 
-#### expose(port, options?)🔹 <a id="cdk8s-plus-deployment-expose"></a>
+#### expose(port, srvOptions?, portOptions?)🔹 <a id="cdk8s-plus-deployment-expose"></a>
 
 Expose a deployment via a service.
 
 This is equivalent to running `kubectl expose deployment <deployment-name>`.
 
 ```ts
-expose(port: number, options?: ExposeOptions): Service
+expose(port: number, srvOptions?: ServiceProps, portOptions?: ServicePortOptions): Service
 ```
 
 * **port** (<code>number</code>)  The port number the service will bind to.
-* **options** (<code>[ExposeOptions](#cdk8s-plus-exposeoptions)</code>)  Options.
-  * **serviceType** (<code>[ServiceType](#cdk8s-plus-servicetype)</code>)  The type of the exposed service. __*Default*__: ClusterIP.
+* **srvOptions** (<code>[ServiceProps](#cdk8s-plus-serviceprops)</code>)  Options to configure the wrapped Service.
+* **portOptions** (<code>[ServicePortOptions](#cdk8s-plus-serviceportoptions)</code>)  Optional settings for the exposed port.
+  * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
+  * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
+  * **protocol** (<code>[Protocol](#cdk8s-plus-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
+  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The value of `port` will be used.
 
 __Returns__:
 * <code>[Service](#cdk8s-plus-service)</code>
@@ -1332,7 +1335,7 @@ Name | Type | Description
 ### Methods
 
 
-#### addDeployment(deployment, port)🔹 <a id="cdk8s-plus-service-adddeployment"></a>
+#### addDeployment(deployment, port, portOptions?)🔹 <a id="cdk8s-plus-service-adddeployment"></a>
 
 Associate a deployment to this service.
 
@@ -1341,11 +1344,16 @@ deployment's pods. The deployment's `labelSelector` will be used to select
 pods.
 
 ```ts
-addDeployment(deployment: Deployment, port: number): void
+addDeployment(deployment: Deployment, port: number, portOptions?: ServicePortOptions): void
 ```
 
 * **deployment** (<code>[Deployment](#cdk8s-plus-deployment)</code>)  The deployment to expose.
 * **port** (<code>number</code>)  The external port.
+* **portOptions** (<code>[ServicePortOptions](#cdk8s-plus-serviceportoptions)</code>)  Optional settings for the port.
+  * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
+  * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
+  * **protocol** (<code>[Protocol](#cdk8s-plus-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
+  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The value of `port` will be used.
 
 
 
@@ -1879,19 +1887,6 @@ Options to specify an environment variable value from a Secret.
 Name | Type | Description 
 -----|------|-------------
 **optional**?🔹 | <code>boolean</code> | Specify whether the Secret or its key must be defined.<br/>__*Default*__: false
-
-
-
-## struct ExposeOptions 🔹 <a id="cdk8s-plus-exposeoptions"></a>
-
-
-Options for exposing a deployment via a service.
-
-
-
-Name | Type | Description 
------|------|-------------
-**serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
 
 
 

--- a/packages/cdk8s-plus/src/deployment.ts
+++ b/packages/cdk8s-plus/src/deployment.ts
@@ -47,6 +47,8 @@ export interface ExposeOptions {
   /**
    * The name of the service to expose.
    * This will be set on the Service.metadata and must be a DNS_LABEL
+   * 
+   * @default undefined Uses the system generated name.
    */
   readonly name?: string;
   
@@ -179,7 +181,7 @@ export class Deployment extends Resource implements IPodTemplate {
    */
   public expose(port: number, options: ExposeOptions = {}): Service {
     const service = new Service(this, 'Service', {
-      metadata: options.name == null ? {} : {name: options.name},
+      metadata: options.name ? { name: options.name } : undefined,
       type: options.serviceType ?? ServiceType.CLUSTER_IP,
     });
 

--- a/packages/cdk8s-plus/src/deployment.ts
+++ b/packages/cdk8s-plus/src/deployment.ts
@@ -1,6 +1,6 @@
 import * as k8s from './imports/k8s';
 import { Construct, Node } from 'constructs';
-import { Service, ServiceType } from './service';
+import { Service, ServicePortOptions, ServiceProps, ServiceType } from './service';
 import { Resource, ResourceProps } from './base';
 import * as cdk8s from 'cdk8s';
 import { ApiObjectMetadataDefinition, Names } from 'cdk8s';
@@ -31,18 +31,6 @@ export interface DeploymentProps extends ResourceProps, PodTemplateProps {
    */
   readonly defaultSelector?: boolean;
 
-}
-
-/**
- * Options for exposing a deployment via a service.
- */
-export interface ExposeOptions {
-  /**
-   * The type of the exposed service.
-   *
-   * @default - ClusterIP.
-   */
-  readonly serviceType?: ServiceType;
 }
 
 /**
@@ -154,14 +142,16 @@ export class Deployment extends Resource implements IPodTemplate {
    * This is equivalent to running `kubectl expose deployment <deployment-name>`.
    *
    * @param port The port number the service will bind to.
-   * @param options Options.
+   * @param srvOptions Options to configure the wrapped Service.
+   * @param portOptions Optional settings for the exposed port.
    */
-  public expose(port: number, options: ExposeOptions = {}): Service {
+  public expose(port: number, srvOptions: ServiceProps = {}, portOptions: ServicePortOptions = {}): Service {
     const service = new Service(this, 'Service', {
-      type: options.serviceType ?? ServiceType.CLUSTER_IP,
+      ...srvOptions,
+      type: srvOptions.type ?? ServiceType.CLUSTER_IP,
     });
 
-    service.addDeployment(this, port);
+    service.addDeployment(this, port, portOptions);
     return service;
   }
 

--- a/packages/cdk8s-plus/src/service.ts
+++ b/packages/cdk8s-plus/src/service.ts
@@ -174,8 +174,9 @@ export class Service extends Resource {
    *
    * @param deployment The deployment to expose
    * @param port The external port
+   * @param portOptions Optional settings for the port.
    */
-  public addDeployment(deployment: Deployment, port: number) {
+  public addDeployment(deployment: Deployment, port: number, portOptions: ServicePortOptions = {}) {
     const containers = deployment.containers;
     if (containers.length === 0) {
       throw new Error('Cannot expose a deployment without containers');
@@ -198,6 +199,8 @@ export class Service extends Resource {
       // just a PoC, we assume the first container is the main one.
       // TODO: figure out what the correct thing to do here.
       targetPort: containers[0].port,
+
+      ...portOptions,
     });
   }
 
@@ -233,9 +236,11 @@ export class Service extends Resource {
 
     for (const port of this._ports) {
       ports.push({
+        name: port.name,
         port: port.port,
         targetPort: port.targetPort,
         nodePort: port.nodePort,
+        protocol: port.protocol,
       });
     }
 

--- a/packages/cdk8s-plus/src/service.ts
+++ b/packages/cdk8s-plus/src/service.ts
@@ -174,9 +174,9 @@ export class Service extends Resource {
    *
    * @param deployment The deployment to expose
    * @param port The external port
-   * @param portOptions Optional settings for the port.
+   * @param options Optional settings for the port.
    */
-  public addDeployment(deployment: Deployment, port: number, portOptions: ServicePortOptions = {}) {
+  public addDeployment(deployment: Deployment, port: number, options: ServicePortOptions = {}) {
     const containers = deployment.containers;
     if (containers.length === 0) {
       throw new Error('Cannot expose a deployment without containers');
@@ -196,11 +196,11 @@ export class Service extends Resource {
     }
 
     this.serve(port, {
-      ...portOptions, 
+      ...options, 
 
       // just a PoC, we assume the first container is the main one.
       // TODO: figure out what the correct thing to do here.
-      targetPort: portOptions.targetPort ?? containers[0].port,
+      targetPort: options.targetPort ?? containers[0].port,
     });
   }
 

--- a/packages/cdk8s-plus/src/service.ts
+++ b/packages/cdk8s-plus/src/service.ts
@@ -168,9 +168,9 @@ export class Service extends Resource {
   /**
    * Associate a deployment to this service.
    *
-   * Requests will be routed to the port exposed by the first container in the
-   * deployment's pods. The deployment's `labelSelector` will be used to select
-   * pods.
+   * If not targetPort is specific in the portOptions, then requests will be routed
+   * to the port exposed by the first container in the deployment's pods. 
+   * The deployment's `labelSelector` will be used to select pods.
    *
    * @param deployment The deployment to expose
    * @param port The external port
@@ -196,11 +196,11 @@ export class Service extends Resource {
     }
 
     this.serve(port, {
+      ...portOptions, 
+
       // just a PoC, we assume the first container is the main one.
       // TODO: figure out what the correct thing to do here.
-      targetPort: containers[0].port,
-
-      ...portOptions,
+      targetPort: portOptions.targetPort ?? containers[0].port,
     });
   }
 

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -79,7 +79,7 @@ test('Can be exposed as via service', () => {
     ],
   });
 
-  deployment.expose(9200, { serviceType: kplus.ServiceType.LOAD_BALANCER});
+  deployment.expose(9200, { type: kplus.ServiceType.LOAD_BALANCER});
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('LoadBalancer');
@@ -108,6 +108,42 @@ test('Expose uses the correct default values', () => {
   expect(spec.type).toEqual('ClusterIP');
 
 });
+
+test('Expose can set service and port details', () => {
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment', {
+    containers: [
+      new kplus.Container({
+        image: 'image',
+        port: 9300,
+      }),
+    ],
+  });
+
+  deployment.expose(
+    9200,
+    {
+      metadata: { name: 'test-srv' },
+      type: kplus.ServiceType.CLUSTER_IP,
+    },
+    { name: 'port-name', protocol: kplus.Protocol.UDP },
+  );
+
+  const srv = Testing.synth(chart)[1];
+  const spec = srv.spec;
+
+  expect(srv.metadata.name).toEqual('test-srv');
+  expect(spec.type).toEqual('ClusterIP');
+  expect(spec.selector).toEqual({
+    'cdk8s.deployment': 'test-Deployment-9e0110cd',
+  });
+  expect(spec.ports![0].port).toEqual(9200);
+  expect(spec.ports![0].targetPort).toEqual(9300);
+  expect(spec.ports![0].name).toEqual('port-name');
+  expect(spec.ports![0].protocol).toEqual('UDP');
+});
+
 
 test('Cannot be exposed if there are no containers in spec', () => {
 

--- a/packages/cdk8s-plus/test/deployment.test.ts
+++ b/packages/cdk8s-plus/test/deployment.test.ts
@@ -79,7 +79,7 @@ test('Can be exposed as via service', () => {
     ],
   });
 
-  deployment.expose(9200, { type: kplus.ServiceType.LOAD_BALANCER});
+  deployment.expose(9200, { serviceType: kplus.ServiceType.LOAD_BALANCER});
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('LoadBalancer');
@@ -106,6 +106,7 @@ test('Expose uses the correct default values', () => {
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('ClusterIP');
+  expect(spec.ports![0].targetPort).toEqual(9300);
 
 });
 
@@ -124,10 +125,11 @@ test('Expose can set service and port details', () => {
   deployment.expose(
     9200,
     {
-      metadata: { name: 'test-srv' },
-      type: kplus.ServiceType.CLUSTER_IP,
+      name: 'test-srv',
+      serviceType: kplus.ServiceType.CLUSTER_IP,    
+      protocol: kplus.Protocol.UDP,
+      targetPort: 9500,
     },
-    { name: 'port-name', protocol: kplus.Protocol.UDP },
   );
 
   const srv = Testing.synth(chart)[1];
@@ -139,8 +141,7 @@ test('Expose can set service and port details', () => {
     'cdk8s.deployment': 'test-Deployment-9e0110cd',
   });
   expect(spec.ports![0].port).toEqual(9200);
-  expect(spec.ports![0].targetPort).toEqual(9300);
-  expect(spec.ports![0].name).toEqual('port-name');
+  expect(spec.ports![0].targetPort).toEqual(9500);  
   expect(spec.ports![0].protocol).toEqual('UDP');
 });
 


### PR DESCRIPTION
This PR expands the `Deployment expose()` method to allow users to fully specify options to the generated Service and Port.  Originally I created this so I could provide a user defined name for the Service through metadata.  In the process I also found the need to allow specifying the port details for name and protocol.