### PR TITLE
feat: add YAML parse and stringify

### DIFF
--- a/packages/cdk8s/API.md
+++ b/packages/cdk8s/API.md
@@ -1257,6 +1257,19 @@ static load(urlOrFile: string): Array<any>
 __Returns__:
 * <code>Array<any></code>
 
+#### *static* parse(str)🔹 <a id="cdk8s-yaml-parse"></a>
+
+Converts a String with YAML formatting to a set of objects.
+
+```ts
+static parse(str: string): any
+```
+
+* **str** (<code>string</code>)  The YAML String.
+
+__Returns__:
+* <code>any</code>
+
 #### *static* save(filePath, docs)🔹 <a id="cdk8s-yaml-save"></a>
 
 Saves a set of objects as a multi-document YAML file.
@@ -1270,6 +1283,19 @@ static save(filePath: string, docs: Array<any>): void
 
 
 
+
+#### *static* stringify(value)🔹 <a id="cdk8s-yaml-stringify"></a>
+
+Converts a set of objects to a YAML string.
+
+```ts
+static stringify(value: any): string
+```
+
+* **value** (<code>any</code>)  The set of objects.
+
+__Returns__:
+* <code>string</code>
 
 #### *static* tmp(docs)🔹 <a id="cdk8s-yaml-tmp"></a>
 

--- a/packages/cdk8s/src/yaml.ts
+++ b/packages/cdk8s/src/yaml.ts
@@ -85,7 +85,7 @@ export class Yaml {
    * @param str The YAML String.
    * @returns A value that matches the type of the root value of the parsed YAML document.
    */
-  public static parse(str: string): any{
+  public static parse(str: string): any {
     return YAML.parse(str);
   }
 

--- a/packages/cdk8s/src/yaml.ts
+++ b/packages/cdk8s/src/yaml.ts
@@ -76,7 +76,7 @@ export class Yaml {
    * @param value The set of objects.
    * @returns A String with YAML formatting.
    */
-  public static stringify(value: any): string{
+  public static stringify(value: any): string {
     return YAML.stringify(value);
   }
 

--- a/packages/cdk8s/src/yaml.ts
+++ b/packages/cdk8s/src/yaml.ts
@@ -72,6 +72,24 @@ export class Yaml {
   }
 
   /**
+   * Converts a set of objects to a YAML string.
+   * @param value The set of objects.
+   * @returns A String with YAML formatting.
+   */
+  public static stringify(value: any): string{
+    return YAML.stringify(value);
+  }
+
+  /**
+   * Converts a String with YAML formatting to a set of objects.
+   * @param str The YAML String.
+   * @returns A value that matches the type of the root value of the parsed YAML document.
+   */
+  public static parse(str: string): any{
+    return YAML.parse(str);
+  }
+
+  /**
    * Utility class.
    */
   private constructor() {


### PR DESCRIPTION
Fixes #419 

This PR exposes two YAML methods: parse and stringify.

I didn't add tests b/c it's just a wrapper, but if needed, I can add some.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
