### PR TITLE
feat(cli): import from crds.dev

### DIFF
--- a/packages/cdk8s-cli/src/cli/cmds/import.ts
+++ b/packages/cdk8s-cli/src/cli/cmds/import.ts
@@ -13,12 +13,13 @@ class Command implements yargs.CommandModule {
   public readonly aliases = ['gen', 'import', 'generate'];
 
   public readonly builder = (args: yargs.Argv) => args
-    .positional('SPEC', { default: config.imports, desc: 'import spec with the syntax [NAME:=]SPEC where NAME is an optional module name and supported SPEC are: k8s, crd.yaml, https://domain/crd.yaml).', array: true })
+    .positional('SPEC', { default: config.imports, desc: 'import spec with the syntax [NAME:=]SPEC where NAME is an optional module name and supported SPEC are: k8s, crd.yaml, https://domain/crd.yaml, github:account/repo[@VERSION]).', array: true })
     .example('cdk8s import k8s', 'Imports Kubernetes API objects to imports/k8s.ts')
     .example('cdk8s import k8s --no-class-prefix', 'Imports Kubernetes API objects without the "Kube" prefix')
     .example('cdk8s import k8s@1.13.0', 'Imports a specific version of the Kubernetes API')
     .example('cdk8s import jenkins.io_jenkins_crd.yaml', 'Imports constructs for the Jenkins custom resource definition from a file')
     .example('cdk8s import mattermost:=mattermost_crd.yaml', 'Imports constructs for the mattermost cluster custom resource definition using a custom module name')
+    .example('cdk8s import github:crossplane/crossplane@0.14.0', 'Imports constructs for a GitHub repo using doc.crds.dev')
 
     .option('output', { default: DEFAULT_OUTDIR, type: 'string', desc: 'Output directory', alias: 'o' })
     .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type (only for "k8s")' })

--- a/packages/cdk8s-cli/src/import/crds-dev.ts
+++ b/packages/cdk8s-cli/src/import/crds-dev.ts
@@ -1,0 +1,58 @@
+import { ImportCustomResourceDefinition, ManifestObjectDefinition } from './crd';
+
+/**
+ *
+ *              github:crossplane/crossplane@0.14.0
+ *              |--^- |  ^         ^         ^ ^  ^
+ *                 |     |         |         | |  |
+ *  - provider ----+     |         |         | |  |
+ *  - account -----------+         |         | |  |
+ *  - repo ------------------------+         | |  |
+ *  - major ---------------------------------+ |  |
+ *  - minor -----------------------------------+  |
+ *  - patch --------------------------------------+
+ */
+
+/**
+ * Matches a https://doc.crds.dev repo
+ *
+ *  - ManifestObjectDefinition[] if found
+ *  - undefined if not
+ *
+ * @param source
+ */
+export async function importCrdsDevRepoMatch(source: string): Promise<undefined | ManifestObjectDefinition[]> {
+  const url = crdsDevUrl(source);
+  if (url) {
+    const crd = await ImportCustomResourceDefinition.match({
+      source: url,
+    });
+
+    return crd;
+  }
+
+  return undefined;
+}
+
+export function crdsDevUrl(source: string): (undefined | string) {
+  const match = /^github:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\@([0-9]+)\.([0-9]+)(?:\.([0-9]+))?)?$/.exec(source);
+  if (match) {
+    const account = match[1];
+    const repo = match[2];
+    const major = match[3];
+
+    //default to master if no version specified
+    //TODO: get latest released version from available versions
+    let url = `https://doc.crds.dev/raw/github.com/${account}/${repo}`;
+    if (major) {
+      const minor = match[4];
+      const patch = match[5] ?? '0';
+
+      url = `https://doc.crds.dev/raw/github.com/${account}/${repo}@v${major}.${minor}.${patch}`;
+    }
+
+    return url;
+  }
+
+  return undefined;
+}

--- a/packages/cdk8s-cli/src/import/dispatch.ts
+++ b/packages/cdk8s-cli/src/import/dispatch.ts
@@ -1,6 +1,7 @@
 import { ImportSpec } from '../config';
 import { ImportOptions } from './base';
 import { ImportCustomResourceDefinition } from './crd';
+import { importCrdsDevRepoMatch } from './crds-dev';
 import { ImportKubernetesApi } from './k8s';
 
 export async function importDispatch(imports: ImportSpec[], argv: any, options: ImportOptions) {
@@ -22,6 +23,11 @@ async function matchImporter(importSpec: ImportSpec, argv: any) {
   const k8s = await ImportKubernetesApi.match(importSpec, argv);
   if (k8s) {
     return new ImportKubernetesApi(k8s);
+  }
+
+  const crdsDev = await importCrdsDevRepoMatch(importSpec.source);
+  if (crdsDev) {
+    return new ImportCustomResourceDefinition(crdsDev);
   }
 
   const crd = await ImportCustomResourceDefinition.match(importSpec);

--- a/packages/cdk8s-cli/test/import/__snapshots__/import-crds-dev.test.ts.snap
+++ b/packages/cdk8s-cli/test/import/__snapshots__/import-crds-dev.test.ts.snap
@@ -1,0 +1,909 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`crds.dev import github:crossplane/crossplane@0.14.0 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": Object {
+    "cdk8s": "999.999.999",
+    "constructs": "3.0.4",
+  },
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "apiextensionscrossplaneiocomposition",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "1.13.0 (build 385c325)",
+  "license": "Apache-2.0",
+  "name": "apiextensionscrossplaneiocomposition",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "apiextensionscrossplaneiocomposition",
+    },
+  },
+  "types": Object {
+    "apiextensionscrossplaneiocomposition.Composition": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "base": "cdk8s.ApiObject",
+      "docs": Object {
+        "custom": Object {
+          "schema": "Composition",
+        },
+        "summary": "Composition defines the group of resources to be created when a compatible type is created with reference to the composition.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.Composition",
+      "initializer": Object {
+        "docs": Object {
+          "summary": "Defines a \\"Composition\\" API object.",
+        },
+        "locationInModule": Object {
+          "filename": "apiextensions.crossplane.io/composition.ts",
+          "line": 17,
+        },
+        "parameters": Array [
+          Object {
+            "docs": Object {
+              "summary": "the scope in which to define this object.",
+            },
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "docs": Object {
+              "summary": "a scope-local name for the object.",
+            },
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "docs": Object {
+              "summary": "initialiation props.",
+            },
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "apiextensionscrossplaneiocomposition.CompositionProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 10,
+      },
+      "name": "Composition",
+    },
+    "apiextensionscrossplaneiocomposition.CompositionProps": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "Composition",
+        },
+        "summary": "Composition defines the group of resources to be created when a compatible type is created with reference to the composition.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 31,
+      },
+      "name": "CompositionProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "Composition#metadata",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 35,
+          },
+          "name": "metadata",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "Composition#spec",
+            },
+            "summary": "CompositionSpec specifies the desired state of the definition.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 42,
+          },
+          "name": "spec",
+          "optional": true,
+          "type": Object {
+            "fqn": "apiextensionscrossplaneiocomposition.CompositionSpec",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpec": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpec",
+        },
+        "summary": "CompositionSpec specifies the desired state of the definition.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpec",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 51,
+      },
+      "name": "CompositionSpec",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpec#compositeTypeRef",
+            },
+            "summary": "CompositeTypeRef specifies the type of composite resource that this composition is compatible with.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 57,
+          },
+          "name": "compositeTypeRef",
+          "type": Object {
+            "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecCompositeTypeRef",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpec#resources",
+            },
+            "summary": "Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 64,
+          },
+          "name": "resources",
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResources",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpec#writeConnectionSecretsToNamespace",
+            },
+            "summary": "WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 71,
+          },
+          "name": "writeConnectionSecretsToNamespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecCompositeTypeRef": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecCompositeTypeRef",
+        },
+        "summary": "CompositeTypeRef specifies the type of composite resource that this composition is compatible with.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecCompositeTypeRef",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 80,
+      },
+      "name": "CompositionSpecCompositeTypeRef",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecCompositeTypeRef#apiVersion",
+            },
+            "summary": "APIVersion of the type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 86,
+          },
+          "name": "apiVersion",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecCompositeTypeRef#kind",
+            },
+            "summary": "Kind of the type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 93,
+          },
+          "name": "kind",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResources": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResources",
+        },
+        "summary": "ComposedTemplate is used to provide information about how the composed resource should be processed.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResources",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 102,
+      },
+      "name": "CompositionSpecResources",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResources#base",
+            },
+            "summary": "Base is the target resource that the patches will be applied on.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 108,
+          },
+          "name": "base",
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResources#connectionDetails",
+            },
+            "summary": "ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 115,
+          },
+          "name": "connectionDetails",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesConnectionDetails",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResources#patches",
+            },
+            "summary": "Patches will be applied as overlay to the base resource.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 122,
+          },
+          "name": "patches",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatches",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResources#readinessChecks",
+            },
+            "remarks": "All checks have to return true in order for resource to be considered ready. The default readiness check is to have the \\"Ready\\" condition to be \\"True\\".",
+            "summary": "ReadinessChecks allows users to define custom readiness checks.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 129,
+          },
+          "name": "readinessChecks",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecks",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesConnectionDetails": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesConnectionDetails",
+        },
+        "summary": "ConnectionDetail includes the information about the propagation of the connection information from one secret to another.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesConnectionDetails",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 138,
+      },
+      "name": "CompositionSpecResourcesConnectionDetails",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesConnectionDetails#fromConnectionSecretKey",
+            },
+            "summary": "FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 144,
+          },
+          "name": "fromConnectionSecretKey",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesConnectionDetails#name",
+            },
+            "remarks": "Leave empty if you'd like to use the same key name.",
+            "summary": "Name of the connection secret key that will be propagated to the connection secret of the composition instance.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 151,
+          },
+          "name": "name",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesConnectionDetails#value",
+            },
+            "remarks": "Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.",
+            "summary": "Value that will be propagated to the connection secret of the composition instance.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 158,
+          },
+          "name": "value",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatches": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesPatches",
+        },
+        "summary": "Patch is used to patch the field on the base resource at ToFieldPath after piping the value that is at FromFieldPath of the target resource through transformers.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatches",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 167,
+      },
+      "name": "CompositionSpecResourcesPatches",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatches#fromFieldPath",
+            },
+            "summary": "FromFieldPath is the path of the field on the upstream resource whose value to be used as input.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 173,
+          },
+          "name": "fromFieldPath",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatches#toFieldPath",
+            },
+            "remarks": "Leave empty if you'd like to propagate to the same path on the target resource.",
+            "summary": "ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 180,
+          },
+          "name": "toFieldPath",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatches#transforms",
+            },
+            "summary": "Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 187,
+          },
+          "name": "transforms",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransforms",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransforms": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesPatchesTransforms",
+        },
+        "summary": "Transform is a unit of process whose input is transformed into an output with the supplied configuration.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransforms",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 232,
+      },
+      "name": "CompositionSpecResourcesPatchesTransforms",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransforms#type",
+            },
+            "summary": "Type of the transform to be run.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 259,
+          },
+          "name": "type",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransforms#map",
+            },
+            "summary": "Map uses the input as a key in the given map and returns the value.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 238,
+          },
+          "name": "map",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransforms#math",
+            },
+            "summary": "Math is used to transform the input via mathematical operations such as multiplication.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 245,
+          },
+          "name": "math",
+          "optional": true,
+          "type": Object {
+            "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsMath",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransforms#string",
+            },
+            "remarks": "Note that the input does not necessarily need to be a string.",
+            "summary": "String is used to transform the input into a string or a different kind of string.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 252,
+          },
+          "name": "string",
+          "optional": true,
+          "type": Object {
+            "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsString",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsMath": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesPatchesTransformsMath",
+        },
+        "summary": "Math is used to transform the input via mathematical operations such as multiplication.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsMath",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 284,
+      },
+      "name": "CompositionSpecResourcesPatchesTransformsMath",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransformsMath#multiply",
+            },
+            "summary": "Multiply the value.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 290,
+          },
+          "name": "multiply",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsString": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesPatchesTransformsString",
+        },
+        "remarks": "Note that the input does not necessarily need to be a string.",
+        "summary": "String is used to transform the input into a string or a different kind of string.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesPatchesTransformsString",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 299,
+      },
+      "name": "CompositionSpecResourcesPatchesTransformsString",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesPatchesTransformsString#fmt",
+            },
+            "remarks": "See https://golang.org/pkg/fmt/ for details.",
+            "summary": "Format the input using a Go format string.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 305,
+          },
+          "name": "fmt",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecks": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesReadinessChecks",
+        },
+        "summary": "ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecks",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 196,
+      },
+      "name": "CompositionSpecResourcesReadinessChecks",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesReadinessChecks#type",
+            },
+            "summary": "Type indicates the type of probe you'd like to use.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 223,
+          },
+          "name": "type",
+          "type": Object {
+            "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecksType",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesReadinessChecks#fieldPath",
+            },
+            "summary": "FieldPath shows the path of the field whose value will be used.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 202,
+          },
+          "name": "fieldPath",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesReadinessChecks#matchInteger",
+            },
+            "summary": "MatchInt is the value you'd like to match if you're using \\"MatchInt\\" type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 209,
+          },
+          "name": "matchInteger",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "CompositionSpecResourcesReadinessChecks#matchString",
+            },
+            "summary": "MatchString is the value you'd like to match if you're using \\"MatchString\\" type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "apiextensions.crossplane.io/composition.ts",
+            "line": 216,
+          },
+          "name": "matchString",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+    },
+    "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecksType": Object {
+      "assembly": "apiextensionscrossplaneiocomposition",
+      "docs": Object {
+        "custom": Object {
+          "schema": "CompositionSpecResourcesReadinessChecksType",
+        },
+        "summary": "Type indicates the type of probe you'd like to use.",
+      },
+      "fqn": "apiextensionscrossplaneiocomposition.CompositionSpecResourcesReadinessChecksType",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "apiextensions.crossplane.io/composition.ts",
+        "line": 268,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "MatchString.",
+          },
+          "name": "MATCH_STRING",
+        },
+        Object {
+          "docs": Object {
+            "summary": "MatchInteger.",
+          },
+          "name": "MATCH_INTEGER",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NonEmpty.",
+          },
+          "name": "NON_EMPTY",
+        },
+        Object {
+          "docs": Object {
+            "summary": "None.",
+          },
+          "name": "NONE",
+        },
+      ],
+      "name": "CompositionSpecResourcesReadinessChecksType",
+    },
+  },
+  "version": "0.0.0",
+}
+`;

--- a/packages/cdk8s-cli/test/import/fixtures/crds-dev/github-crossplane-crossplane-v0.14.0.yaml
+++ b/packages/cdk8s-cli/test/import/fixtures/crds-dev/github-crossplane-crossplane-v0.14.0.yaml
@@ -1,0 +1,897 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: compositeresourcedefinitions.apiextensions.crossplane.io
+spec:
+  group: apiextensions.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: CompositeResourceDefinition
+    listKind: CompositeResourceDefinitionList
+    plural: compositeresourcedefinitions
+    shortNames:
+    - xrd
+    singular: compositeresourcedefinition
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Established')].status
+      name: ESTABLISHED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Offered')].status
+      name: OFFERED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositeResourceDefinitionSpec specifies the desired state of the definition.
+            properties:
+              claimNames:
+                description: ClaimNames specifies the names of an optional composite resource claim. When claim names are specified Crossplane will create a namespaced 'composite resource claim' CRD that corresponds to the defined composite resource. This composite resource claim acts as a namespaced proxy for the composite resource; creating, updating, or deleting the claim will create, update, or delete a corresponding composite resource. You may add claim names to an existing CompositeResourceDefinition, but they cannot be changed or removed once they have been set.
+                properties:
+                  categories:
+                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    type: string
+                  listKind:
+                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    type: string
+                  plural:
+                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    type: string
+                  shortNames:
+                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    items:
+                      type: string
+                    type: array
+                  singular:
+                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    type: string
+                required:
+                - kind
+                - plural
+                type: object
+              connectionSecretKeys:
+                description: ConnectionSecretKeys is the list of keys that will be exposed to the end user of the defined kind.
+                items:
+                  type: string
+                type: array
+              defaultCompositionRef:
+                description: DefaultCompositionRef refers to the Composition resource that will be used in case no composition selector is given.
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                required:
+                - name
+                type: object
+              enforcedCompositionRef:
+                description: EnforcedCompositionRef refers to the Composition resource that will be used by all composite instances whose schema is defined by this definition.
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                required:
+                - name
+                type: object
+              group:
+                description: Group specifies the API group of the defined composite resource. Composite resources are served under `/apis/<group>/...`. Must match the name of the XRD (in the form `<names.plural>.<group>`).
+                type: string
+              names:
+                description: Names specifies the resource and kind names of the defined composite resource.
+                properties:
+                  categories:
+                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    type: string
+                  listKind:
+                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    type: string
+                  plural:
+                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    type: string
+                  shortNames:
+                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    items:
+                      type: string
+                    type: array
+                  singular:
+                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    type: string
+                required:
+                - kind
+                - plural
+                type: object
+              versions:
+                description: 'Versions is the list of all API versions of the defined composite resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have identical schemas; Crossplane does not currently support conversion between different version schemas.'
+                items:
+                  description: CompositeResourceDefinitionVersion describes a version of an XR.
+                  properties:
+                    additionalPrinterColumns:
+                      description: 'AdditionalPrinterColumns specifies additional columns returned in Table output. If no columns are specified, a single column displaying the age of the custom resource is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
+                      items:
+                        description: CustomResourceColumnDefinition specifies a column for server side printing.
+                        properties:
+                          description:
+                            description: description is a human readable description of this column.
+                            type: string
+                          format:
+                            description: format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            type: string
+                          jsonPath:
+                            description: jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+                            type: string
+                          name:
+                            description: name is a human readable name for the column.
+                            type: string
+                          priority:
+                            description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+                            format: int32
+                            type: integer
+                          type:
+                            description: type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            type: string
+                        required:
+                        - jsonPath
+                        - name
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: Name of this version, e.g. “v1”, “v2beta1”, etc. Composite resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+                      type: string
+                    referenceable:
+                      description: Referenceable specifies that this version may be referenced by a Composition in order to configure which resources an XR may be composed of. Exactly one version must be marked as referenceable; all Compositions must target only the referenceable version. The referenceable version must be served.
+                      type: boolean
+                    schema:
+                      description: Schema describes the schema used for validation, pruning, and defaulting of this version of the defined composite resource. Fields required by all composite resources will be injected into this schema automatically, and will override equivalently named fields in this schema. Omitting this schema results in a schema that contains only the fields required by all composite resources.
+                      properties:
+                        openAPIV3Schema:
+                          description: OpenAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    served:
+                      description: Served specifies that this version should be served via REST APIs.
+                      type: boolean
+                  required:
+                  - name
+                  - referenceable
+                  - served
+                  type: object
+                type: array
+            required:
+            - group
+            - names
+            - versions
+            type: object
+          status:
+            description: CompositeResourceDefinitionStatus shows the observed state of the definition.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllers:
+                description: Controllers represents the status of the controllers that power this composite resource definition.
+                properties:
+                  compositeResourceClaimType:
+                    description: The CompositeResourceClaimTypeRef is the type of composite resource claim that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    properties:
+                      apiVersion:
+                        description: APIVersion of the type.
+                        type: string
+                      kind:
+                        description: Kind of the type.
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    type: object
+                  compositeResourceType:
+                    description: The CompositeResourceTypeRef is the type of composite resource that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    properties:
+                      apiVersion:
+                        description: APIVersion of the type.
+                        type: string
+                      kind:
+                        description: Kind of the type.
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Established')].status
+      name: ESTABLISHED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Offered')].status
+      name: OFFERED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositeResourceDefinitionSpec specifies the desired state of the definition.
+            properties:
+              claimNames:
+                description: ClaimNames specifies the names of an optional composite resource claim. When claim names are specified Crossplane will create a namespaced 'composite resource claim' CRD that corresponds to the defined composite resource. This composite resource claim acts as a namespaced proxy for the composite resource; creating, updating, or deleting the claim will create, update, or delete a corresponding composite resource. You may add claim names to an existing CompositeResourceDefinition, but they cannot be changed or removed once they have been set.
+                properties:
+                  categories:
+                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    type: string
+                  listKind:
+                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    type: string
+                  plural:
+                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    type: string
+                  shortNames:
+                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    items:
+                      type: string
+                    type: array
+                  singular:
+                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    type: string
+                required:
+                - kind
+                - plural
+                type: object
+              connectionSecretKeys:
+                description: ConnectionSecretKeys is the list of keys that will be exposed to the end user of the defined kind.
+                items:
+                  type: string
+                type: array
+              defaultCompositionRef:
+                description: DefaultCompositionRef refers to the Composition resource that will be used in case no composition selector is given.
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                required:
+                - name
+                type: object
+              enforcedCompositionRef:
+                description: EnforcedCompositionRef refers to the Composition resource that will be used by all composite instances whose schema is defined by this definition.
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                required:
+                - name
+                type: object
+              group:
+                description: Group specifies the API group of the defined composite resource. Composite resources are served under `/apis/<group>/...`. Must match the name of the XRD (in the form `<names.plural>.<group>`).
+                type: string
+              names:
+                description: Names specifies the resource and kind names of the defined composite resource.
+                properties:
+                  categories:
+                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    type: string
+                  listKind:
+                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    type: string
+                  plural:
+                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    type: string
+                  shortNames:
+                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    items:
+                      type: string
+                    type: array
+                  singular:
+                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    type: string
+                required:
+                - kind
+                - plural
+                type: object
+              versions:
+                description: 'Versions is the list of all API versions of the defined composite resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have identical schemas; Crossplane does not currently support conversion between different version schemas.'
+                items:
+                  description: CompositeResourceDefinitionVersion describes a version of an XR.
+                  properties:
+                    additionalPrinterColumns:
+                      description: 'AdditionalPrinterColumns specifies additional columns returned in Table output. If no columns are specified, a single column displaying the age of the custom resource is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
+                      items:
+                        description: CustomResourceColumnDefinition specifies a column for server side printing.
+                        properties:
+                          description:
+                            description: description is a human readable description of this column.
+                            type: string
+                          format:
+                            description: format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            type: string
+                          jsonPath:
+                            description: jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+                            type: string
+                          name:
+                            description: name is a human readable name for the column.
+                            type: string
+                          priority:
+                            description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+                            format: int32
+                            type: integer
+                          type:
+                            description: type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            type: string
+                        required:
+                        - jsonPath
+                        - name
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: Name of this version, e.g. “v1”, “v2beta1”, etc. Composite resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+                      type: string
+                    referenceable:
+                      description: Referenceable specifies that this version may be referenced by a Composition in order to configure which resources an XR may be composed of. Exactly one version must be marked as referenceable; all Compositions must target only the referenceable version. The referenceable version must be served.
+                      type: boolean
+                    schema:
+                      description: Schema describes the schema used for validation, pruning, and defaulting of this version of the defined composite resource. Fields required by all composite resources will be injected into this schema automatically, and will override equivalently named fields in this schema. Omitting this schema results in a schema that contains only the fields required by all composite resources.
+                      properties:
+                        openAPIV3Schema:
+                          description: OpenAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    served:
+                      description: Served specifies that this version should be served via REST APIs.
+                      type: boolean
+                  required:
+                  - name
+                  - referenceable
+                  - served
+                  type: object
+                type: array
+            required:
+            - group
+            - names
+            - versions
+            type: object
+          status:
+            description: CompositeResourceDefinitionStatus shows the observed state of the definition.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllers:
+                description: Controllers represents the status of the controllers that power this composite resource definition.
+                properties:
+                  compositeResourceClaimType:
+                    description: The CompositeResourceClaimTypeRef is the type of composite resource claim that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    properties:
+                      apiVersion:
+                        description: APIVersion of the type.
+                        type: string
+                      kind:
+                        description: Kind of the type.
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    type: object
+                  compositeResourceType:
+                    description: The CompositeResourceTypeRef is the type of composite resource that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    properties:
+                      apiVersion:
+                        description: APIVersion of the type.
+                        type: string
+                      kind:
+                        description: Kind of the type.
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: compositions.apiextensions.crossplane.io
+spec:
+  group: apiextensions.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: Composition
+    listKind: CompositionList
+    plural: compositions
+    singular: composition
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositionSpec specifies the desired state of the definition.
+            properties:
+              compositeTypeRef:
+                description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the type.
+                    type: string
+                  kind:
+                    description: Kind of the type.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                type: object
+              resources:
+                description: Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.
+                items:
+                  description: ComposedTemplate is used to provide information about how the composed resource should be processed.
+                  properties:
+                    base:
+                      description: Base is the target resource that the patches will be applied on.
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    connectionDetails:
+                      description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
+                      items:
+                        description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
+                        properties:
+                          fromConnectionSecretKey:
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.
+                            type: string
+                          name:
+                            description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          value:
+                            description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
+                            type: string
+                        type: object
+                      type: array
+                    patches:
+                      description: Patches will be applied as overlay to the base resource.
+                      items:
+                        description: Patch is used to patch the field on the base resource at ToFieldPath after piping the value that is at FromFieldPath of the target resource through transformers.
+                        properties:
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input.
+                            type: string
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              properties:
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                        required:
+                        - fromFieldPath
+                        type: object
+                      type: array
+                    readinessChecks:
+                      description: ReadinessChecks allows users to define custom readiness checks. All checks have to return true in order for resource to be considered ready. The default readiness check is to have the "Ready" condition to be "True".
+                      items:
+                        description: ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption
+                        properties:
+                          fieldPath:
+                            description: FieldPath shows the path of the field whose value will be used.
+                            type: string
+                          matchInteger:
+                            description: MatchInt is the value you'd like to match if you're using "MatchInt" type.
+                            format: int64
+                            type: integer
+                          matchString:
+                            description: MatchString is the value you'd like to match if you're using "MatchString" type.
+                            type: string
+                          type:
+                            description: Type indicates the type of probe you'd like to use.
+                            enum:
+                            - MatchString
+                            - MatchInteger
+                            - NonEmpty
+                            - None
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - base
+                  type: object
+                type: array
+              writeConnectionSecretsToNamespace:
+                description: WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.
+                type: string
+            required:
+            - compositeTypeRef
+            - resources
+            type: object
+          status:
+            description: CompositionStatus shows the observed state of the composition.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositionSpec specifies the desired state of the definition.
+            properties:
+              compositeTypeRef:
+                description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the type.
+                    type: string
+                  kind:
+                    description: Kind of the type.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                type: object
+              resources:
+                description: Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.
+                items:
+                  description: ComposedTemplate is used to provide information about how the composed resource should be processed.
+                  properties:
+                    base:
+                      description: Base is the target resource that the patches will be applied on.
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    connectionDetails:
+                      description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
+                      items:
+                        description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
+                        properties:
+                          fromConnectionSecretKey:
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.
+                            type: string
+                          name:
+                            description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          value:
+                            description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
+                            type: string
+                        type: object
+                      type: array
+                    patches:
+                      description: Patches will be applied as overlay to the base resource.
+                      items:
+                        description: Patch is used to patch the field on the base resource at ToFieldPath after piping the value that is at FromFieldPath of the target resource through transformers.
+                        properties:
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input.
+                            type: string
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              properties:
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                        required:
+                        - fromFieldPath
+                        type: object
+                      type: array
+                    readinessChecks:
+                      description: ReadinessChecks allows users to define custom readiness checks. All checks have to return true in order for resource to be considered ready. The default readiness check is to have the "Ready" condition to be "True".
+                      items:
+                        description: ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption
+                        properties:
+                          fieldPath:
+                            description: FieldPath shows the path of the field whose value will be used.
+                            type: string
+                          matchInteger:
+                            description: MatchInt is the value you'd like to match if you're using "MatchInt" type.
+                            format: int64
+                            type: integer
+                          matchString:
+                            description: MatchString is the value you'd like to match if you're using "MatchString" type.
+                            type: string
+                          type:
+                            description: Type indicates the type of probe you'd like to use.
+                            enum:
+                            - MatchString
+                            - MatchInteger
+                            - NonEmpty
+                            - None
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - base
+                  type: object
+                type: array
+              writeConnectionSecretsToNamespace:
+                description: WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.
+                type: string
+            required:
+            - compositeTypeRef
+            - resources
+            type: object
+          status:
+            description: CompositionStatus shows the observed state of the composition.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/packages/cdk8s-cli/test/import/import-crd.test.ts
+++ b/packages/cdk8s-cli/test/import/import-crd.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import { ImportCustomResourceDefinition } from '../../src/import/crd';
-import { expectImportMatchSnapshot } from './util';
+import { testImportMatchSnapshot } from './util';
 
 const fixtures = path.join(__dirname, 'fixtures');
 
@@ -21,7 +21,7 @@ describe('snapshots', () => {
       continue;
     }
     const crd = readFixture(fixture);
-    expectImportMatchSnapshot(fixture, () => new ImportCustomResourceDefinition(crd));
+    testImportMatchSnapshot(fixture, () => new ImportCustomResourceDefinition(crd));
   }
 });
 
@@ -216,7 +216,7 @@ test('can import a "List" of CRDs (kubectl get crds -o json)', () => {
 
 describe('classPrefix can be used to add a prefix to all construct class names', () => {
   const crd = readFixture('multi_object_crd.yaml');
-  expectImportMatchSnapshot('Foo', () => new ImportCustomResourceDefinition(crd), {
+  testImportMatchSnapshot('Foo', () => new ImportCustomResourceDefinition(crd), {
     classNamePrefix: 'Foo',
   });
 });

--- a/packages/cdk8s-cli/test/import/import-crds-dev.test.ts
+++ b/packages/cdk8s-cli/test/import/import-crds-dev.test.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { mocked } from 'ts-jest/utils';
+import { ImportCustomResourceDefinition } from '../../src/import/crd';
+import { importCrdsDevRepoMatch, crdsDevUrl } from '../../src/import/crds-dev';
+import { download } from '../../src/util';
+import { expectImportMatchSnapshot } from './util';
+
+jest.mock('../../src/util', () => {
+  const mod = jest.requireActual('../../src/util');
+  return {
+    ...mod,
+    download: jest.fn(),
+  };
+});
+
+jest.setTimeout(3 * 60_000);
+
+const fullImportTests = [
+  { provider: 'github', account: 'crossplane', repo: 'crossplane', version: '0.14.0' },
+];
+
+const crdsDevUrlTests = [
+  { import: 'github:crossplane/crossplane', expected: 'https://doc.crds.dev/raw/github.com/crossplane/crossplane' },
+  { import: 'github:crossplane/crossplane@0.14', expected: 'https://doc.crds.dev/raw/github.com/crossplane/crossplane@v0.14.0' },
+  { import: 'github:crossplane/crossplane@0.14.0', expected: 'https://doc.crds.dev/raw/github.com/crossplane/crossplane@v0.14.0' },
+  { import: 'unsupported:crossplane/crossplane@0.14.0', expected: undefined, reason: 'unsupported provider' },
+  { import: 'github:account/repo@1', expected: undefined, reason: 'major minor required if version present' },
+];
+
+const readFixture = (fixture: string) => {
+  const fixtures = path.join(__dirname, 'fixtures', 'crds-dev');
+  const filePath = path.join(fixtures, fixture);
+
+  return fs.readFileSync(filePath, 'utf-8');
+};
+
+describe('crds.dev import', () => {
+  for ( const t of fullImportTests ) {
+    const source = `${t.provider}:${t.account}/${t.repo}@${t.version}`;
+
+    mocked(download).mockImplementation((_url: string): Promise<string> => {
+      return new Promise((ok, _ko) => {
+        const mockFile = `${t.provider}-${t.account}-${t.repo}-v${t.version}.yaml`;
+        const crds = readFixture(mockFile);
+        ok(crds.toString());
+      });
+    });
+
+    test(source, async () => {
+      const crdsDev = await importCrdsDevRepoMatch(source);
+      expect(crdsDev).toBeDefined();
+      if (crdsDev) {
+        await expectImportMatchSnapshot( () => new ImportCustomResourceDefinition(crdsDev) );
+      }
+    });
+  }
+});
+
+describe('crds.dev import errors', () => {
+  for ( const t of crdsDevUrlTests.filter( o => o.expected === undefined )) {
+    test(t.import, async () => {
+      const crdsDev = await importCrdsDevRepoMatch(t.import);
+      expect(crdsDev).toBeUndefined();
+    });
+  }
+});
+
+describe('crds.dev url map', () => {
+  for ( const t of crdsDevUrlTests ) {
+    test(t.import, () => {
+      const url = crdsDevUrl(t.import);
+      expect(url).toBe(t.expected);
+    });
+  }
+});

--- a/packages/cdk8s-cli/test/import/import-k8s.test.ts
+++ b/packages/cdk8s-cli/test/import/import-k8s.test.ts
@@ -1,8 +1,8 @@
 import { ImportKubernetesApi } from '../../src/import/k8s';
-import { expectImportMatchSnapshot } from './util';
+import { testImportMatchSnapshot } from './util';
 
 const k8s = (v: string) =>
-  expectImportMatchSnapshot(`k8s@${v}`, () => new ImportKubernetesApi({ apiVersion: v }));
+  testImportMatchSnapshot(`k8s@${v}`, () => new ImportKubernetesApi({ apiVersion: v }));
 
 k8s('1.14.0');
 k8s('1.15.0');

--- a/packages/cdk8s-cli/test/import/util.ts
+++ b/packages/cdk8s-cli/test/import/util.ts
@@ -3,28 +3,33 @@ import * as path from 'path';
 import { ImportBase, ImportOptions, Language } from '../../src/import/base';
 import { mkdtemp } from '../../src/util';
 
-export function expectImportMatchSnapshot(name: string, fn: () => ImportBase, options?: Partial<ImportOptions>) {
-  jest.setTimeout(3 * 60_000);
+jest.setTimeout(3 * 60_000);
+
+export function testImportMatchSnapshot(name: string, fn: () => ImportBase, options?: Partial<ImportOptions>) {
 
   test(name, async () => {
-    await mkdtemp(async workdir => {
-      const importer = fn();
-      const jsiiPath = path.join(workdir, '.jsii');
+    await expectImportMatchSnapshot(fn, options);
+  });
+}
 
-      await importer.import({
-        outdir: workdir,
-        outputJsii: jsiiPath,
-        targetLanguage: Language.TYPESCRIPT,
-        ...options,
-      });
+export async function expectImportMatchSnapshot(fn: () => ImportBase, options?: Partial<ImportOptions>) {
+  await mkdtemp(async workdir => {
+    const importer = fn();
+    const jsiiPath = path.join(workdir, '.jsii');
 
-      const manifest = JSON.parse((await fs.readFile(jsiiPath)).toString('utf-8'));
-
-      // patch cdk8s version in manifest because it's not stable
-      manifest.dependencies.cdk8s = '999.999.999';
-      manifest.fingerprint = '<fingerprint>';
-
-      expect(manifest).toMatchSnapshot();
+    await importer.import({
+      outdir: workdir,
+      outputJsii: jsiiPath,
+      targetLanguage: Language.TYPESCRIPT,
+      ...options,
     });
+
+    const manifest = JSON.parse((await fs.readFile(jsiiPath)).toString('utf-8'));
+
+    // patch cdk8s version in manifest because it's not stable
+    manifest.dependencies.cdk8s = '999.999.999';
+    manifest.fingerprint = '<fingerprint>';
+
+    expect(manifest).toMatchSnapshot();
   });
 }


### PR DESCRIPTION
Introduce crds.dev import shortcut: `cdk8s import github:account/repo[@VERSION]`

Example:
`cdk8s import github:crossplane/crossplane@0.14.0`

Resolves #377

In a future PR would like to generate a single module per k8s API group with all CRDs for that API group, so you could:
```ts
import { CompositeResourceDefinition, Composition } from './imports/apiextensions.crossplane.io';
```

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
