### PR TITLE
fix: set yaml default schema to 1.1

### DIFF
--- a/packages/cdk8s/src/yaml.ts
+++ b/packages/cdk8s/src/yaml.ts
@@ -3,13 +3,13 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as YAML from 'yaml';
-import { Type } from 'yaml/util';
 
 const MAX_DOWNLOAD_BUFFER = 10 * 1024 * 1024;
 
-// Ensure that all strings are quoted when written to yaml to avoid unquoted
-// primitive types in the output yaml in fields that require strings.
-YAML.scalarOptions.str.defaultType = Type.QUOTE_DOUBLE;
+// Set default YAML schema to 1.1. This ensures saved YAML is backward compatible with other parsers, such as PyYAML
+// It also ensures that octal numbers in the form `0775` will be parsed
+// correctly on YAML load. (see https://github.com/eemeli/yaml/issues/205)
+YAML.defaultOptions.schema = 'yaml-1.1';
 
 /**
  * YAML utilities.
@@ -55,9 +55,7 @@ export class Yaml {
   public static load(urlOrFile: string): any[] {
     const body = loadurl(urlOrFile);
 
-    // we need to use yaml-1.1 so that octal numbers in the form `0775` will be parsed
-    // correctly (see https://github.com/eemeli/yaml/issues/205)
-    const objects = YAML.parseAllDocuments(body, { schema: 'yaml-1.1' });
+    const objects = YAML.parseAllDocuments(body);
     const result = new Array<any>();
 
     for (const obj of objects.map(x => x.toJSON())) {

--- a/packages/cdk8s/test/__snapshots__/yaml.test.ts.snap
+++ b/packages/cdk8s/test/__snapshots__/yaml.test.ts.snap
@@ -278,7 +278,7 @@ empty_object: {}
 `;
 
 exports[`save multiple documents 1`] = `
-"foo: \\"bar\\"
+"foo: bar
 hello:
   - 1
   - 2
@@ -289,7 +289,7 @@ number: 2
 `;
 
 exports[`save single document 1`] = `
-"foo: \\"bar\\"
+"foo: bar
 hello:
   - 1
   - 2
@@ -299,7 +299,7 @@ hello:
 
 exports[`save strings are quoted 1`] = `
 "foo: \\"on\\"
-bar: \\"this has a \\\\\\"big quote\\\\\\"\\"
+bar: this has a \\"big quote\\"
 not_a_string: true
 "
 `;

--- a/test/test-java-app/expected/test.k8s.yaml
+++ b/test/test-java-app/expected/test.k8s.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-pod-c815bc91
 spec:
   containers:
-    - image: paulbouwer/hello-kubernetes:1.7
+    - image: paulbower/hello-kubernetes:1.7
       name: hello-kubernetes
       ports:
         - containerPort: 8080

--- a/test/test-java-app/expected/test.k8s.yaml
+++ b/test/test-java-app/expected/test.k8s.yaml
@@ -1,10 +1,10 @@
-apiVersion: "v1"
-kind: "Pod"
+apiVersion: v1
+kind: Pod
 metadata:
-  name: "test-pod-c815bc91"
+  name: test-pod-c815bc91
 spec:
   containers:
-    - image: "paulbower/hello-kubernetes:1.7"
-      name: "hello-kubernetes"
+    - image: paulbouwer/hello-kubernetes:1.7
+      name: hello-kubernetes
       ports:
         - containerPort: 8080

--- a/test/test-python-app/expected/test.k8s.yaml
+++ b/test/test-python-app/expected/test.k8s.yaml
@@ -1,10 +1,10 @@
-apiVersion: "v1"
-kind: "Pod"
+apiVersion: v1
+kind: Pod
 metadata:
-  name: "test-pod-c82fd911"
+  name: test-pod-c82fd911
 spec:
   containers:
-    - image: "paulbouwer/hello-kubernetes:1.7"
-      name: "hello-kubernetes"
+    - image: paulbouwer/hello-kubernetes:1.7
+      name: hello-kubernetes
       ports:
         - containerPort: 8080

--- a/test/test-typescript-app/expected/test.k8s.yaml
+++ b/test/test-typescript-app/expected/test.k8s.yaml
@@ -1,10 +1,10 @@
-apiVersion: "v1"
-kind: "Pod"
+apiVersion: v1
+kind: Pod
 metadata:
-  name: "test-pod-c82fd911"
+  name: test-pod-c82fd911
 spec:
   containers:
-    - image: "paulbouwer/hello-kubernetes:1.7"
-      name: "hello-kubernetes"
+    - image: paulbouwer/hello-kubernetes:1.7
+      name: hello-kubernetes
       ports:
         - containerPort: 8080


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

---
Currently, the output of multiline strings is very ugly in the rendered YAML files; there are many extra newlines and backslashes, majorly hurting readability.

To fix #172, this PR returns to the default YAML string settings that allow the parser to decide between double-quoting or creating a block-literal from a string. 

To ensure we don't bring back the issues from #325, this PR also sets the default YAML schema to `yaml-1.1`, to retain compatibility with most other YAML parsers' default settings.

Aside from the tests in the PR, I have also confirmed this fix against the repro steps in #325.