### PR TITLE
chore: fix versioning for homebrew releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,10 @@ jobs:
     steps:
       # extract version number from package.json
       - uses: actions/checkout@v2
+      - name: installing dependencies
+        run: tools/install-workflow-deps.sh
+      - name: set version
+        run: tools/align-version.sh
       - name: version
         id: get_version
         run: |


### PR DESCRIPTION
Closes https://github.com/awslabs/cdk8s/issues/409

Seems like this has been actually failing for a while looking at commit history here: https://github.com/Homebrew/homebrew-core/search?q=cdk8s&type=commits

And other build history in our own repo here: https://github.com/awslabs/cdk8s/runs/1285293264?check_suite_focus=true

I think doing a version-bump after pulling the repo should solve it.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
