### PR TITLE
fix(lib): deprecated toISOString() conflicts with toIsoString()

### DIFF
--- a/packages/cdk8s/API.md
+++ b/packages/cdk8s/API.md
@@ -568,18 +568,6 @@ toHumanString(): string
 __Returns__:
 * <code>string</code>
 
-#### toISOString()⚠️ <a id="cdk8s-duration-toisostring"></a>
-
-Return an ISO 8601 representation of this period.
-
-```ts
-toISOString(): string
-```
-
-
-__Returns__:
-* <code>string</code>
-
 #### toIsoString()🔹 <a id="cdk8s-duration-toisostring"></a>
 
 Return an ISO 8601 representation of this period.

--- a/packages/cdk8s/src/duration.ts
+++ b/packages/cdk8s/src/duration.ts
@@ -161,17 +161,6 @@ export class Duration {
   }
 
   /**
-   * Return an ISO 8601 representation of this period
-   *
-   * @returns a string starting with 'PT' describing the period
-   * @see https://www.iso.org/fr/standard/70907.html
-   * @deprecated Use `toIsoString()` instead.
-   */
-  public toISOString(): string {
-    return this.toIsoString();
-  }
-
-  /**
    * Turn this duration into a human-readable string
    */
   public toHumanString(): string {
@@ -210,7 +199,7 @@ export class Duration {
       return `${this.amount}${symbol}`;
     }
     const remainder = this.amount % modulus;
-    const quotient = next((this.amount - remainder) / modulus).toISOString().slice(2);
+    const quotient = next((this.amount - remainder) / modulus).toIsoString().slice(2);
     return remainder > 0
       ? `${quotient}${remainder}${symbol}`
       : quotient;

--- a/packages/cdk8s/test/duration.test.ts
+++ b/packages/cdk8s/test/duration.test.ts
@@ -45,20 +45,6 @@ test('Duration in days', () => {
   expect(duration.toDays()).toBe(1);
 });
 
-test('toISOString', () => {
-  expect(Duration.seconds(0).toISOString()).toBe('PT0S');
-  expect(Duration.minutes(0).toISOString()).toBe('PT0S');
-  expect(Duration.hours(0).toISOString()).toBe('PT0S');
-  expect(Duration.days(0).toISOString()).toBe('PT0S');
-
-  expect(Duration.seconds(5).toISOString()).toBe('PT5S');
-  expect(Duration.minutes(5).toISOString()).toBe('PT5M');
-  expect(Duration.hours(5).toISOString()).toBe('PT5H');
-  expect(Duration.days(5).toISOString()).toBe('PT5D');
-
-  expect(Duration.seconds(1 + 60 * (1 + 60 * (1 + 24))).toISOString()).toBe('PT1D1H1M1S');
-});
-
 test('toIsoString', () => {
   expect(Duration.seconds(0).toIsoString()).toBe('PT0S');
   expect(Duration.minutes(0).toIsoString()).toBe('PT0S');


### PR DESCRIPTION
As we prepare to release experimental go support for CDK8s, we encountered an issue where `Duration.toIsoString()` and `Duration.toISOString()` conflict when they are converted to Go naming conventions.

Since one of them is deprecated, just remove it.

BREAKING CHANGE: the deprecated API `Duration.toISOString()` has been removed. Use `Duration.toIsoString()` instead.


---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
