### PR TITLE
feat(plus-17): add named port, port objects, exposing multiple ports

### DIFF
--- a/packages/cdk8s-plus-17/API.md
+++ b/packages/cdk8s-plus-17/API.md
@@ -288,10 +288,10 @@ __Returns__:
 Get exposed port on this container.
 
 ```ts
-lookupPort(targetPort: string &#124; number, throwOnNotfound: boolean): ContainerPort
+lookupPort(targetPort: string &#124; number &#124; ContainerPort, throwOnNotfound: boolean): ContainerPort
 ```
 
-* **targetPort** (<code>string &#124; number</code>)  - Number or name of exposed port.
+* **targetPort** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  - Number or name of exposed port.
 * **throwOnNotfound** (<code>boolean</code>)  *No description*
 
 __Returns__:
@@ -495,7 +495,7 @@ expose(port: number, options?: ExposeOptions): Service
   * **name** (<code>string</code>)  The name of the service to expose. __*Default*__: undefined Uses the system generated name.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
   * **serviceType** (<code>[ServiceType](#cdk8s-plus-17-servicetype)</code>)  The type of the exposed service. __*Default*__: ClusterIP.
-  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
+  * **targetPort** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  The port number or name the service will redirect to. __*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
 
 __Returns__:
 * <code>[Service](#cdk8s-plus-17-service)</code>
@@ -505,10 +505,10 @@ __Returns__:
 Get exposed port on this deployment.
 
 ```ts
-lookupPort(targetPort: string &#124; number, throwOnNotfound: boolean): ContainerPort
+lookupPort(targetPort: string &#124; number &#124; ContainerPort, throwOnNotfound: boolean): ContainerPort
 ```
 
-* **targetPort** (<code>string &#124; number</code>)  - Number or name of exposed port.
+* **targetPort** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  - Number or name of exposed port.
 * **throwOnNotfound** (<code>boolean</code>)  *No description*
 
 __Returns__:
@@ -1114,7 +1114,7 @@ static fromHttpGet(path: string, options?: HttpGetProbeOptions): Probe
   * **periodSeconds** (<code>[Duration](#cdk8s-duration)</code>)  How often (in seconds) to perform the probe. __*Default*__: Duration.seconds(10) Minimum value is 1.
   * **successThreshold** (<code>number</code>)  Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. __*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
   * **timeoutSeconds** (<code>[Duration](#cdk8s-duration)</code>)  Number of seconds after which the probe times out. __*Default*__: Duration.seconds(1)
-  * **port** (<code>string &#124; number</code>)  The TCP port to use when sending the GET request. __*Default*__: defaults to `container.port`.
+  * **port** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  The TCP port to use when sending the GET request. __*Default*__: defaults to `container.port`.
 
 __Returns__:
 * <code>[Probe](#cdk8s-plus-17-probe)</code>
@@ -1310,7 +1310,7 @@ addDeployment(deployment: Deployment, port: number, options?: ServicePortOptions
   * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
   * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
-  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
+  * **targetPort** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
 
 
 
@@ -1344,7 +1344,7 @@ serve(port: number, options?: ServicePortOptions): void
   * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
   * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
-  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
+  * **targetPort** (<code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
 
 
 
@@ -1735,7 +1735,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of the service to expose.<br/>__*Default*__: undefined Uses the system generated name.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
 **serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-17-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
-**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
+**targetPort**?🔹 | <code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code> | The port number or name the service will redirect to.<br/>__*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
 
 
 
@@ -1751,7 +1751,7 @@ Name | Type | Description
 **failureThreshold**?🔹 | <code>number</code> | Minimum consecutive failures for the probe to be considered failed after having succeeded.<br/>__*Default*__: 3
 **initialDelaySeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Number of seconds after the container has started before liveness probes are initiated.<br/>__*Default*__: immediate
 **periodSeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | How often (in seconds) to perform the probe.<br/>__*Default*__: Duration.seconds(10) Minimum value is 1.
-**port**?🔹 | <code>string &#124; number</code> | The TCP port to use when sending the GET request.<br/>__*Default*__: defaults to `container.port`.
+**port**?🔹 | <code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code> | The TCP port to use when sending the GET request.<br/>__*Default*__: defaults to `container.port`.
 **successThreshold**?🔹 | <code>number</code> | Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.<br/>__*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
 **timeoutSeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Number of seconds after which the probe times out.<br/>__*Default*__: Duration.seconds(1)
 
@@ -2181,7 +2181,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of this port within the service.<br/>__*Optional*__
 **nodePort**?🔹 | <code>number</code> | The port on each node on which this service is exposed when type=NodePort or LoadBalancer.<br/>__*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
-**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
+**targetPort**?🔹 | <code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
 
 
 
@@ -2197,7 +2197,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of this port within the service.<br/>__*Optional*__
 **nodePort**?🔹 | <code>number</code> | The port on each node on which this service is exposed when type=NodePort or LoadBalancer.<br/>__*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
-**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
+**targetPort**?🔹 | <code>string &#124; number &#124; [ContainerPort](#cdk8s-plus-17-containerport)</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
 
 
 

--- a/packages/cdk8s-plus-17/API.md
+++ b/packages/cdk8s-plus-17/API.md
@@ -6,6 +6,7 @@ Name|Description
 ----|-----------
 [ConfigMap](#cdk8s-plus-17-configmap)|ConfigMap holds configuration data for pods to consume.
 [Container](#cdk8s-plus-17-container)|A single application container that you want to run within a pod.
+[ContainerPort](#cdk8s-plus-17-containerport)|*No description*
 [Deployment](#cdk8s-plus-17-deployment)|A Deployment provides declarative updates for Pods and ReplicaSets.
 [EnvValue](#cdk8s-plus-17-envvalue)|Utility class for creating reading env values from various sources.
 [IngressV1Beta1](#cdk8s-plus-17-ingressv1beta1)|Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
@@ -30,6 +31,8 @@ Name|Description
 [CommandProbeOptions](#cdk8s-plus-17-commandprobeoptions)|Options for `Probe.fromCommand()`.
 [ConfigMapProps](#cdk8s-plus-17-configmapprops)|Properties for initialization of `ConfigMap`.
 [ConfigMapVolumeOptions](#cdk8s-plus-17-configmapvolumeoptions)|Options for the ConfigMap-based volume.
+[ContainerPortOptions](#cdk8s-plus-17-containerportoptions)|*No description*
+[ContainerPortProps](#cdk8s-plus-17-containerportprops)|*No description*
 [ContainerProps](#cdk8s-plus-17-containerprops)|Properties for creating a container.
 [DeploymentProps](#cdk8s-plus-17-deploymentprops)|Properties for initialization of `Deployment`.
 [EmptyDirVolumeOptions](#cdk8s-plus-17-emptydirvolumeoptions)|Options for volumes populated with an empty directory.
@@ -219,6 +222,7 @@ new Container(props: ContainerProps)
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -236,9 +240,9 @@ Name | Type | Description
 **imagePullPolicy**🔹 | <code>[ImagePullPolicy](#cdk8s-plus-17-imagepullpolicy)</code> | Image pull policy for this container.
 **mounts**🔹 | <code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code> | Volume mounts configured for this container.
 **name**🔹 | <code>string</code> | The name of the container.
+**ports**🔹 | <code>Array<[ContainerPort](#cdk8s-plus-17-containerport)></code> | List of ports this container exposes.
 **args**?🔹 | <code>Array<string></code> | Arguments to the entrypoint.<br/>__*Optional*__
 **command**?🔹 | <code>Array<string></code> | Entrypoint array (the command to execute when the container starts).<br/>__*Optional*__
-**port**?🔹 | <code>number</code> | The port this container exposes.<br/>__*Optional*__
 **workingDir**?🔹 | <code>string</code> | The working directory inside the container.<br/>__*Optional*__
 
 ### Methods
@@ -261,6 +265,38 @@ addEnv(name: string, value: EnvValue): void
 
 
 
+#### expose(portNumber, options?)🔹 <a id="cdk8s-plus-17-container-expose"></a>
+
+Expose a port on this container.
+
+```ts
+expose(portNumber: number, options?: ContainerPortOptions): ContainerPort
+```
+
+* **portNumber** (<code>number</code>)  - Number of port to expose.
+* **options** (<code>[ContainerPortOptions](#cdk8s-plus-17-containerportoptions)</code>)  - Expose options.
+  * **hostIP** (<code>string</code>)  What host IP to bind the external port to. __*Optional*__
+  * **hostPort** (<code>number</code>)  Number of port to expose on the host. __*Optional*__
+  * **name** (<code>string</code>)  If specified, this must be an IANA_SVC_NAME and unique within the pod. __*Optional*__
+  * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  Protocol for port. __*Optional*__
+
+__Returns__:
+* <code>[ContainerPort](#cdk8s-plus-17-containerport)</code>
+
+#### lookupPort(targetPort, throwOnNotfound)🔹 <a id="cdk8s-plus-17-container-lookupport"></a>
+
+Get exposed port on this container.
+
+```ts
+lookupPort(targetPort: string &#124; number, throwOnNotfound: boolean): ContainerPort
+```
+
+* **targetPort** (<code>string &#124; number</code>)  - Number or name of exposed port.
+* **throwOnNotfound** (<code>boolean</code>)  *No description*
+
+__Returns__:
+* <code>[ContainerPort](#cdk8s-plus-17-containerport)</code>
+
 #### mount(path, volume, options?)🔹 <a id="cdk8s-plus-17-container-mount"></a>
 
 Mount a volume to a specific path so that it is accessible by the container.
@@ -281,6 +317,57 @@ mount(path: string, volume: Volume, options?: MountOptions): void
 
 
 
+
+
+
+## class ContainerPort 🔹 <a id="cdk8s-plus-17-containerport"></a>
+
+
+
+
+### Initializer
+
+
+
+
+```ts
+new ContainerPort(props: ContainerPortProps)
+```
+
+* **props** (<code>[ContainerPortProps](#cdk8s-plus-17-containerportprops)</code>)  *No description*
+  * **hostIP** (<code>string</code>)  What host IP to bind the external port to. __*Optional*__
+  * **hostPort** (<code>number</code>)  Number of port to expose on the host. __*Optional*__
+  * **name** (<code>string</code>)  If specified, this must be an IANA_SVC_NAME and unique within the pod. __*Optional*__
+  * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  Protocol for port. __*Optional*__
+  * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. 
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**port**🔹 | <code>number</code> | Number of port to expose on the pod's IP address.
+**hostIP**?🔹 | <code>string</code> | What host IP to bind the external port to.<br/>__*Optional*__
+**hostPort**?🔹 | <code>number</code> | Number of port to expose on the host.<br/>__*Optional*__
+**name**?🔹 | <code>string</code> | If specified, this must be an IANA_SVC_NAME and unique within the pod.<br/>__*Optional*__
+**protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | Protocol for port.<br/>__*Optional*__
+
+### Methods
+
+
+#### nameOrPort()🔹 <a id="cdk8s-plus-17-containerport-nameorport"></a>
+
+Get name or containerPort.
+
+```ts
+nameOrPort(): string &#124; number
+```
+
+
+__Returns__:
+* <code>string &#124; number</code>
 
 
 
@@ -371,6 +458,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -407,10 +495,24 @@ expose(port: number, options?: ExposeOptions): Service
   * **name** (<code>string</code>)  The name of the service to expose. __*Default*__: undefined Uses the system generated name.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
   * **serviceType** (<code>[ServiceType](#cdk8s-plus-17-servicetype)</code>)  The type of the exposed service. __*Default*__: ClusterIP.
-  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The port of the first container in the deployment (ie. containers[0].port)
+  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
 
 __Returns__:
 * <code>[Service](#cdk8s-plus-17-service)</code>
+
+#### lookupPort(targetPort, throwOnNotfound)🔹 <a id="cdk8s-plus-17-deployment-lookupport"></a>
+
+Get exposed port on this deployment.
+
+```ts
+lookupPort(targetPort: string &#124; number, throwOnNotfound: boolean): ContainerPort
+```
+
+* **targetPort** (<code>string &#124; number</code>)  - Number or name of exposed port.
+* **throwOnNotfound** (<code>boolean</code>)  *No description*
+
+__Returns__:
+* <code>[ContainerPort](#cdk8s-plus-17-containerport)</code>
 
 #### selectByLabel(key, value)🔹 <a id="cdk8s-plus-17-deployment-selectbylabel"></a>
 
@@ -739,6 +841,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -823,6 +926,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -899,6 +1003,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -1009,7 +1114,7 @@ static fromHttpGet(path: string, options?: HttpGetProbeOptions): Probe
   * **periodSeconds** (<code>[Duration](#cdk8s-duration)</code>)  How often (in seconds) to perform the probe. __*Default*__: Duration.seconds(10) Minimum value is 1.
   * **successThreshold** (<code>number</code>)  Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. __*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
   * **timeoutSeconds** (<code>[Duration](#cdk8s-duration)</code>)  Number of seconds after which the probe times out. __*Default*__: Duration.seconds(1)
-  * **port** (<code>number</code>)  The TCP port to use when sending the GET request. __*Default*__: defaults to `container.port`.
+  * **port** (<code>string &#124; number</code>)  The TCP port to use when sending the GET request. __*Default*__: defaults to `container.port`.
 
 __Returns__:
 * <code>[Probe](#cdk8s-plus-17-probe)</code>
@@ -1205,7 +1310,7 @@ addDeployment(deployment: Deployment, port: number, options?: ServicePortOptions
   * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
   * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
-  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The value of `port` will be used.
+  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
 
 
 
@@ -1239,7 +1344,7 @@ serve(port: number, options?: ServicePortOptions): void
   * **name** (<code>string</code>)  The name of this port within the service. __*Optional*__
   * **nodePort** (<code>number</code>)  The port on each node on which this service is exposed when type=NodePort or LoadBalancer. __*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
   * **protocol** (<code>[Protocol](#cdk8s-plus-17-protocol)</code>)  The IP protocol for this port. __*Default*__: Protocol.TCP
-  * **targetPort** (<code>number</code>)  The port number the service will redirect to. __*Default*__: The value of `port` will be used.
+  * **targetPort** (<code>string &#124; number</code>)  The port number or name the service will redirect to. __*Default*__: The value of `port` will be used.
 
 
 
@@ -1487,6 +1592,39 @@ Name | Type | Description
 
 
 
+## struct ContainerPortOptions 🔹 <a id="cdk8s-plus-17-containerportoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**hostIP**?🔹 | <code>string</code> | What host IP to bind the external port to.<br/>__*Optional*__
+**hostPort**?🔹 | <code>number</code> | Number of port to expose on the host.<br/>__*Optional*__
+**name**?🔹 | <code>string</code> | If specified, this must be an IANA_SVC_NAME and unique within the pod.<br/>__*Optional*__
+**protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | Protocol for port.<br/>__*Optional*__
+
+
+
+## struct ContainerPortProps 🔹 <a id="cdk8s-plus-17-containerportprops"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**port**🔹 | <code>number</code> | Number of port to expose on the pod's IP address.
+**hostIP**?🔹 | <code>string</code> | What host IP to bind the external port to.<br/>__*Optional*__
+**hostPort**?🔹 | <code>number</code> | Number of port to expose on the host.<br/>__*Optional*__
+**name**?🔹 | <code>string</code> | If specified, this must be an IANA_SVC_NAME and unique within the pod.<br/>__*Optional*__
+**protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | Protocol for port.<br/>__*Optional*__
+
+
+
 ## struct ContainerProps 🔹 <a id="cdk8s-plus-17-containerprops"></a>
 
 
@@ -1504,6 +1642,7 @@ Name | Type | Description
 **liveness**?🔹 | <code>[Probe](#cdk8s-plus-17-probe)</code> | Periodic probe of container liveness.<br/>__*Default*__: no liveness probe is defined
 **name**?🔹 | <code>string</code> | Name of the container specified as a DNS_LABEL.<br/>__*Default*__: 'main'
 **port**?🔹 | <code>number</code> | Number of port to expose on the pod's IP address.<br/>__*Default*__: No port is exposed.
+**ports**?🔹 | <code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code> | List of ports to expose from the container.<br/>__*Default*__: No port is exposed.
 **readiness**?🔹 | <code>[Probe](#cdk8s-plus-17-probe)</code> | Determines when the container is ready to serve traffic.<br/>__*Default*__: no readiness probe is defined
 **startup**?🔹 | <code>[Probe](#cdk8s-plus-17-probe)</code> | StartupProbe indicates that the Pod has successfully initialized.<br/>__*Default*__: no startup probe is defined.
 **volumeMounts**?🔹 | <code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code> | Pod volumes to mount into the container's filesystem.<br/>__*Optional*__
@@ -1596,7 +1735,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of the service to expose.<br/>__*Default*__: undefined Uses the system generated name.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
 **serviceType**?🔹 | <code>[ServiceType](#cdk8s-plus-17-servicetype)</code> | The type of the exposed service.<br/>__*Default*__: ClusterIP.
-**targetPort**?🔹 | <code>number</code> | The port number the service will redirect to.<br/>__*Default*__: The port of the first container in the deployment (ie. containers[0].port)
+**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The first port of the first container in the deployment (ie. containers[0].ports[0])
 
 
 
@@ -1612,7 +1751,7 @@ Name | Type | Description
 **failureThreshold**?🔹 | <code>number</code> | Minimum consecutive failures for the probe to be considered failed after having succeeded.<br/>__*Default*__: 3
 **initialDelaySeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Number of seconds after the container has started before liveness probes are initiated.<br/>__*Default*__: immediate
 **periodSeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | How often (in seconds) to perform the probe.<br/>__*Default*__: Duration.seconds(10) Minimum value is 1.
-**port**?🔹 | <code>number</code> | The TCP port to use when sending the GET request.<br/>__*Default*__: defaults to `container.port`.
+**port**?🔹 | <code>string &#124; number</code> | The TCP port to use when sending the GET request.<br/>__*Default*__: defaults to `container.port`.
 **successThreshold**?🔹 | <code>number</code> | Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.<br/>__*Default*__: 1 Must be 1 for liveness and startup. Minimum value is 1.
 **timeoutSeconds**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Number of seconds after which the probe times out.<br/>__*Default*__: Duration.seconds(1)
 
@@ -1672,6 +1811,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -1734,6 +1874,7 @@ addContainer(container: ContainerProps): Container
   * **liveness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Periodic probe of container liveness. __*Default*__: no liveness probe is defined
   * **name** (<code>string</code>)  Name of the container specified as a DNS_LABEL. __*Default*__: 'main'
   * **port** (<code>number</code>)  Number of port to expose on the pod's IP address. __*Default*__: No port is exposed.
+  * **ports** (<code>Array<[ContainerPortProps](#cdk8s-plus-17-containerportprops)></code>)  List of ports to expose from the container. __*Default*__: No port is exposed.
   * **readiness** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  Determines when the container is ready to serve traffic. __*Default*__: no readiness probe is defined
   * **startup** (<code>[Probe](#cdk8s-plus-17-probe)</code>)  StartupProbe indicates that the Pod has successfully initialized. __*Default*__: no startup probe is defined.
   * **volumeMounts** (<code>Array<[VolumeMount](#cdk8s-plus-17-volumemount)></code>)  Pod volumes to mount into the container's filesystem. __*Optional*__
@@ -1846,7 +1987,7 @@ Properties for initialization of `Job`.
 
 Name | Type | Description 
 -----|------|-------------
-**activeDeadline**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Specifies the duration in seconds the job may be active before the system tries to terminate it.<br/>__*Default*__: If unset, then there is no deadline.
+**activeDeadline**?🔹 | <code>[Duration](#cdk8s-duration)</code> | Specifies the duration the job may be active before the system tries to terminate it.<br/>__*Default*__: If unset, then there is no deadline.
 **backoffLimit**?🔹 | <code>number</code> | Specifies the number of retries before marking this job failed.<br/>__*Default*__: If not set, system defaults to 6.
 **containers**?🔹 | <code>Array<[ContainerProps](#cdk8s-plus-17-containerprops)></code> | List of containers belonging to the pod.<br/>__*Default*__: No containers. Note that a pod spec must include at least one container.
 **metadata**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Metadata that all persisted resources must have, which includes all objects users must create.<br/>__*Optional*__
@@ -2040,7 +2181,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of this port within the service.<br/>__*Optional*__
 **nodePort**?🔹 | <code>number</code> | The port on each node on which this service is exposed when type=NodePort or LoadBalancer.<br/>__*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
-**targetPort**?🔹 | <code>number</code> | The port number the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
+**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
 
 
 
@@ -2056,7 +2197,7 @@ Name | Type | Description
 **name**?🔹 | <code>string</code> | The name of this port within the service.<br/>__*Optional*__
 **nodePort**?🔹 | <code>number</code> | The port on each node on which this service is exposed when type=NodePort or LoadBalancer.<br/>__*Default*__: to auto-allocate a port if the ServiceType of this Service requires one.
 **protocol**?🔹 | <code>[Protocol](#cdk8s-plus-17-protocol)</code> | The IP protocol for this port.<br/>__*Default*__: Protocol.TCP
-**targetPort**?🔹 | <code>number</code> | The port number the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
+**targetPort**?🔹 | <code>string &#124; number</code> | The port number or name the service will redirect to.<br/>__*Default*__: The value of `port` will be used.
 
 
 
@@ -2162,4 +2303,5 @@ Name | Description
 **NODE_PORT** 🔹|Exposes the Service on each Node's IP at a static port (the NodePort).
 **LOAD_BALANCER** 🔹|Exposes the Service externally using a cloud provider's load balancer.
 **EXTERNAL_NAME** 🔹|Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
+
 

--- a/packages/cdk8s-plus-17/src/common.ts
+++ b/packages/cdk8s-plus-17/src/common.ts
@@ -1,0 +1,5 @@
+export enum Protocol {
+  TCP = 'TCP',
+  UDP = 'UDP',
+  SCTP = 'SCTP'
+}

--- a/packages/cdk8s-plus-17/src/container-port.ts
+++ b/packages/cdk8s-plus-17/src/container-port.ts
@@ -1,0 +1,95 @@
+import { Protocol } from './common';
+import * as k8s from './imports/k8s';
+
+export interface ContainerPortOptions {
+  /**
+   * What host IP to bind the external port to.
+   */
+  readonly hostIP?: string;
+
+  /**
+   * Number of port to expose on the host. This must be a valid port number, 0 < x < 65536.
+   */
+  readonly hostPort?: number;
+
+  /**
+   * If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name.
+   */
+  readonly name?: string;
+
+  /**
+   * Protocol for port. Must be UDP, TCP, or SCTP.
+   */
+  readonly protocol?: Protocol;
+}
+
+export interface ContainerPortProps extends ContainerPortOptions {
+  /**
+   * Number of port to expose on the pod's IP address.
+   */
+  readonly port: number;
+}
+
+export class ContainerPort {
+  /**
+   * Number of port to expose on the pod's IP address.
+   */
+  public readonly port: number;
+
+  /**
+   * What host IP to bind the external port to.
+   */
+  public readonly hostIP?: string;
+
+  /**
+   * Number of port to expose on the host. This must be a valid port number, 0 < x < 65536.
+   */
+  public readonly hostPort?: number;
+
+  /**
+   * If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name.
+   */
+  public readonly name?: string;
+
+  /**
+   * Protocol for port. Must be UDP, TCP, or SCTP.
+   */
+  public readonly protocol?: Protocol;
+
+  public constructor(props: ContainerPortProps) {
+    if (props.port <= 0 || props.port >= 65536) {
+      throw new Error(`containerPort should be 0 < x < 65536. Received: ${props.port}`);
+    }
+    if (props.hostPort) {
+      if (props.hostPort <= 0 || props.hostPort >= 65536) {
+        throw new Error(`hostPort should be 0 < x < 65536. Received: ${props.hostPort}`);
+      }
+    }
+
+    this.port = props.port;
+    this.hostIP = props.hostIP;
+    this.hostPort = props.hostPort;
+    this.name = props.name;
+    this.protocol = props.protocol;
+  }
+
+  /**
+   * Get name or containerPort
+   */
+  public nameOrPort(): string | number {
+    return this.name ?? this.port;
+  }
+
+  /**
+   * @internal
+   */
+  _toKube(): k8s.ContainerPort {
+    return {
+      containerPort: this.port,
+      name: this.name,
+      hostIP: this.hostIP,
+      hostPort: this.hostPort,
+      protocol: this.protocol,
+    };
+  }
+}

--- a/packages/cdk8s-plus-17/src/container.ts
+++ b/packages/cdk8s-plus-17/src/container.ts
@@ -395,25 +395,36 @@ export class Container {
    * @param targetPort - Number or name of exposed port
    * @param throwOnNotfound
    */
-  public lookupPort(targetPort: number | string, throwOnNotfound: true): ContainerPort
-  public lookupPort(targetPort: number | string, throwOnNotfound?: boolean): ContainerPort | undefined
-  public lookupPort(targetPort: number | string, throwOnNotfound: boolean = false): ContainerPort | undefined {
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound: true): ContainerPort
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound?: boolean): ContainerPort | undefined
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound: boolean = false): ContainerPort | undefined {
     if (typeof targetPort === 'number') {
       for (const port of this.ports) {
         if (targetPort === port.port) {
           return port;
         }
       }
-    } else {
+    } else if (typeof targetPort === 'string') {
       for (const port of this.ports) {
         if (targetPort === port.name) {
+          return port;
+        }
+      }
+    } else {
+      for (const port of this.ports) {
+        // compare reference to ensure the origin
+        if (port === targetPort) {
           return port;
         }
       }
     }
 
     if (throwOnNotfound) {
-      throw new Error('a targetPort is not exposed on this container');
+      if (typeof targetPort === 'number' || typeof targetPort === 'string') {
+        throw new Error('a targetPort is not exposed on this container');
+      } else {
+        throw new Error('a targetPort is originated from other containers');
+      }
     }
 
     return undefined;

--- a/packages/cdk8s-plus-17/src/deployment.ts
+++ b/packages/cdk8s-plus-17/src/deployment.ts
@@ -65,7 +65,7 @@ export interface ExposeOptions {
    *
    * @default - The first port of the first container in the deployment (ie. containers[0].ports[0])
    */
-  readonly targetPort?: number | string;
+  readonly targetPort?: number | string | ContainerPort;
 }
 
 
@@ -204,9 +204,9 @@ export class Deployment extends Resource implements IPodTemplate {
    * @param targetPort - Number or name of exposed port
    * @param throwOnNotfound
    */
-  public lookupPort(targetPort: number | string, throwOnNotfound: true): ContainerPort
-  public lookupPort(targetPort: number | string, throwOnNotfound?: boolean): ContainerPort | undefined
-  public lookupPort(targetPort: number | string, throwOnNotfound: boolean = false): ContainerPort | undefined {
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound: true): ContainerPort
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound?: boolean): ContainerPort | undefined
+  public lookupPort(targetPort: number | string | ContainerPort, throwOnNotfound: boolean = false): ContainerPort | undefined {
     for (const container of this.containers) {
       const result = container.lookupPort(targetPort);
       if (result) {
@@ -215,7 +215,11 @@ export class Deployment extends Resource implements IPodTemplate {
     }
 
     if (throwOnNotfound) {
-      throw new Error('a targetPort is not exposed on any container in this deployment');
+      if (typeof targetPort === 'number' || typeof targetPort === 'string') {
+        throw new Error('a targetPort is not exposed on any container in this deployment');
+      } else {
+        throw new Error('a targetPort is originated from other deployment');
+      }
     }
 
     return undefined;

--- a/packages/cdk8s-plus-17/src/index.ts
+++ b/packages/cdk8s-plus-17/src/index.ts
@@ -10,3 +10,5 @@ export * from './service';
 export * from './volume';
 export * from './ingress-v1beta1';
 export * from './probe';
+export * from './container-port';
+export * from './common';

--- a/packages/cdk8s-plus-17/src/probe.ts
+++ b/packages/cdk8s-plus-17/src/probe.ts
@@ -64,7 +64,7 @@ export interface HttpGetProbeOptions extends ProbeOptions {
    *
    * @default - defaults to `container.port`.
    */
-  readonly port?: number;
+  readonly port?: number | string;
 }
 
 /**
@@ -89,12 +89,15 @@ export abstract class Probe {
   public static fromHttpGet(path: string, options: HttpGetProbeOptions = { }): Probe {
     return {
       _toKube(container) {
+        let port: number | string;
+        if (options.port !== undefined) {
+          port = container.lookupPort(options.port, true).nameOrPort();
+        } else {
+          port = container.ports[0]?.nameOrPort() ?? 80;
+        }
         return {
           ...parseProbeOptions(options),
-          httpGet: {
-            path,
-            port: options.port ?? container.port ?? 80,
-          },
+          httpGet: { path, port },
         };
       },
     };

--- a/packages/cdk8s-plus-17/src/probe.ts
+++ b/packages/cdk8s-plus-17/src/probe.ts
@@ -1,5 +1,6 @@
 import { Duration } from 'cdk8s';
 import { Container } from './container';
+import { ContainerPort } from './container-port';
 import * as k8s from './imports/k8s';
 
 /**
@@ -64,7 +65,7 @@ export interface HttpGetProbeOptions extends ProbeOptions {
    *
    * @default - defaults to `container.port`.
    */
-  readonly port?: number | string;
+  readonly port?: number | string | ContainerPort;
 }
 
 /**

--- a/packages/cdk8s-plus-17/src/service.ts
+++ b/packages/cdk8s-plus-17/src/service.ts
@@ -282,7 +282,7 @@ export interface ServicePortOptions {
    *
    * @default - The value of `port` will be used.
    */
-  readonly targetPort?: number | string;
+  readonly targetPort?: number | string | ContainerPort;
 }
 
 /**

--- a/packages/cdk8s-plus-17/test/container.test.ts
+++ b/packages/cdk8s-plus-17/test/container.test.ts
@@ -286,4 +286,27 @@ describe('Container', () => {
       });
     }).toThrow();
   });
+
+  test('lookupPort should preserve reference', () => {
+    const container = new kplus.Container({
+      image: 'image',
+    });
+    const port = container.expose(80);
+
+    expect(container.lookupPort(80)).toBe(port);
+  });
+
+  test('lookupPort should aware of the port object ownership', () => {
+    const container1 = new kplus.Container({
+      image: 'image',
+    });
+    const port1 = container1.expose(80);
+
+    const container2 = new kplus.Container({
+      image: 'image',
+    });
+    container2.expose(80);
+
+    expect(container2.lookupPort(port1)).toBeUndefined();
+  });
 });

--- a/packages/cdk8s-plus-17/test/container.test.ts
+++ b/packages/cdk8s-plus-17/test/container.test.ts
@@ -89,6 +89,10 @@ describe('Container', () => {
       imagePullPolicy: kplus.ImagePullPolicy.NEVER,
       workingDir: 'workingDir',
       port: 9000,
+      ports: [{
+        port: 9100,
+        name: 'port',
+      }],
       command: ['command'],
       env: {
         key: kplus.EnvValue.fromValue('value'),
@@ -104,6 +108,10 @@ describe('Container', () => {
       workingDir: 'workingDir',
       ports: [{
         containerPort: 9000,
+      },
+      {
+        containerPort: 9100,
+        name: 'port',
       }],
       command: ['command'],
       env: [{
@@ -251,4 +259,31 @@ describe('Container', () => {
     });
   });
 
+  test('Ports must be unique', () => {
+    expect(() => {
+      new kplus.Container({
+        image: 'image',
+        ports: [{
+          port: 8000,
+        }, {
+          port: 8000,
+        }],
+      });
+    }).toThrow();
+  });
+
+  test('Port names must be unique', () => {
+    expect(() => {
+      new kplus.Container({
+        image: 'image',
+        ports: [{
+          port: 80,
+          name: 'port',
+        }, {
+          port: 8080,
+          name: 'port',
+        }],
+      });
+    }).toThrow();
+  });
 });

--- a/packages/cdk8s-plus-17/test/deployment.test.ts
+++ b/packages/cdk8s-plus-17/test/deployment.test.ts
@@ -268,3 +268,33 @@ test('Port names must be unique in a deployment', () => {
     ],
   })).toThrow();
 });
+
+test('lookupPort should preserve reference', () => {
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment');
+  const container = deployment.addContainer({
+    image: 'image',
+  });
+  const port = container.expose(80);
+
+  expect(container.lookupPort(80)).toBe(port);
+});
+
+test('lookupPort should aware of the port object ownership', () => {
+  const chart = Testing.chart();
+
+  const deployment1 = new kplus.Deployment(chart, 'Deployment1');
+  const container1 = deployment1.addContainer({
+    image: 'image',
+  });
+  const port1 = container1.expose(80);
+
+  const deployment2 = new kplus.Deployment(chart, 'Deployment2');
+  const container2 = deployment1.addContainer({
+    image: 'image',
+  });
+  container2.expose(80);
+
+  expect(deployment2.lookupPort(port1)).toBeUndefined();
+});

--- a/packages/cdk8s-plus-17/test/probe.test.ts
+++ b/packages/cdk8s-plus-17/test/probe.test.ts
@@ -28,20 +28,58 @@ describe('fromHttpGet()', () => {
     const container = new Container({ image: 'foobar', port: 5555 });
 
     // WHEN
-    const min = Probe.fromHttpGet('/hello', { port: 1234 });
+    const min = Probe.fromHttpGet('/hello', { port: 5555 });
 
     // THEN
     expect(min._toKube(container)).toEqual({
       failureThreshold: 3,
       httpGet: {
         path: '/hello',
-        port: 1234,
+        port: 5555,
       },
       initialDelaySeconds: undefined,
       periodSeconds: undefined,
       successThreshold: undefined,
       timeoutSeconds: undefined,
     });
+  });
+
+  test('specific port by name', () => {
+    // GIVEN
+    const container = new Container({
+      image: 'foobar',
+      ports: [{
+        port: 5555,
+        name: 'port',
+      }],
+    });
+
+    // WHEN
+    const min = Probe.fromHttpGet('/hello', { port: 'port' });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      failureThreshold: 3,
+      httpGet: {
+        path: '/hello',
+        port: 'port',
+      },
+      initialDelaySeconds: undefined,
+      periodSeconds: undefined,
+      successThreshold: undefined,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('cannot probe on not exposed port', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromHttpGet('/hello', { port: 1234 });
+
+    // THEN
+    expect(() => min._toKube(container)).toThrow();
   });
 
   test('options', () => {

--- a/packages/cdk8s-plus-17/test/service.test.ts
+++ b/packages/cdk8s-plus-17/test/service.test.ts
@@ -108,6 +108,62 @@ test('Can associate a deployment with an existing service', () => {
 
 });
 
+test('Can associate a deployment with an existing service by a port', () => {
+  const chart = Testing.chart();
+
+  const service = new kplus.Service(chart, 'service');
+  const deployment = new kplus.Deployment(chart, 'dep');
+  deployment.addContainer({ image: 'foo', port: 7777 });
+
+  service.addDeployment(deployment, 1122, {
+    targetPort: 7777,
+  });
+
+  const spec = Testing.synth(chart)[0].spec;
+  expect(spec.ports).toEqual([{ port: 1122, targetPort: 7777 }]);
+});
+
+test('Can associate a deployment with an existing service by a port name', () => {
+  const chart = Testing.chart();
+
+  const service = new kplus.Service(chart, 'service');
+  const deployment = new kplus.Deployment(chart, 'dep');
+  deployment.addContainer({
+    image: 'foo',
+    ports: [{
+      port: 7777,
+      name: 'port',
+    }],
+  });
+
+  service.addDeployment(deployment, 1122, {
+    targetPort: 'port',
+  });
+
+  const spec = Testing.synth(chart)[0].spec;
+  expect(spec.ports).toEqual([{ port: 1122, targetPort: 'port' }]);
+});
+
+test('Cannot associate a deployment with an existing service by a non-existing port', () => {
+  const chart = Testing.chart();
+
+  const service = new kplus.Service(chart, 'service');
+  const deployment = new kplus.Deployment(chart, 'dep');
+  deployment.addContainer({
+    image: 'foo',
+    ports: [{
+      port: 7777,
+      name: 'port',
+    }],
+  });
+
+  expect(() => {
+    service.addDeployment(deployment, 1122, {
+      targetPort: 'non-existing',
+    });
+  }).toThrow();
+});
+
 test('Cannot add a deployment if it does not have a label selector', () => {
 
   const chart = Testing.chart();


### PR DESCRIPTION
Container can expose multiple ports, also it can name its ports.
Container and Deployment would validate the uniqueness of ports and port names. Kubernetes says they must be unique, but doesn't validate them, so ports can be silently shadowed, and can expose wrong port.
Probe and Services can expose by a port number, a port name, and a port object.
Container owns ContainerPort objects (Deployments owns them indirectly) and validate ownership by object reference even if the object seems to somewhat valid to prevent to expose wrong port with same properties.

Closes: https://github.com/awslabs/cdk8s/issues/439

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
