### PR TITLE
fix: which command missing for windows

### DIFF
--- a/packages/cdk8s-cli/src/util.ts
+++ b/packages/cdk8s-cli/src/util.ts
@@ -6,6 +6,10 @@ import * as path from 'path';
 import { parse } from 'url';
 import * as fs from 'fs-extra';
 
+export function whichShim(): string {
+  return (os.platform.toString() === 'win32') ? 'where' : 'which';
+}
+
 export async function shell(program: string, args: string[] = [], options: SpawnOptions = { }) {
   const command = `"${program} ${args.join(' ')}" at ${path.resolve(options.cwd ?? '.')}`;
   return new Promise((ok, ko) => {

--- a/packages/cdk8s-cli/src/util.ts
+++ b/packages/cdk8s-cli/src/util.ts
@@ -6,10 +6,6 @@ import * as path from 'path';
 import { parse } from 'url';
 import * as fs from 'fs-extra';
 
-export function whichShim(): string {
-  return (os.platform.toString() === 'win32') ? 'where' : 'which';
-}
-
 export async function shell(program: string, args: string[] = [], options: SpawnOptions = { }) {
   const command = `"${program} ${args.join(' ')}" at ${path.resolve(options.cwd ?? '.')}`;
   return new Promise((ok, ko) => {

--- a/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
@@ -6,7 +6,7 @@ const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = (variables) => {
   try {
-    execSync(`${platform() == 'win32' ? 'where' : 'which'} mvn`);
+    execSync(`${platform() === 'win32' ? 'where' : 'which'} mvn`);
   } catch {
     console.error(`Unable to find "mvn". Install from https://maven.apache.org/install.html`);
     process.exit(1);

--- a/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
@@ -1,11 +1,12 @@
 const { execSync } = require('child_process');
 const { readFileSync } = require('fs');
+import { whichShim } from '../../src/util';
 
 const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = (variables) => {
   try {
-    execSync('which mvn');
+    execSync(`${whichShim()} mvn`);
   } catch {
     console.error(`Unable to find "mvn". Install from https://maven.apache.org/install.html`);
     process.exit(1);

--- a/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/java-app/.hooks.sscaff.js
@@ -1,12 +1,12 @@
 const { execSync } = require('child_process');
 const { readFileSync } = require('fs');
-import { whichShim } from '../../src/util';
+const { platform } = require('os');
 
 const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = (variables) => {
   try {
-    execSync(`${whichShim()} mvn`);
+    execSync(`${platform() == 'win32' ? 'where' : 'which'} mvn`);
   } catch {
     console.error(`Unable to find "mvn". Install from https://maven.apache.org/install.html`);
     process.exit(1);

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -1,19 +1,19 @@
 const { execSync } = require('child_process');
 const { chmodSync } = require('fs');
 const { readFileSync } = require('fs');
-import { whichShim } from '../../src/util';
+const { platform } = require('os');
 
 const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = () => {
   try {
-    execSync(`${whichShim()} pipenv`);
+    execSync(`${platform() == 'win32' ? 'where' : 'which'} pipenv`);
   } catch {
     console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`);
     process.exit(1);
   }
   try {
-    execSync(`${whichShim()} pip3`);
+    execSync(`${platform() == 'win32' ? 'where' : 'which'} pip3`);
   } catch {
     console.error(`Unable to find "pip3". Install from https://pip.pypa.io`);
     process.exit(1);

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -1,20 +1,21 @@
 const { execSync } = require('child_process');
 const { chmodSync } = require('fs');
 const { readFileSync } = require('fs');
+import { whichShim } from '../../src/util';
 
 const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = () => {
   try {
-    execSync('which pipenv')
+    execSync(`${whichShim()} pipenv`);
   } catch {
-    console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`)
+    console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`);
     process.exit(1);
   }
   try {
-    execSync('which pip3')
+    execSync(`${whichShim()} pip3`);
   } catch {
-    console.error(`Unable to find "pip3". Install from https://pip.pypa.io`)
+    console.error(`Unable to find "pip3". Install from https://pip.pypa.io`);
     process.exit(1);
   }
 };

--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -7,13 +7,13 @@ const cli = require.resolve('../../bin/cdk8s');
 
 exports.pre = () => {
   try {
-    execSync(`${platform() == 'win32' ? 'where' : 'which'} pipenv`);
+    execSync(`${platform() === 'win32' ? 'where' : 'which'} pipenv`);
   } catch {
     console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`);
     process.exit(1);
   }
   try {
-    execSync(`${platform() == 'win32' ? 'where' : 'which'} pip3`);
+    execSync(`${platform() === 'win32' ? 'where' : 'which'} pip3`);
   } catch {
     console.error(`Unable to find "pip3". Install from https://pip.pypa.io`);
     process.exit(1);


### PR DESCRIPTION
Closes https://github.com/awslabs/cdk8s/issues/414

Looked at these for some more info:

https://superuser.com/questions/207707/what-is-windows-equivalent-of-the-which-command-in-unix-is-there-an-equivale
https://stackoverflow.com/questions/8683895/how-do-i-determine-the-current-operating-system-with-node-js

---

It brings up the larger question though - should the `build` workflow run on Windows? Will the JSII/superchain docker image work on Windows?

---

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
