### PR TITLE
fix(cli): python init template doesn't install cdk8s-plus in the correct env

### DIFF
--- a/packages/cdk8s-cli/src/cli/cmds/init.ts
+++ b/packages/cdk8s-cli/src/cli/cmds/init.ts
@@ -32,11 +32,10 @@ class Command implements yargs.CommandModule {
 
     console.error(`Initializing a project from the ${argv.type} template`);
     const templatePath = path.join(templatesDir, argv.type);
-
     const deps: any = await determineDeps(argv.cdk8SVersion, argv.dist);
 
     try {
-      await sscaff(templatePath, '.', { ...deps });
+      await sscaff(templatePath, '.', { ...deps, dist: argv.dist, pre: argv.cdk8SVersion.includes('-') });
     } catch (e) {
       throw new Error(`error during project initialization: ${e.stack}\nSTDOUT:\n${e.stdout?.toString()}\nSTDERR:\n${e.stderr?.toString()}`);
     }

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -28,10 +28,28 @@ exports.post = options => {
     throw new Error(`missing context "pypi_cdk8s_plus"`);
   }
 
+  const flags = [];
+
+  if (options.dist) {
+    // https://github.com/awslabs/cdk8s/pull/399
+    flags.push('--skip-lock');
+  }
+
+  if (options.pre) {
+    flags.push('--pre');
+  }
+
+  const args = flags.join(' ');
+
   execSync('pipenv lock --clear')
-  execSync('pipenv install --skip-lock', { stdio: 'inherit' });
-  execSync(`pipenv install --pre ${pypi_cdk8s}`, { stdio: 'inherit' });
-  execSync(`pipenv install --pre ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
+
+  // this installs the libraries in the Pipfile we provide
+  execSync('pipenv install', { stdio: 'inherit' });
+
+  // these are more akward to put in the Pipfile since they can be local wheel files
+  execSync(`pipenv install ${args} ${pypi_cdk8s}`, { stdio: 'inherit' });
+  execSync(`pipenv install ${args} ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
+
   chmodSync('main.py', '700');
 
   execSync(`${cli} import k8s -l python`);

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -29,27 +29,9 @@ exports.post = options => {
   }
 
   execSync('pipenv lock --clear')
-  execSync('pipenv install --pre --skip-lock', { stdio: 'inherit' });
+  execSync('pipenv install --skip-lock', { stdio: 'inherit' });
   execSync(`pipenv install --pre ${pypi_cdk8s}`, { stdio: 'inherit' });
-  /**
-   * Using --no-deps flag here to ignore subdependencies. For cdk8s_plus, that's
-   * these dependencies:
-   *
-   * jsii (<2.0.0,>=1.7.0)
-   * publication (>=0.0.3)
-   * cdk8s (==0.0.0)
-   * constructs (<4.0.0,>=3.0.4)
-   *
-   * Even when installing locally, with this command:
-   *
-   * pipenv install dist/python/cdk8s_plus-0.0.0-py3-none-any.whl
-   *
-   * this would point to these sub-dependencies in https://pypi.org/ which
-   * unfortunataly does not have cdk8s-0.0.0. We've already installed that
-   * locally, so this is safe to ignore.
-   *
-   */
-  execSync(`pip3 install --no-deps ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
+  execSync(`pipenv install --pre ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
   chmodSync('main.py', '700');
 
   execSync(`${cli} import k8s -l python`);

--- a/test/test-python-app/test.sh
+++ b/test/test-python-app/test.sh
@@ -8,6 +8,9 @@ mkdir test && cd test
 touch .foo
 mkdir .bar
 
+# debug
+pipenv --version
+
 # initialize an empty project
 cdk8s init python-app
 


### PR DESCRIPTION
A while back we [included](https://github.com/awslabs/cdk8s/pull/293) installation of `cdk8s-plus` as part of the python init template.

The PR [mentioned](https://github.com/awslabs/cdk8s/pull/293#discussion_r474408225) that this was problematic because `cdk8s-plus` depends on `cdk8s`, and dependency resolution in our integ tests fails since it tries to lookup the current version of `cdk8s` in PyPI, and obviously fails as it has not been published yet.

The solution was to use `--no-deps` flag so that remote dependency resolution won't happen. This was kind of safe because `cdk8s` is explicitly installed prior to `cdk8s-plus`:

https://github.com/awslabs/cdk8s/blob/bb0a5cc0762e753f1f18093b3cd15cbb83bd7c5e/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js#L33

And by chance, `cdk8s-plus` does not depend on any module that `cdk8s` does not. So this worked, but is somewhat fragile and risky.

Since `pipenv` does not support `--no-deps`, we used `pip3` instead. However, this caused `cdk8s-plus` to be installed in the wrong location since `pipenv` installs libraries in a dedicated virtualenv it creates. This meant that while template initialization worked, `cdk8s-plus` wasn't really available.

While trying to fix this problem, I noticed that pipenv doesn't actually try to lookup `cdk8s` in PyPI, but identifies that it was already installed locally:

```console
TypeError: Expected pinned or editable requirement, got cdk8s==1.0.0.b2,==1.0.0b2 from file:///__w/cdk8s/cdk8s/dist/python/cdk8s-1.0.0b2-py3-none-any.whl (from -r /tmp/pipenv72k1we70requirements/pipenv-phe405gf-constraints.txt (line 4))
```

Except now its complaining about the requirement specification. This comes from the fact that during `cdk8s` installation, it was populated in the lock file with the absolute path to the wheel, and seems like that is not really supported.

The solution is to add `--skip-lock` (only when running against dist) to the `cdk8s` and `cdk8s-plus` installation. This meant that these packages will not appear in the lock file, but that is ok because the `Pipfile` will point to the exact location of the local wheel:

```text
[packages]
constructs = "~=3.2.34"
cdk8s = {path = "/Users/epolon/dev/src/github.com/awslabs/cdk8s/dist/python/cdk8s-0.0.0-py3-none-any.whl"}
cdk8s-plus-17 = {path = "/Users/epolon/dev/src/github.com/awslabs/cdk8s/dist/python/cdk8s_plus_17-0.0.0-py3-none-any.whl"}
```

In addition, this PR dynamically determines whether to use the `--pre` flag according to version number.

Resolves https://github.com/awslabs/cdk8s/issues/394

------

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
