### PR TITLE
fix(cli): python init templates are broken

### DIFF
--- a/docs/plus/index.md
+++ b/docs/plus/index.md
@@ -164,7 +164,7 @@ app.synth();
 
 === "Python"
 
-    `❯ pip install cdk8s-plus-17 cdk8s`
+    `❯ pip install --pre cdk8s-plus-17 cdk8s`
 
     ```python
     import cdk8s_plus_17 as kplus

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -29,8 +29,8 @@ exports.post = options => {
   }
 
   execSync('pipenv lock --clear')
-  execSync('pipenv install --skip-lock', { stdio: 'inherit' });
-  execSync(`pipenv install ${pypi_cdk8s}`, { stdio: 'inherit' });
+  execSync('pipenv install --pre --skip-lock', { stdio: 'inherit' });
+  execSync(`pipenv install --pre ${pypi_cdk8s}`, { stdio: 'inherit' });
   /**
    * Using --no-deps flag here to ignore subdependencies. For cdk8s_plus, that's
    * these dependencies:


### PR DESCRIPTION
Apparently by default PyPI doesn't offer pre-releases on installation, and in fact doesn't treat the `0.x` version line as a pre-release as well. This means that as far as PyPI is concerned, `0.33.0` is our latest version, and is more stable than `1.0.0b`.

This breaks our init template:

```console
Building requirements...
Resolving dependencies...
✘ Locking Failed!
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/resolver.py", line 785, in _main
[ResolutionFailure]:       resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages)
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/resolver.py", line 753, in resolve_packages
[ResolutionFailure]:       requirements_dir=requirements_dir,
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/resolver.py", line 736, in resolve
[ResolutionFailure]:       req_dir=requirements_dir
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/utils.py", line 1386, in resolve_deps
[ResolutionFailure]:       req_dir=req_dir,
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/utils.py", line 1093, in actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File "/usr/local/Cellar/pipenv/2020.5.28/libexec/lib/python3.8/site-packages/pipenv/utils.py", line 818, in resolve
[ResolutionFailure]:       raise ResolutionFailure(message=str(e))
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.
 Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Could not find a version that matches cdk8s~=1.0.0.b1 (from -r /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/pipenvbpgsc77rrequirements/pipenv-d6wsjivp-constraints.txt (line 3))
Tried: 0.11.0, 0.11.0, 0.12.0, 0.12.0, 0.13.0, 0.13.0, 0.13.1, 0.13.1, 0.14.0, 0.14.0, 0.15.0, 0.15.0, 0.15.1, 0.15.1, 0.16.0, 0.16.0, 0.17.0, 0.17.0, 0.18.0, 0.18.0, 0.19.0, 0.19.0, 0.20.0, 0.20.0, 0.21.0, 0.21.0, 0.22.0, 0.22.0, 0.23.0, 0.23.0, 0.24.0, 0.24.0, 0.25.0, 0.25.0, 0.26.0, 0.26.0, 0.27.0, 0.27.0, 0.28.0, 0.28.0, 0.29.0, 0.29.0, 0.30.0, 0.30.0, 0.31.0, 0.31.0, 0.32.0, 0.32.0, 0.33.0, 0.33.0
Skipped pre-versions: 1.0.0b1, 1.0.0b1
There are incompatible versions in the resolved dependencies:
Error: error during project initialization: Error: Command failed: pipenv install cdk8s~=1.0.0.b1
    at checkExecSyncError (child_process.js:629:11)
    at execSync (child_process.js:666:13)
    at Object.exports.post.options [as post] (/private/tmp/beta/node_modules/cdk8s-cli/templates/python-app/.hooks.sscaff.js:33:3)
    at executePostHook (/private/tmp/beta/node_modules/sscaff/lib/sscaff.js:61:37)
    at Object.sscaff (/private/tmp/beta/node_modules/sscaff/lib/sscaff.js:28:15)
```

Adding an explicit flag to force discovery of pre-releases as well. We need to remove this once we go `1.0`. (noted).

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
