### PR TITLE
fix(plus-17): don't allow containers to be contructed from containers

### DIFF
--- a/packages/cdk8s-plus-17/src/container.ts
+++ b/packages/cdk8s-plus-17/src/container.ts
@@ -285,6 +285,10 @@ export class Container {
   private readonly _startup?: Probe;
 
   constructor(props: ContainerProps) {
+    if (props instanceof Container) {
+      throw new Error('Attempted to construct a container from a Container object.');
+    }
+
     this.name = props.name ?? 'main';
     this.image = props.image;
     this.port = props.port;

--- a/packages/cdk8s-plus-17/test/container.test.ts
+++ b/packages/cdk8s-plus-17/test/container.test.ts
@@ -118,6 +118,17 @@ describe('Container', () => {
 
   });
 
+  test('Must use container props', () => {
+    
+    const container = new kplus.Container({
+      image: 'image',
+    });
+    expect(() => {
+      new kplus.Container(container);
+    }).toThrow();
+        
+  });
+
   test('Can add environment variable', () => {
 
     const container = new kplus.Container({


### PR DESCRIPTION
Add a check for the case where a container is attempted to be built from another container.

Any place that takes ContainerProps actually also accepts Containers. This happens because ContainerProps has all optional properties except image .  Since Container has an a public property image, it gets passed along but that is really the only thing that gets used. 

Problem is that if you pass in a container object, the nested container will not get all the settings, so I don't think this should be allowed.

note: this is a bit of an ugly hack to prevent this.  I was hoping to find a way to do this with the type system but didn't find a solid option without changing some public property names and breaking the API.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
