### PR TITLE
chore(deps): Exclude constructs and projen from transitive dependency upgrades

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,10 +31,6 @@ jobs:
 
           export PATH=./node_modules/.bin:${PATH}
 
-          # We special-case typescript because it's not semantically versionned
-          # and should remain on the same minor.
-          # https://github.com/microsoft/TypeScript/issues/14116
-
           # We reject projen since it may involve breaking changes and we don't
           # want to couple them with pure dependency upgrades.
 
@@ -42,16 +38,13 @@ jobs:
           # we will do constructs upgrades manually for a little while until we sort this out.
 
           # Upgrade dependencies at repository root
-          ncu --upgrade --filter=typescript --target=patch
-          ncu --upgrade --reject=constructs,typescript --target=minor
-
+          ncu --upgrade --reject=constructs,projen --target=minor
 
           # Upgrade all the packages
-          lerna exec --parallel ncu -- --upgrade --filter=typescript --target=patch
-          lerna exec --parallel ncu -- --upgrade --reject='constructs,projen,typescript,${{ steps.list-packages.outputs.list }}' --target=minor
+          lerna exec --parallel ncu -- --upgrade --reject='constructs,projen,${{ steps.list-packages.outputs.list }}' --target=minor
 
       - name: Upgrade lock file
-        run: yarn install && yarn upgrade
+        run: yarn install && yarn upgrade --pattern '!(constructs|projen)'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/packages/cdk8s-cli/package.json
+++ b/packages/cdk8s-cli/package.json
@@ -45,7 +45,7 @@
     "projen": "^0.6.12",
     "standard-version": "^9.0.0",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.5"
+    "typescript": "~3.9.5"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/packages/cdk8s-plus-17/package.json
+++ b/packages/cdk8s-plus-17/package.json
@@ -51,7 +51,7 @@
     "projen": "^0.6.12",
     "standard-version": "^9.0.0",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.5"
+    "typescript": "~3.9.5"
   },
   "peerDependencies": {
     "cdk8s": "^0.0.0",

--- a/packages/cdk8s/package.json
+++ b/packages/cdk8s/package.json
@@ -52,7 +52,7 @@
     "projen": "^0.6.12",
     "standard-version": "^9.0.0",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.5"
+    "typescript": "~3.9.5"
   },
   "peerDependencies": {
     "constructs": "^3.2.34"

--- a/packages/projen-common.js
+++ b/packages/projen-common.js
@@ -36,6 +36,11 @@ exports.fixup = project => {
   // jsii-release is declared at the root level, we don't need it here.
   delete project.devDependencies['jsii-release']
 
+  // typescript is not semantically versionned and should remain on the same minor.
+  // https://github.com/microsoft/TypeScript/issues/14116
+  // TODO add this to projen.
+  project.devDependencies['typescript'] = project.devDependencies['typescript'].replace('^', '~')
+
   delete project.manifest.scripts.bump;
   delete project.manifest.scripts.release;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10681,7 +10681,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5, typescript@^3.9.5, typescript@^3.9.7, typescript@~3.9.7:
+typescript@^3.7.5, typescript@^3.9.7, typescript@~3.9.5, typescript@~3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
We added transitive dependency updates in this [PR](https://github.com/awslabs/cdk8s/pull/465) by running `yarn upgrade`, but this now also upgrades the modules that we previously rejected from `ncu`.

Added a pattern to reject those modules from yarn as well.

Also moved typescript special casing to projen by using a `~` dependency (instead of `^`) so we stick to the current minor like we want.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
