### PR TITLE
fix(lib): Prevent substring of undefined error

### DIFF
--- a/packages/cdk8s/src/names.ts
+++ b/packages/cdk8s/src/names.ts
@@ -187,7 +187,11 @@ function calcHash(node: Node, maxLen: number) {
     return hash.digest('hex').slice(0, maxLen);
   }
 
-  return node.addr.substring(0, HASH_LEN);
+  if (node.addr){ 
+    return node.addr.substring(0, HASH_LEN);
+  }
+
+  return '';
 }
 
 function normalizeToLabelValue(c: string, maxLen: number) {


### PR DESCRIPTION
Currently the calcHash method can be run on ApiObjects without an addr property, resulting in the cdk8s synth command failing due to a substring of an undefined variable. This PR prevents the cdk8s failing, and provides an empty string as a default return. Thanks.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
