### PR TITLE
feat(plus-17): add ResourceRequirements to Container

### DIFF
--- a/packages/cdk8s-plus-17/API.md
+++ b/packages/cdk8s-plus-17/API.md
@@ -16,6 +16,7 @@ Name|Description
 [PodTemplate](#cdk8s-plus-17-podtemplate)|Provides read/write capabilities ontop of a `PodTemplateProps`.
 [Probe](#cdk8s-plus-17-probe)|Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 [Resource](#cdk8s-plus-17-resource)|Base class for all Kubernetes objects in stdk8s.
+[ResourceRequirements](#cdk8s-plus-17-resourcerequirements)|Resource requests and limits.
 [Secret](#cdk8s-plus-17-secret)|Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 [Service](#cdk8s-plus-17-service)|An abstract way to expose an application running on a set of Pods as a network service.
 [ServiceAccount](#cdk8s-plus-17-serviceaccount)|A service account provides an identity for processes that run in a Pod.
@@ -48,6 +49,7 @@ Name|Description
 [PodTemplateProps](#cdk8s-plus-17-podtemplateprops)|Properties of a `PodTemplate`.
 [ProbeOptions](#cdk8s-plus-17-probeoptions)|Probe options.
 [ResourceProps](#cdk8s-plus-17-resourceprops)|Initialization properties for resources.
+[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)|Properties for creating ResourceRequirements.
 [SecretProps](#cdk8s-plus-17-secretprops)|*No description*
 [SecretValue](#cdk8s-plus-17-secretvalue)|Represents a specific value in JSON secret.
 [ServiceAccountProps](#cdk8s-plus-17-serviceaccountprops)|Properties for initialization of `ServiceAccount`.
@@ -66,6 +68,7 @@ Name|Description
 [IPodSpec](#cdk8s-plus-17-ipodspec)|Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 [IPodTemplate](#cdk8s-plus-17-ipodtemplate)|Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 [IResource](#cdk8s-plus-17-iresource)|Represents a resource.
+[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)|Resource requests and limits.
 [ISecret](#cdk8s-plus-17-isecret)|*No description*
 [IServiceAccount](#cdk8s-plus-17-iserviceaccount)|*No description*
 
@@ -220,6 +223,7 @@ new Container(props: ContainerProps)
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -236,6 +240,7 @@ Name | Type | Description
 **imagePullPolicy**🔹 | <code>[ImagePullPolicy](#cdk8s-plus-17-imagepullpolicy)</code> | Image pull policy for this container.
 **mounts**🔹 | <code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code> | Volume mounts configured for this container.
 **name**🔹 | <code>string</code> | The name of the container.
+**resources**🔹 | <code>[ResourceRequirements](#cdk8s-plus-17-resourcerequirements)</code> | Resource requests and limits for this container.
 **args**?🔹 | <code>Array<string></code> | Arguments to the entrypoint.<br/>__*Optional*__
 **command**?🔹 | <code>Array<string></code> | Entrypoint array (the command to execute when the container starts).<br/>__*Optional*__
 **port**?🔹 | <code>number</code> | The port this container exposes.<br/>__*Optional*__
@@ -372,6 +377,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -740,6 +746,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -824,6 +831,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -900,6 +908,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -1051,6 +1060,36 @@ Name | Type | Description
 **apiObject**🔹 | <code>[ApiObject](#cdk8s-apiobject)</code> | The underlying cdk8s API object.
 **metadata**🔹 | <code>[ApiObjectMetadataDefinition](#cdk8s-apiobjectmetadatadefinition)</code> | <span></span>
 **name**🔹 | <code>string</code> | The name of this API object.
+
+
+
+## class ResourceRequirements 🔹 <a id="cdk8s-plus-17-resourcerequirements"></a>
+
+Resource requests and limits.
+
+
+### Initializer
+
+
+
+
+```ts
+new ResourceRequirements(props?: ResourceRequirementsProps)
+```
+
+* **props** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description*
+  * **cpu** (<code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code>)  *No description* __*Optional*__
+  * **memory** (<code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code>)  *No description* __*Optional*__
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**cpu**?🔹 | <code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code> | __*Optional*__
+**memory**?🔹 | <code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code> | __*Optional*__
 
 
 
@@ -1505,6 +1544,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | Name of the container specified as a DNS_LABEL.<br/>__*Default*__: 'main'
 **port**?🔹 | <code>number</code> | Number of port to expose on the pod's IP address.<br/>__*Default*__: No port is exposed.
 **readiness**?🔹 | <code>[Probe](#cdk8s-plus-17-probe)</code> | Determines when the container is ready to serve traffic.<br/>__*Default*__: no readiness probe is defined
+**resources**?🔹 | <code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code> | __*Optional*__
 **startup**?🔹 | <code>[Probe](#cdk8s-plus-17-probe)</code> | StartupProbe indicates that the Pod has successfully initialized.<br/>__*Default*__: no startup probe is defined.
 **volumeMounts**?🔹 | <code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code> | Pod volumes to mount into the container's filesystem.<br/>__*Optional*__
 **workingDir**?🔹 | <code>string</code> | Container's working directory.<br/>__*Default*__: The container runtime's default.
@@ -1673,6 +1713,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -1735,6 +1776,7 @@ addContainer(container: ContainerProps): Container
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
+  * **resources** (<code>[ResourceRequirementsProps](#cdk8s-plus-17-resourcerequirementsprops)</code>)  *No description* __*Optional*__
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
   * **workingDir** (<code>string</code>)  Container's working directory. __*Default*__: The container runtime's default.
@@ -1769,6 +1811,21 @@ Represents a resource.
 Name | Type | Description 
 -----|------|-------------
 **name**🔹 | <code>string</code> | The Kubernetes name of this resource.
+
+
+
+## interface IResourceRequirement 🔹 <a id="cdk8s-plus-17-iresourcerequirement"></a>
+
+
+Resource requests and limits.
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**limit**?🔹 | <code>any</code> | __*Optional*__
+**requests**?🔹 | <code>any</code> | __*Optional*__
 
 
 
@@ -1846,7 +1903,7 @@ Properties for initialization of `Job`.
 
 Name | Type | Description 
 -----|------|-------------
-**activeDeadline**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Specifies the duration in seconds the job may be active before the system tries to terminate it.<br/>__*Default*__: If unset, then there is no deadline.
+**activeDeadline**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Specifies the duration the job may be active before the system tries to terminate it.<br/>__*Default*__: If unset, then there is no deadline.
 **backoffLimit**?🔹 | <code>number</code> | Specifies the number of retries before marking this job failed.<br/>__*Default*__: If not set, system defaults to 6.
 **containers**?🔹 | <code>Array<[ContainerProps](#cdk8s-plus-17-containerprops)></code> | List of containers belonging to the pod.<br/>__*Default*__: No containers. Note that a pod spec must include at least one container.
 **metadata**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Metadata that all persisted resources must have, which includes all objects users must create.<br/>__*Optional*__
@@ -1967,6 +2024,20 @@ Initialization properties for resources.
 Name | Type | Description 
 -----|------|-------------
 **metadata**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Metadata that all persisted resources must have, which includes all objects users must create.<br/>__*Optional*__
+
+
+
+## struct ResourceRequirementsProps 🔹 <a id="cdk8s-plus-17-resourcerequirementsprops"></a>
+
+
+Properties for creating ResourceRequirements.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**cpu**?🔹 | <code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code> | __*Optional*__
+**memory**?🔹 | <code>[IResourceRequirement](#cdk8s-plus-17-iresourcerequirement)</code> | __*Optional*__
 
 
 
@@ -2162,4 +2233,5 @@ Name | Description
 **NODE_PORT** 🔹|Exposes the Service on each Node's IP at a static port (the NodePort).
 **LOAD_BALANCER** 🔹|Exposes the Service externally using a cloud provider's load balancer.
 **EXTERNAL_NAME** 🔹|Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
+
 

--- a/packages/cdk8s-plus-17/test/container.test.ts
+++ b/packages/cdk8s-plus-17/test/container.test.ts
@@ -119,14 +119,14 @@ describe('Container', () => {
   });
 
   test('Must use container props', () => {
-    
+
     const container = new kplus.Container({
       image: 'image',
     });
     expect(() => {
       new kplus.Container(container);
     }).toThrow();
-        
+
   });
 
   test('Can add environment variable', () => {
@@ -251,4 +251,30 @@ describe('Container', () => {
     });
   });
 
+  test('resource requirments can be defined', () => {
+    const container = new kplus.Container({
+      image: 'image',
+      resources: {
+        cpu: {
+          limit: cdk8s.Cpu.units(0.5),
+        },
+        memory: {
+          request: cdk8s.Size.mebibytes(200),
+        },
+      },
+    });
+    container.resources.cpu.request = cdk8s.Cpu.millis(100);
+
+    const expected: k8s.ResourceRequirements = {
+      requests: {
+        cpu: '100m',
+        memory: '200Mi',
+      },
+      limits: {
+        cpu: '500m',
+      },
+    };
+
+    expect(container._toKube().resources).toEqual(expected);
+  });
 });

--- a/packages/cdk8s/API.md
+++ b/packages/cdk8s/API.md
@@ -8,6 +8,7 @@ Name|Description
 [ApiObjectMetadataDefinition](#cdk8s-apiobjectmetadatadefinition)|Object metadata.
 [App](#cdk8s-app)|Represents a cdk8s application.
 [Chart](#cdk8s-chart)|*No description*
+[Cpu](#cdk8s-cpu)|Represents the amount of cpu.
 [DependencyGraph](#cdk8s-dependencygraph)|Represents the dependency graph for a given Node.
 [DependencyVertex](#cdk8s-dependencyvertex)|Represents a vertex in the graph.
 [Duration](#cdk8s-duration)|Represents a length of time.
@@ -399,6 +400,54 @@ static of(c: IConstruct): Chart
 
 __Returns__:
 * <code>[Chart](#cdk8s-chart)</code>
+
+
+
+## class Cpu 🔹 <a id="cdk8s-cpu"></a>
+
+Represents the amount of cpu.
+
+
+### Methods
+
+
+#### toString()🔹 <a id="cdk8s-cpu-tostring"></a>
+
+
+
+```ts
+toString(): string
+```
+
+
+__Returns__:
+* <code>string</code>
+
+#### *static* millis(amount)🔹 <a id="cdk8s-cpu-millis"></a>
+
+Creates a Cpu representing an amount of milllicpus.
+
+```ts
+static millis(amount: number): Cpu
+```
+
+* **amount** (<code>number</code>)  the amount of millicpus the Cpu will represents.
+
+__Returns__:
+* <code>[Cpu](#cdk8s-cpu)</code>
+
+#### *static* units(amount)🔹 <a id="cdk8s-cpu-units"></a>
+
+Creates a Cpu representing an amount of cpus.
+
+```ts
+static units(amount: number): Cpu
+```
+
+* **amount** (<code>number</code>)  the amount of cpus the Cpu will represents.
+
+__Returns__:
+* <code>[Cpu](#cdk8s-cpu)</code>
 
 
 

--- a/packages/cdk8s/src/cpu.ts
+++ b/packages/cdk8s/src/cpu.ts
@@ -1,0 +1,34 @@
+/**
+ * Represents the amount of cpu.
+ */
+export class Cpu {
+  /**
+   * Creates a Cpu representing an amount of cpus.
+   * @param amount the amount of cpus the Cpu will represents.
+   * @returns a new `Cpu` representing `amount` cpus.
+   */
+  public static units(amount: number): Cpu {
+    if (amount < 0.001) {
+      throw new Error(`CPU units cannot be less than 0.001 (1 millicpu). Received: ${amount}`);
+    }
+    return new Cpu(amount * 1000);
+  }
+
+  /**
+   * Creates a Cpu representing an amount of milllicpus.
+   * @param amount the amount of millicpus the Cpu will represents.
+   * @returns a new `Cpu` representing `amount` millicpus.
+   */
+  public static millis(amount: number): Cpu {
+    if (amount < 1) {
+      throw new Error(`cpu units cannot be less than 1 millicpu. Received: ${amount}`);
+    }
+    return new Cpu(amount);
+  }
+
+  private constructor(private readonly _millis: number) {}
+
+  toString(): string {
+    return `${this._millis}m`;
+  }
+}

--- a/packages/cdk8s/src/index.ts
+++ b/packages/cdk8s/src/index.ts
@@ -12,3 +12,4 @@ export * from './helm';
 export * from './json-patch';
 export * from './duration';
 export * from './size';
+export * from './cpu';


### PR DESCRIPTION
HPA requires containers to set resource requests and limits. I've added a Cpu unit type and a way to define resource requirements to Container.

Closes: https://github.com/awslabs/cdk8s/issues/438

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
