### PR TITLE
fix: Lazy is not resolved in metadata

### DIFF
--- a/packages/cdk8s/src/metadata.ts
+++ b/packages/cdk8s/src/metadata.ts
@@ -1,3 +1,4 @@
+import { resolve } from './_resolve';
 import { sanitizeValue } from './_util';
 
 /**
@@ -141,12 +142,12 @@ export class ApiObjectMetadataDefinition {
    */
   public toJson() {
     const sanitize = (x: any) => sanitizeValue(x, { filterEmptyArrays: true, filterEmptyObjects: true });
-    return sanitize({
+    return sanitize(resolve({
       ...this._additionalAttributes,
       name: this.name,
       namespace: this.namespace,
       annotations: this.annotations,
       labels: this.labels,
-    });
+    }));
   }
 }

--- a/packages/cdk8s/test/metadata.test.ts
+++ b/packages/cdk8s/test/metadata.test.ts
@@ -1,4 +1,4 @@
-import { ApiObjectMetadataDefinition } from '../src';
+import { ApiObjectMetadataDefinition, Lazy } from '../src';
 
 test('Can add a label', () => {
 
@@ -44,6 +44,38 @@ test('Instantiation properties are all respected', () => {
     namespace: 'namespace',
     annotations: {
       key: 'value',
+    },
+    labels: {
+      key: 'value',
+    },
+  };
+
+  expect(actual).toStrictEqual(expected);
+
+});
+
+test('ensure Lazy properties are resolved', () => {
+
+  const meta = new ApiObjectMetadataDefinition({
+    labels: { key: 'value' },
+    annotations: {
+      key: 'value',
+      lazy: Lazy.any({ produce: () => { return { uiMeta: 'is good' }; } }),
+    },
+    name: 'name',
+    namespace: 'namespace',
+  });
+
+  const actual = meta.toJson();
+
+  const expected = {
+    name: 'name',
+    namespace: 'namespace',
+    annotations: {
+      key: 'value',
+      lazy: {
+        uiMeta: 'is good',
+      },
     },
     labels: {
       key: 'value',


### PR DESCRIPTION
Allows annotations to be dynamically rendered.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
