### PR TITLE
fix(docs): WebService typescript example formatting

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -497,6 +497,7 @@ For example, this one line will add a hello world service to our chart:
     containerPort: 8080,
     replicas: 10
     });
+    ```
 
 === "Python"
     ```python


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

![image](https://user-images.githubusercontent.com/4562878/99904624-4eaf6480-2ccc-11eb-8792-bc4cf98af97e.png)

missing closing backticks break the rendering
