### PR TITLE
feat(plus-17): Add support for externalName on Service

### DIFF
--- a/packages/cdk8s-plus-17/API.md
+++ b/packages/cdk8s-plus-17/API.md
@@ -1164,6 +1164,7 @@ new Service(scope: Construct, id: string, props?: ServiceProps)
   * **metadata** (<code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code>)  Metadata that all persisted resources must have, which includes all objects users must create. __*Optional*__
   * **clusterIP** (<code>string</code>)  The IP address of the service and is usually assigned randomly by the master. __*Default*__: Automatically assigned.
   * **externalIPs** (<code>Array<string></code>)  A list of IP addresses for which nodes in the cluster will also accept traffic for this service. __*Default*__: No external IPs.
+  * **externalName** (<code>string</code>)  The external reference that kubedns or equivalent will return as a CNAME record for this service. __*Default*__: No external name.
   * **ports** (<code>Array<[ServicePort](#cdk8s-plus-17-serviceport)></code>)  The port exposed by this service. __*Optional*__
   * **type** (<code>[ServiceType](#cdk8s-plus-17-servicetype)</code>)  Determines how the Service is exposed. __*Default*__: ServiceType.ClusterIP
 
@@ -1179,6 +1180,7 @@ Name | Type | Description
 **selector**🔹 | <code>Map<string, string></code> | Returns the labels which are used to select pods for this service.
 **type**🔹 | <code>[ServiceType](#cdk8s-plus-17-servicetype)</code> | Determines how the Service is exposed.
 **clusterIP**?🔹 | <code>string</code> | The IP address of the service and is usually assigned randomly by the master.<br/>__*Optional*__
+**externalName**?🔹 | <code>string</code> | The external reference to use for this service.<br/>__*Optional*__
 
 ### Methods
 
@@ -2065,6 +2067,7 @@ Name | Type | Description
 -----|------|-------------
 **clusterIP**?🔹 | <code>string</code> | The IP address of the service and is usually assigned randomly by the master.<br/>__*Default*__: Automatically assigned.
 **externalIPs**?🔹 | <code>Array<string></code> | A list of IP addresses for which nodes in the cluster will also accept traffic for this service.<br/>__*Default*__: No external IPs.
+**externalName**?🔹 | <code>string</code> | The external reference that kubedns or equivalent will return as a CNAME record for this service.<br/>__*Default*__: No external name.
 **metadata**?🔹 | <code>[ApiObjectMetadata](#cdk8s-apiobjectmetadata)</code> | Metadata that all persisted resources must have, which includes all objects users must create.<br/>__*Optional*__
 **ports**?🔹 | <code>Array<[ServicePort](#cdk8s-plus-17-serviceport)></code> | The port exposed by this service.<br/>__*Optional*__
 **type**?🔹 | <code>[ServiceType](#cdk8s-plus-17-servicetype)</code> | Determines how the Service is exposed.<br/>__*Default*__: ServiceType.ClusterIP

--- a/packages/cdk8s-plus-17/test/service.test.ts
+++ b/packages/cdk8s-plus-17/test/service.test.ts
@@ -24,6 +24,23 @@ test('Must be configured with at least one port', () => {
 
 });
 
+test('Can be configured for externalName', () => {
+
+  const chart = Testing.chart();
+
+  new kplus.Service(chart, 'service', {
+    type: kplus.ServiceType.EXTERNAL_NAME,
+    externalName: 'https://www.external.com',
+  });
+
+  // assert the k8s spec has it.
+  const spec = Testing.synth(chart)[0].spec;
+  expect(spec.externalName).toEqual('https://www.external.com');
+  expect(spec.selector).toBeUndefined();
+  expect(spec.ports).toBeUndefined();
+});
+
+
 test('Can select by label', () => {
 
   const chart = Testing.chart();


### PR DESCRIPTION
This add support for Services that are of type EXTERNAL_NAME.

I pushed this up before I saw the other PR https://github.com/awslabs/cdk8s/pull/424 from @pusherman.

There may be some ideas here to merge into that one or vice versa.  My goal is simply to get support for external name through.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
