### PR TITLE
fix(docs): correct logo paths

### DIFF
--- a/docs/assets/logos/readme.md
+++ b/docs/assets/logos/readme.md
@@ -20,29 +20,29 @@
     </tr>
     <tr>
         <th>color</th>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.color.png" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.color.png" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.color.png" width="75"></td>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.color.svg" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.color.svg" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.color.svg" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.color.png" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.color.png" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.color.png" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.color.svg" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.color.svg" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.color.svg" width="75"></td>
     </tr>
     <tr>
         <th>black</th>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.black.png" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.black.png" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.black.png" width="75"></td>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.black.svg" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.black.svg" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.black.svg" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.black.png" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.black.png" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.black.png" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.black.svg" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.black.svg" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.black.svg" width="75"></td>
     </tr>
     <tr>
         <th>white</th>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.white.png" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.white.png" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.white.png" width="75"></td>
-        <td><img src="/docs/assets/logos/horizontal/cdk8s.horizontal.white.svg" width="200"></td>
-        <td><img src="/docs/assets/logos/stacked/cdk8s.stacked.white.svg" width="95"></td>
-        <td><img src="/docs/assets/logos/icon/cdk8s.icon.white.svg" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.white.png" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.white.png" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.white.png" width="75"></td>
+        <td><img src="../horizontal/cdk8s.horizontal.white.svg" width="200"></td>
+        <td><img src="../stacked/cdk8s.stacked.white.svg" width="95"></td>
+        <td><img src="../icon/cdk8s.icon.white.svg" width="75"></td>
     </tr>
 </table>


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

Currently, there is an issue which the logo images doesn't appeared correctly with 404 status code in the websites:

- https://cdk8s.io/docs/v1.0.0-beta.5/assets/logos/readme/
- https://cdk8s.io/docs/latest/assets/logos/readme/

![image](https://user-images.githubusercontent.com/26626194/104044912-24d0e380-5221-11eb-97a8-2a8bcd10b412.png)

It was occurred because it used incorrect absolute path at *docs/assets/logos/readme.md*, though multiple versions are published at once (e.g. _docs/latest_, _docs/v1.0.0-beta.5_). So this pull request makes it use relative path which can be successfully accessed from multiple versions. (e.g. `/docs/assets/logos/icon/cdk8s.icon.color.png` → `../icon/cdk8s.icon.color.png`)

![image](https://user-images.githubusercontent.com/26626194/104047184-965e6100-5224-11eb-81c7-29b20ee06525.png)

## How to test

1. Build docs by `CONTRIBUTING.md`.
1. Run HTTP server on the published directory. I used `python -m http.server <port>`.
1. Open the url `http://localhost:<port>/docs/assets/logos/readme`.
1. Check the images are shown correctly.

