### PR TITLE
fix(lib): ENOBUFS for large helm charts

### DIFF
--- a/packages/cdk8s/src/helm.ts
+++ b/packages/cdk8s/src/helm.ts
@@ -7,6 +7,8 @@ import * as yaml from 'yaml';
 import { Include } from './include';
 import { Names } from './names';
 
+const MAX_HELM_BUFFER = 10 * 1024 * 1024;
+
 /**
  * Options for `Helm`.
  */
@@ -98,7 +100,10 @@ export class Helm extends Include {
 }
 
 function renderTemplate(workdir: string, prog: string, args: string[]) {
-  const helm = cp.spawnSync(prog, args);
+  const helm = cp.spawnSync(prog, args, {
+      maxBuffer: MAX_HELM_BUFFER
+  });
+  
   if (helm.error) {
     const err = helm.error.message;
     if (err.includes('ENOENT')) {

--- a/packages/cdk8s/test/helm.test.ts
+++ b/packages/cdk8s/test/helm.test.ts
@@ -128,7 +128,7 @@ test('helmFlags can be used to specify additional helm options', () => {
   ];
 
   expect(spawnMock).toHaveBeenCalledTimes(1);
-  expect(spawnMock).toHaveBeenCalledWith('helm', expectedArgs);
+  expect(spawnMock).toHaveBeenCalledWith('helm', expectedArgs, {"maxBuffer": 10485760});
 });
 
 test('propagates helm failures', () => {


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

With charts such as cert-manager with crds included, the helm import functionality can run into an ENOBUFS error due to insufficient buffer size. This is very similar to issue #363 (except with helm instead of yaml download) and uses a very similar fix to PR #454. Thanks.