### PR TITLE
chore(cli): remove pip3 validation since its no longer needed

### DIFF
--- a/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
+++ b/packages/cdk8s-cli/templates/python-app/.hooks.sscaff.js
@@ -12,12 +12,6 @@ exports.pre = () => {
     console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`);
     process.exit(1);
   }
-  try {
-    execSync(`${platform() === 'win32' ? 'where' : 'which'} pip3`);
-  } catch {
-    console.error(`Unable to find "pip3". Install from https://pip.pypa.io`);
-    process.exit(1);
-  }
 };
 
 exports.post = options => {


### PR DESCRIPTION
This [PR](https://github.com/awslabs/cdk8s/pull/399) removed the need for `pip3`, but the validation still remained.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
