### PR TITLE
chore(release): skip homebrew release for beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
   release_homebrew:
     name: Release to Homebrew
     # The branch or tag ref that triggered the workflow run.
-    if: startsWith(github.event.head_commit.message, 'chore(release)')
+    if: startsWith(github.event.head_commit.message, 'chore(release)') && contains(github.event.head_commit.message, 'beta') == false
     needs: release_npm
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To avoid unnecessarily opening PRs with Homebrew-core.

Signed-off-by: campionfellin <campionfellin@gmail.com>

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
