### PR TITLE
fix(plus-17): multiple mounts per volume result in duplicate volumes for pod spec

### DIFF
--- a/packages/cdk8s-plus-17/src/pod.ts
+++ b/packages/cdk8s-plus-17/src/pod.ts
@@ -82,7 +82,7 @@ export class PodSpec implements IPodSpec {
     this.serviceAccount = props.serviceAccount;
 
     if (props.containers) {
-      props.containers.map(c => this.addContainer(c));
+      props.containers.forEach(c => this.addContainer(c));
     }
 
     if (props.volumes) {

--- a/packages/cdk8s-plus-17/src/pod.ts
+++ b/packages/cdk8s-plus-17/src/pod.ts
@@ -125,16 +125,6 @@ export class PodSpec implements IPodSpec {
     const volumes: Map<string, Volume> = new Map();
     const containers: k8s.Container[] = [];
 
-    function addVolume(volume: Volume) {
-      const existingVolume = volumes.get(volume.name);
-      // its ok to call this function twice on the same volume, but its not ok to call twice on a different volume
-      // with the same name.
-      if (existingVolume && existingVolume !== volume) {
-        throw new Error(`Invalid mount configuration. At least two different volumes have the same name: ${volume.name}`);
-      }
-      volumes.set(volume.name, volume);
-    }
-
     // automatically add volume from the container mount
     // to this pod so thats its available to the container.
     for (const container of this.containers) {
@@ -146,6 +136,16 @@ export class PodSpec implements IPodSpec {
 
     for (const volume of this.volumes) {
       addVolume(volume);
+    }
+
+    function addVolume(volume: Volume) {
+      const existingVolume = volumes.get(volume.name);
+      // its ok to call this function twice on the same volume, but its not ok to call twice on a different volume
+      // with the same name.
+      if (existingVolume && existingVolume !== volume) {
+        throw new Error(`Invalid mount configuration. At least two different volumes have the same name: ${volume.name}`);
+      }
+      volumes.set(volume.name, volume);
     }
 
     return {

--- a/packages/cdk8s-plus-17/src/pod.ts
+++ b/packages/cdk8s-plus-17/src/pod.ts
@@ -125,9 +125,9 @@ export class PodSpec implements IPodSpec {
     const volumes: Map<string, Volume> = new Map();
     const containers: k8s.Container[] = [];
 
-    // automatically add volume from the container mount
-    // to this pod so thats its available to the container.
     for (const container of this.containers) {
+      // automatically add volume from the container mount
+      // to this pod so thats its available to the container.
       for (const mount of container.mounts) {
         addVolume(mount.volume);
       }

--- a/packages/cdk8s-plus-17/src/pod.ts
+++ b/packages/cdk8s-plus-17/src/pod.ts
@@ -140,8 +140,8 @@ export class PodSpec implements IPodSpec {
 
     function addVolume(volume: Volume) {
       const existingVolume = volumes.get(volume.name);
-      // its ok to call this function twice on the same volume, but its not ok to call twice on a different volume
-      // with the same name.
+      // its ok to call this function twice on the same volume, but its not ok to
+      // call it twice on a different volume with the same name.
       if (existingVolume && existingVolume !== volume) {
         throw new Error(`Invalid mount configuration. At least two different volumes have the same name: ${volume.name}`);
       }

--- a/packages/cdk8s-plus-17/test/pod.test.ts
+++ b/packages/cdk8s-plus-17/test/pod.test.ts
@@ -2,6 +2,50 @@ import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
 
+test('multiple mounts per volume', () => {
+
+  const chart = Testing.chart();
+
+  const configMap = new kplus.ConfigMap(chart, 'Config', {
+    data: {
+      f1: 'f1-content',
+      f2: 'f2-content',
+    },
+  });
+
+  const volume = kplus.Volume.fromConfigMap(configMap);
+
+  new kplus.Pod(chart, 'Pod', {
+    containers: [
+      {
+        image: 'image',
+        volumeMounts: [
+          {
+            volume: volume,
+            path: 'f1',
+            subPath: 'f1',
+          },
+          {
+            volume: volume,
+            path: 'f2',
+            subPath: 'f2',
+          },
+        ],
+      },
+    ],
+  });
+
+  const podSpec = Testing.synth(chart).filter(r => r.kind === 'Pod')[0].spec;
+
+  expect(podSpec.volumes).toEqual([{
+    configMap: {
+      name: 'test-config-c8c927dd',
+    },
+    name: 'configmap-test-config-c8c927dd',
+  }]);
+
+});
+
 test('defaultChild', () => {
 
   const chart = Testing.chart();

--- a/packages/cdk8s-plus-17/test/pod.test.ts
+++ b/packages/cdk8s-plus-17/test/pod.test.ts
@@ -2,7 +2,7 @@ import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
 
-test('fails instantiating with two volumes with the same name', () => {
+test('fails with two volumes with the same name', () => {
 
   const chart = Testing.chart();
 
@@ -33,7 +33,7 @@ test('fails adding a volume with the same name', () => {
 
 });
 
-test('fails instantiating with a container that has two mounts with different volumes of the same name', () => {
+test('fails with a container that has mounts with different volumes of the same name', () => {
 
   const chart = Testing.chart();
 
@@ -65,7 +65,7 @@ test('fails instantiating with a container that has two mounts with different vo
 
 });
 
-test('multiple mounts per volume', () => {
+test('can configure multiple mounts with the same volume', () => {
 
   const chart = Testing.chart();
 


### PR DESCRIPTION
Allow multiple container mounts to use the same volume.

This PR also introduces a restriction for adding two different volumes with the same name to a pod.

Fixes https://github.com/awslabs/cdk8s/issues/483

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
