### PR TITLE
feat(plus): add liveness and startup probes to Container

### DIFF
--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -221,9 +221,11 @@ new Container(props: ContainerProps)
   * **command** (<code>Array<string></code>)  Entrypoint array. __*Default*__: The docker image's ENTRYPOINT.
   * **env** (<code>Map<string, [EnvValue](#cdk8s-plus-envvalue)></code>)  List of environment variables to set in the container. __*Default*__: No environment variables.
   * **imagePullPolicy** (<code>[ImagePullPolicy](#cdk8s-plus-imagepullpolicy)</code>)  Image pull policy for this container. __*Default*__: ImagePullPolicy.ALWAYS
+  * **liveness** (<code>[Probe](#cdk8s-plus-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **startup** (<code>[Probe](#cdk8s-plus-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
 
@@ -1801,9 +1803,11 @@ Name | Type | Description
 **command**?🔹 | <code>Array<string></code> | Entrypoint array.<br/>__*Default*__: The docker image's ENTRYPOINT.
 **env**?🔹 | <code>Map<string, [EnvValue](#cdk8s-plus-envvalue)></code> | List of environment variables to set in the container.<br/>__*Default*__: No environment variables.
 **imagePullPolicy**?🔹 | <code>[ImagePullPolicy](#cdk8s-plus-imagepullpolicy)</code> | Image pull policy for this container.<br/>__*Default*__: ImagePullPolicy.ALWAYS
+**liveness**?🔹 | <code>[Probe](#cdk8s-plus-probe)</code> | Periodic probe of container liveness.<br/>__*Default*__: no liveness probe is defined
 **name**?🔹 | <code>string</code> | Name of the container specified as a DNS_LABEL.<br/>__*Default*__: 'main'
 **port**?🔹 | <code>number</code> | Number of port to expose on the pod's IP address.<br/>__*Default*__: No port is exposed.
 **readiness**?🔹 | <code>[Probe](#cdk8s-plus-probe)</code> | Determines when the container is ready to serve traffic.<br/>__*Default*__: no readiness probe is defined
+**startup**?🔹 | <code>[Probe](#cdk8s-plus-probe)</code> | StartupProbe indicates that the Pod has successfully initialized.<br/>__*Default*__: no startup probe is defined.
 **volumeMounts**?🔹 | <code>Array<[VolumeMount](#cdk8s-plus-volumemount)></code> | Pod volumes to mount into the container's filesystem.<br/>__*Optional*__
 **workingDir**?🔹 | <code>string</code> | Container's working directory.<br/>__*Default*__: The container runtime's default.
 

--- a/packages/cdk8s-plus/README.md
+++ b/packages/cdk8s-plus/README.md
@@ -272,7 +272,7 @@ A `Probe` instance can be created through one of the `fromXxx` static methods:
 - `Probe.fromHttpGet()`
 - `Probe.fromCommand()`
 
-Readiness probes can be configured at the container-level through the `readiness` option:
+Readiness, liveness, and startup probes can be configured at the container-level through the `readiness`, `liveness`, and `startup` options:
 
 ```ts
 new kplus.Container({

--- a/packages/cdk8s-plus/src/container.ts
+++ b/packages/cdk8s-plus/src/container.ts
@@ -225,6 +225,21 @@ export interface ContainerProps {
    * @default - no readiness probe is defined
    */
   readonly readiness?: Probe; 
+
+  /**
+   * Periodic probe of container liveness. Container will be restarted if the probe fails. 
+   * 
+   * @default - no liveness probe is defined
+   */
+  readonly liveness?: Probe; 
+
+  /**
+   * StartupProbe indicates that the Pod has successfully initialized. 
+   * If specified, no other probes are executed until this completes successfully
+   * 
+   * @default - no startup probe is defined.
+   */
+  readonly startup?: Probe;
 }
 
 /**
@@ -266,6 +281,8 @@ export class Container {
   private readonly _args?: readonly string[];
   private readonly _env: { [name: string]: EnvValue };
   private readonly _readiness?: Probe;
+  private readonly _liveness?: Probe;
+  private readonly _startup?: Probe;
 
   constructor(props: ContainerProps) {
     this.name = props.name ?? 'main';
@@ -275,6 +292,8 @@ export class Container {
     this._args = props.args;
     this._env = props.env ?? { };
     this._readiness = props.readiness;
+    this._liveness = props.liveness;
+    this._startup = props.startup;
     this.workingDir = props.workingDir;
     this.mounts = props.volumeMounts ?? [];
     this.imagePullPolicy = props.imagePullPolicy ?? ImagePullPolicy.ALWAYS;
@@ -366,6 +385,8 @@ export class Container {
       workingDir: this.workingDir,
       env: renderEnv(this._env),
       readinessProbe: this._readiness?._toKube(this),
+      livenessProbe: this._liveness?._toKube(this),
+      startupProbe: this._startup?._toKube(this),
     };
   }
 }

--- a/packages/cdk8s-plus/test/container.test.ts
+++ b/packages/cdk8s-plus/test/container.test.ts
@@ -198,12 +198,18 @@ describe('Container', () => {
     expect(container._toKube().volumeMounts).toEqual([expected]);
   });
 
-  test('"readiness" can be used to define readiness probes', () => {
+  test('"readiness", "liveness", and "startup" can be used to define probes', () => {
     // GIVEN
     const container = new kplus.Container({ 
       image: 'foo',
       readiness: kplus.Probe.fromHttpGet('/ping', {
         timeoutSeconds: Duration.minutes(2),
+      }),
+      liveness: kplus.Probe.fromHttpGet('/live', {
+        timeoutSeconds: Duration.minutes(3),
+      }),
+      startup: kplus.Probe.fromHttpGet('/startup', {
+        timeoutSeconds: Duration.minutes(4),
       }),
     });
 
@@ -215,6 +221,22 @@ describe('Container', () => {
       periodSeconds: undefined, 
       successThreshold: undefined, 
       timeoutSeconds: 120,
+    });
+    expect(container._toKube().livenessProbe).toEqual({
+      failureThreshold: 3, 
+      httpGet: {path: '/live', port: 80}, 
+      initialDelaySeconds: undefined, 
+      periodSeconds: undefined, 
+      successThreshold: undefined, 
+      timeoutSeconds: 180,
+    });
+    expect(container._toKube().startupProbe).toEqual({
+      failureThreshold: 3, 
+      httpGet: {path: '/startup', port: 80}, 
+      initialDelaySeconds: undefined, 
+      periodSeconds: undefined, 
+      successThreshold: undefined, 
+      timeoutSeconds: 240,
     });
   });
 


### PR DESCRIPTION
This PR expands the probe support in Container to include liveness and startup probes.


