### PR TITLE
feat(plus): add method to mount raw volume to a container

### DIFF
--- a/packages/cdk8s-plus/API.md
+++ b/packages/cdk8s-plus/API.md
@@ -1733,6 +1733,20 @@ static fromEmptyDir(name: string, options?: EmptyDirVolumeOptions): Volume
 __Returns__:
 * <code>[Volume](#cdk8s-plus-volume)</code>
 
+#### *static* fromVolumeSpec(name, volume)🔹 <a id="cdk8s-plus-volume-fromvolumespec"></a>
+
+Create a volume the wraps a k8s.Volume for usage in cdk8s-plus.
+
+```ts
+static fromVolumeSpec(name: string, volume: any): Volume
+```
+
+* **name** (<code>string</code>)  Name of the volume.
+* **volume** (<code>any</code>)  The k8s.Volume resource to wrap.
+
+__Returns__:
+* <code>[Volume](#cdk8s-plus-volume)</code>
+
 
 
 ## struct AddDirectoryOptions 🔹 <a id="cdk8s-plus-adddirectoryoptions"></a>

--- a/packages/cdk8s-plus/src/volume.ts
+++ b/packages/cdk8s-plus/src/volume.ts
@@ -99,6 +99,20 @@ export class Volume {
   }
 
   /**
+   * Create a volume the wraps a k8s.Volume for usage in cdk8s-plus.
+   * 
+   * @param name Name of the volume.
+   * @param volume The k8s.Volume resource to wrap.
+   * 
+   * note: 
+   *    Using Omit outputs: 
+   *      jsii/compiler - Type model errors prevented the JSII assembly from being created
+   */
+  public static fromVolumeSpec(name: string, volume: any /*Omit<k8s.Volume, 'name'>*/): Volume {
+    return new Volume(name, volume);
+  }
+
+  /**
    * @internal
    */
   public _toKube(): k8s.Volume {

--- a/packages/cdk8s-plus/test/pod.test.ts
+++ b/packages/cdk8s-plus/test/pod.test.ts
@@ -1,5 +1,6 @@
 import * as kplus from '../src';
 import { Testing } from 'cdk8s';
+import * as k8s from '../src/imports/k8s';
 
 test('Can add container post instantiation', () => {
 
@@ -64,6 +65,33 @@ test('Automatically adds volumes from container mounts', () => {
   expect(spec.volumes[0].emptyDir).toBeTruthy();
 
 });
+
+test('Supports raw volume mounts', () => {
+  const host_vol: Omit<k8s.Volume, 'name'> = {
+    hostPath: {
+      path: '/data',
+      type: 'DirectoryOrCreate',
+    },
+  };
+
+  const chart = Testing.chart();
+
+  const pod = new kplus.Pod(chart, 'Pod');
+
+  const volume = kplus.Volume.fromVolumeSpec('data-vol', host_vol);
+
+  const container = new kplus.Container({ image: 'image' });
+  container.mount('/data', volume);
+
+  pod.addContainer(container);
+
+  const spec = Testing.synth(chart)[0].spec;
+
+  expect(spec.volumes[0].name).toEqual('data-vol');
+  expect(spec.volumes[0].hostPath).toBeTruthy();
+
+});
+
 
 test('Synthesizes spec lazily', () => {
 


### PR DESCRIPTION
This is the best way I have found to use kplus and allow mounting to all the various k8s volume types.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
