### PR TITLE
chore(deps): Dedicated automation token

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CDK8S_AUTOMATION_TOKEN }}
           commit-message: Upgrade yarn.lock
           branch: github-actions/dependencies
           labels: auto-merge


### PR DESCRIPTION
Apparently PR's created Using the default `secrets.GITHUB_TOKEN` do not trigger workflow executions on them.
This means the PR's currently created by the automatic dependency upgrade will never run CI.

Created a dedicated automation token so that workflows can be triggered.

See https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
